### PR TITLE
major ver release, latest QC, PQO, DTO, NM, PiccoloPlots

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
-version = "0.10.0"
+version = "0.11.0"
 
 [deps]
 NamedTrajectories = "538bc3a1-5ab9-4fc3-b776-35ca1e893e08"
@@ -12,10 +12,10 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 TrajectoryIndexingUtils = "6dad8b7f-dd9a-4c28-9b70-85b9a079bfc8"
 
 [compat]
-NamedTrajectories = "0.6"
-PiccoloPlots = "0.3"
-PiccoloQuantumObjects = "0.7"
-QuantumCollocation = "0.9"
+NamedTrajectories = "0.8"
+PiccoloPlots = "0.4"
+PiccoloQuantumObjects = "0.10"
+QuantumCollocation = "0.10"
 Reexport = "1.2"
 TrajectoryIndexingUtils = "0.1"
 julia = "1.10, 1.11, 1.12"


### PR DESCRIPTION
Latest and greatest changes in NamedTrajectories.jl, QuantumCollocation.jl, PiccoloQuantumObjects.jl, PiccoloPlots.jl, and also (by proxy via QuantumCollocation) the latest DirectTrajOpt.jl.

On the left, the original breaking (and important!) changes, on the right, we have some follow on breaking changes. These were made in stages to maintain compat with QuantumToolbox, Makie, and the SciML ecosystem while doing a major refactor on our entire meta-packaged codebase.

[NamedTrajectories.jl](https://github.com/harmoniqs/NamedTrajectories.jl/releases/tag/v0.8.0) and https://github.com/harmoniqs/NamedTrajectories.jl/releases/tag/v0.8.2
[QuantumCollocation.jl](https://github.com/harmoniqs/QuantumCollocation.jl/releases/tag/v0.9.0) and https://github.com/harmoniqs/QuantumCollocation.jl/releases/tag/v0.10.0
[PiccoloQuantumObjects.jl](https://github.com/harmoniqs/PiccoloQuantumObjects.jl/releases/tag/v0.9.0) and https://github.com/harmoniqs/PiccoloQuantumObjects.jl/releases/tag/v0.10.0
[PiccoloPlots.jl](https://github.com/harmoniqs/PiccoloPlots.jl/releases/tag/v0.4.0)
[DirectTrajOpt.jl](https://github.com/harmoniqs/DirectTrajOpt.jl/releases/tag/v0.7.0) and https://github.com/harmoniqs/DirectTrajOpt.jl/releases/tag/v0.8.0
