### PR TITLE
Operator algebras broken

### DIFF
--- a/src/quantum/quantum_system_utils.jl
+++ b/src/quantum/quantum_system_utils.jl
@@ -147,7 +147,8 @@ function operator_algebra(
                 continue
             end
 
-            comm = is_hermitian(comm) ? comm : im * comm
+            # comm = is_hermitian(comm) ? comm : im * comm
+            comm = is_hermitian(comm) ? im * comm : comm
             comm = clean(comm, normalize = normalize, remove_trace = remove_trace)
 
             v = vec(comm)


### PR DESCRIPTION
Given a basis `(rx, ry, rz)` for $\mathfrak{so}(3)$, we expect that `ri * rj - rj * ri == rk` whenever `(i, j, k)` a cyclic permutation of `(1, 2, 3)`. However, when prompted with generators `[rx, ry]`, `Piccolo.Quantum.QuantumSystemUtils.operator_algebra` erroneously returns a basis consisting of `[rx, ry, im * rz]`, rather than the expected `[rx, ry, rz]` (resulting in an operator acting on $\mathbb{C}^3$, rather than an operator acting on the associated matrix Lie group $\mathrm{SO} (n) $). This seems to stem from a difference in conventions between mathematicians' and physicists' usage of Lie algebras, wherein mathematicians and physicists expect generators to be skew-symmetric (anti-Hermitian) and symmetric (Hermitian), respectively. A potential solution is to explicitly differentiate between anti-Hermitian and Hermitian representations, as well as adding handling for complexified operator algebras. However, this may not generalize particularly well, as, for instance, representations of $\mathfrak{so} (1,3)$ on $\mathfrak{sl} (2,\mathbb{C})$ (associated to the double-valued representation of $\mathrm{SO}(1,3)$ on $\mathrm{SL} (2,\mathbb{C}) $) are spanned (as a real vector space) by both Hermitian and anti-Hermitian generators; namely, $\lbrace \frac{1}{2}\sigma_k\rbrace_{k\in\lbrace 1,2,3\rbrace}\cup\lbrace \frac{1}{2i}\sigma_k\rbrace_{k\in\lbrace 1,2,3\rbrace}$.

```
ex = ComplexF64.([1,0,0])
ey = ComplexF64.([0,1,0])
ez = ComplexF64.([0,0,1])

rx = ez * ey' - ey * ez'
ry = ex * ez' - ez * ex'
rz = ey * ex' - ex * ey'

(rx, ry, rz) = (rx, ry, rz) ./ sqrt(2)

# These tests should pass
Piccolo.Quantum.QuantumSystemUtils.operator_algebra([rx, ry]) == [rx, ry, rz] || error()
Piccolo.Quantum.QuantumSystemUtils.operator_algebra([rx, ry]) != [rx, ry, im * rz] || error()
```