### PR TITLE
Test versioned doc deploy fix from PiccoloDocsTemplate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
       statuses: write
     env:
-      DOC_TEMPLATE_VERSION: "v0.5.0" # Change this to the specific tag version you want
+      DOC_TEMPLATE_VERSION: "fix/repository-dispatch-deploy" # Change this to the specific tag version you want
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
## Summary
- Points `DOC_TEMPLATE_VERSION` to `fix/repository-dispatch-deploy` branch of PiccoloDocsTemplate.jl
- Tests the fix for Documenter.jl rejecting `repository_dispatch` events, which prevents versioned docs from deploying

## Test plan
- Merge to main, then push a `v1.0.0+docs` tag to trigger a `repository_dispatch` and verify versioned docs deploy to gh-pages