### PR TITLE
add ssh key to trigger repository workflows

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -28,8 +28,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
-      - name: Re-trigger docs build
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          event-type: tagbot-release-created
+          ssh: ${{ secrets.TAGBOT_SSH_KEY }}


### PR DESCRIPTION
TagBot workflow configuration updated to trigger workflows in repository and retain tag information
 - Updated the SSH key to `TAGBOT_SSH_KEY` for TagBot authentication.
 - Removed the step that re-triggers the documentation build using the `repository-dispatch` action.