### PR TITLE
use latest docs template for correct stable behavior

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
       statuses: write
     env:
-      DOC_TEMPLATE_VERSION: "fix/repository-dispatch-deploy" # Change this to the specific tag version you want
+      DOC_TEMPLATE_VERSION: "v0.7.0" # Change this to the specific tag version you want
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
PiccoloDocsTemplate has been updated with a release to support more sane behavior - namely putting the stable docs in the front when the user loads the page. This of course can still be overridden by the keyword arg, but will default to documenter's default.