### PR TITLE
Add JuliaFormatter CI workflow

### DIFF
--- a/.github/workflows/Formatter.yml
+++ b/.github/workflows/Formatter.yml
@@ -1,0 +1,41 @@
+name: Formatter
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  julia-format:
+    name: Formatter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install JuliaFormatter and format
+        run: |
+          julia --color=yes -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
+          julia --color=yes -e 'using JuliaFormatter; format(".", verbose=true)'
+      - name: Commit formatted code
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet && exit 0
+          git add -A
+          git commit -m "chore: autoformat"
+          git push
+      - name: Format check
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          julia --color=yes -e '
+          out = Cmd(`git diff --name-only`) |> read |> String
+          if out == ""
+            exit(0)
+          else
+            @error "Some files have not been formatted !!!"
+            write(stdout, out)
+            exit(1)
+          end'


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs JuliaFormatter on PRs and pushes to `main`
- On `workflow_dispatch`, automatically commits and pushes formatted code
- On PRs/pushes, runs a format check and fails if unformatted files are detected