### PR TITLE
fix: cap SciMLBase compat to <2.146 to avoid DiffEqBase rrule conflict

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
-version = "1.3.1"
+version = "1.3.2"
 authors = ["Aaron Trowbridge <aaron@harmoniqs.co> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary

- `SciMLBase` 2.146.0 added `@non_differentiable SciMLBase.numargs(::Any)`, which generates a `ChainRulesCore.rrule` that conflicts with one already defined in `DiffEqBase` 6.210.0 (current latest)
- Julia does not permit method overwriting during precompilation → all packages transitively depending on `DiffEqBase` (`DirectTrajOpt`, `OrdinaryDiffEqLinear`, `OrdinaryDiffEqTsit5`) fail to precompile
- Caps `SciMLBase = "2.145.0 - 2.145"` until `DiffEqBase` releases a version that removes the duplicate `rrule`

## Test plan

- [x] `using Piccolo` loads without precompilation errors
- [x] `Pkg.update("SciMLBase")` does not pull 2.146.0