### PR TITLE
Add TASKS.md and tasksmd-sync workflow

### DIFF
--- a/.github/workflows/tasksmd-sync.yml
+++ b/.github/workflows/tasksmd-sync.yml
@@ -1,0 +1,23 @@
+name: Sync TASKS.md
+
+on:
+  push:
+    branches: [main]
+    paths: ['TASKS.md']
+  pull_request:
+    paths: ['TASKS.md']
+
+jobs:
+  sync-tasks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: harmoniqs/tasksmd-sync@main
+        with:
+          tasks-file: TASKS.md
+          org: harmoniqs
+          project-number: '2'
+          repo-label: ${{ github.event.repository.name }}
+          github-token: ${{ secrets.PROJECTS_TOKEN }}
+          dry-run: ${{ github.event_name == 'pull_request' }}

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,44 @@
+# Tasks
+
+## Todo
+
+### Add plot recipes for pulse types
+- **Labels:** feature, visualization
+
+Add plotting support for pulse objects (`SplinePulse`, `ZeroOrderHoldPulse`, `LinearPulse`),
+akin to the existing unitary population plots. Should integrate with the Makie extension.
+
+### Improved testing for re-solving problems with global variables
+- **Labels:** testing
+
+Expand and improve test coverage for re-solving optimal control problems that use
+global variables, including edge cases and regression tests.
+
+### Saving and loading pulse objects
+- **Labels:** feature
+
+Now that typed pulse objects (`SplinePulse`, `ZeroOrderHoldPulse`, `LinearPulse`) exist
+and are an important work product, add serialization support (save/load) so pulses can
+be persisted and resampled across sessions (likely via JLD2).
+
+### Sort out integrator usage with SplinePulseProblem and pulse type constraints
+- **Labels:** refactor
+
+Clarify and enforce which integrators are valid for each problem type:
+- Private Piccolissimo integrators should work with `SplinePulseProblem`
+- `SmoothPulseProblem` and `BangBangProblem` should only accept zero-order hold pulses
+
+## In Progress
+
+### Implement tasksmd-sync for Piccolo.jl
+- **Labels:** meta, tooling
+
+Add `TASKS.md` and `.github/workflows/tasksmd-sync.yml` to sync tasks to the
+harmoniqs GitHub Project board. This PR.
+
+## Done
+
+### Typed drive system (LinearDrive, NonlinearDrive) with auto-Jacobian
+
+Merged in PR #79. Added `LinearDrive` and `NonlinearDrive` types with automatic
+Jacobian generation via ForwardDiff.


### PR DESCRIPTION
## Summary

- Adds `TASKS.md` to the repo root as the source of truth for Piccolo.jl tasks
- Adds `.github/workflows/tasksmd-sync.yml` to sync `TASKS.md` → harmoniqs GitHub Project board 2 via [`tasksmd-sync`](https://github.com/harmoniqs/tasksmd-sync)

**Behavior:**
- On PRs that touch `TASKS.md`: dry-run mode, posts a preview comment of changes
- On push to `main`: live sync creates/updates/archives board items labeled `Piccolo.jl`

**Initial tasks in `TASKS.md`:**
- Plot recipes for `SplinePulse`, `ZeroOrderHoldPulse`, `LinearPulse`
- Improved testing for re-solving problems with global variables
- Save/load support for pulse objects (JLD2)
- Enforce integrator/pulse-type constraints (`SplinePulseProblem` ↔ Piccolissimo integrators; `SmoothPulse`/`BangBang` ↔ zero-order hold only)
- This PR itself (In Progress)

## Prerequisites

`PROJECTS_TOKEN` secret must be set in the repo settings with Projects read/write scope (standard for harmoniqs repos).

## Test plan

- [x] Confirm `Sync TASKS.md` workflow runs in dry-run mode on this PR and posts a preview comment
- [ ] After merge, confirm workflow runs live and items appear on the harmoniqs project board filtered by `Piccolo.jl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)