### PR TITLE
fix: remove type parameter G from UnitaryTrajectory, add AbstractMatrix conversion overloads

### DIFF
--- a/src/quantum/trajectories/named_trajectory_conversion.jl
+++ b/src/quantum/trajectories/named_trajectory_conversion.jl
@@ -844,7 +844,7 @@ end
 
     @test qtraj2 isa UnitaryTrajectory
     @test qtraj2.system === system
-    @test qtraj2.goal === X_gate
+    @test qtraj2.goal == X_gate
 end
 
 @testitem "NamedTrajectory with Δt_bounds" begin

--- a/src/quantum/trajectories/named_trajectory_conversion.jl
+++ b/src/quantum/trajectories/named_trajectory_conversion.jl
@@ -629,7 +629,7 @@ end
 
     # Test interface
     @test get_system(qtraj) === system
-    @test get_goal(qtraj) === X_gate
+    @test get_goal(qtraj) == X_gate
     @test state_name(qtraj) == :Ũ⃗
     @test drive_name(qtraj) == :u
     @test time_name(qtraj) == :t

--- a/src/quantum/trajectories/unitary_trajectory.jl
+++ b/src/quantum/trajectories/unitary_trajectory.jl
@@ -3,7 +3,7 @@
 # ============================================================================ #
 
 """
-    UnitaryTrajectory{P<:AbstractPulse, S<:ODESolution, G} <: AbstractQuantumTrajectory{P}
+    UnitaryTrajectory{P<:AbstractPulse, S<:ODESolution} <: AbstractQuantumTrajectory{P}
 
 Trajectory for unitary gate synthesis. The ODE solution is computed at construction.
 
@@ -11,7 +11,7 @@ Trajectory for unitary gate synthesis. The ODE solution is computed at construct
 - `system::QuantumSystem`: The quantum system
 - `pulse::P`: The control pulse (stores drive_name)
 - `initial::Matrix{ComplexF64}`: Initial unitary (default: identity)
-- `goal::G`: Target unitary operator (AbstractPiccoloOperator or Matrix)
+- `goal::Union{Matrix{ComplexF64}, EmbeddedOperator}`: Target unitary operator
 - `solution::S`: Pre-computed ODE solution
 
 # Callable
@@ -20,12 +20,12 @@ Trajectory for unitary gate synthesis. The ODE solution is computed at construct
 # Conversion to NamedTrajectory
 Use `NamedTrajectory(traj, N)` or `NamedTrajectory(traj, times)` for optimization.
 """
-mutable struct UnitaryTrajectory{P<:AbstractPulse,S<:ODESolution,G} <:
+mutable struct UnitaryTrajectory{P<:AbstractPulse,S<:ODESolution} <:
                AbstractQuantumTrajectory{P}
     system::QuantumSystem
     pulse::P
     initial::Matrix{ComplexF64}
-    goal::G
+    goal::Union{Matrix{ComplexF64},EmbeddedOperator}
     solution::S
 end
 
@@ -49,13 +49,13 @@ Create a unitary trajectory by solving the Schrödinger equation.
 function UnitaryTrajectory(
     system::QuantumSystem,
     pulse::AbstractPulse,
-    goal::G;
+    goal::Union{Matrix{ComplexF64},EmbeddedOperator};
     initial::AbstractMatrix{<:Number} = Matrix{ComplexF64}(I, system.levels, system.levels),
     algorithm = MagnusAdapt4(),
     abstol::Real = 1e-8,
     reltol::Real = 1e-8,
     n_save::Int = 101,
-) where {G}
+)
     @assert n_drives(pulse) == system.n_drives "Pulse has $(n_drives(pulse)) drives, system has $(system.n_drives)"
 
     U0 = Matrix{ComplexF64}(initial)
@@ -65,7 +65,21 @@ function UnitaryTrajectory(
     prob = UnitaryOperatorODEProblem(system, pulse, tstops; U0 = U0)
     sol = solve(prob, algorithm; saveat = save_times, abstol = abstol, reltol = reltol)
 
-    return UnitaryTrajectory{typeof(pulse),typeof(sol),G}(system, pulse, U0, goal, sol)
+    return UnitaryTrajectory{typeof(pulse),typeof(sol)}(system, pulse, U0, goal, sol)
+end
+
+function UnitaryTrajectory(
+    system::QuantumSystem,
+    pulse::AbstractPulse,
+    goal::Union{AbstractMatrix{<:Number},EmbeddedOperator};
+    initial::AbstractMatrix{<:Number} = Matrix{ComplexF64}(I, system.levels, system.levels),
+    algorithm = MagnusAdapt4(),
+    abstol::Real = 1e-8,
+    reltol::Real = 1e-8,
+    n_save::Int = 101,
+)
+    goal_converted = goal isa AbstractMatrix ? ComplexF64.(goal) : goal
+    return UnitaryTrajectory(system, pulse, goal_converted; initial, algorithm, abstol, reltol, n_save)
 end
 
 """
@@ -86,17 +100,30 @@ Convenience constructor that creates a zero pulse of duration T.
 """
 function UnitaryTrajectory(
     system::QuantumSystem,
-    goal::G,
+    goal::Union{Matrix{ComplexF64},EmbeddedOperator},
     T::Real;
     drive_name::Symbol = :u,
     algorithm = MagnusAdapt4(),
     abstol::Real = 1e-8,
     reltol::Real = 1e-8,
-) where {G}
+)
     times = [0.0, T]
     controls = vcat([rand(Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
     pulse = ZeroOrderPulse(controls, times; drive_name)
     return UnitaryTrajectory(system, pulse, goal; algorithm, abstol, reltol)
+end
+
+function UnitaryTrajectory(
+    system::QuantumSystem,
+    goal::Union{AbstractMatrix{<:Number},EmbeddedOperator},
+    T::Real;
+    drive_name::Symbol = :u,
+    algorithm = MagnusAdapt4(),
+    abstol::Real = 1e-8,
+    reltol::Real = 1e-8,
+)
+    goal_converted = goal isa AbstractMatrix ? ComplexF64.(goal) : goal
+    return UnitaryTrajectory(system, goal_converted, T; drive_name, algorithm, abstol, reltol)
 end
 
 # Callable: sample solution at any time
@@ -119,7 +146,7 @@ end
 
     @test qtraj isa UnitaryTrajectory
     @test qtraj.system === system
-    @test qtraj.goal === X_gate
+    @test qtraj.goal == X_gate
     @test qtraj.initial ≈ Matrix{ComplexF64}(I, 2, 2)
 
     # Create with explicit pulse


### PR DESCRIPTION
Removes unconstrained type parameter `G` from `UnitaryTrajectory{P,S,G}`, replacing it with the concrete `Union{Matrix{ComplexF64}, EmbeddedOperator}`. Adds overloaded constructors accepting `AbstractMatrix{<:Number}` that convert to `ComplexF64` before delegating, so callers can pass e.g. `Float64` or `Int` matrices without errors.

Based on @gennadiryan's contribution in https://github.com/harmoniqs/PiccoloQuantumObjects.jl/pull/70.