### PR TITLE
chore: write back board item IDs to TASKS.md

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -33,6 +33,7 @@ Clarify and enforce which integrators are valid for each problem type:
 - `SmoothPulseProblem` and `BangBangProblem` should only accept zero-order hold pulses
 
 ### Refactor hermiticity check to a warning
+<!-- id: PVTI_lADOC9ysqc4BETyazgotxLM -->
 - **Labels:** refactor
 
 The hermiticity check for quantum systems currently throws an error. Change it to a


### PR DESCRIPTION
Automated writeback of project board item IDs by tasksmd-sync. Merge this to keep TASKS.md in sync with the project board.