### PR TITLE
feat: drive Hessian, per-drive du bounds, generalized free-phase, FunctionPulse

### DIFF
--- a/docs/literate/concepts/systems.jl
+++ b/docs/literate/concepts/systems.jl
@@ -134,6 +134,12 @@ drive_coeff_jac(d_auto, [3.0, 4.0, 0.0], 1)
 # `QuantumSystem` construction — sign errors or off-by-one bugs are caught
 # immediately.
 #
+# The **Hessian** ``\partial^2 f / \partial u_i \partial u_j`` is also
+# auto-generated via ForwardDiff (for both constructor forms).  It is used by
+# `SplineIntegrator` when `exact_hessian=true` to compute exact second-order
+# sensitivity matrices — essential for convergence with nonlinear drives.
+# You can override it with `coeff_hess = (u, i, j) -> ...` if needed.
+#
 # ### Structural Sparsity
 #
 # When a nonlinear drive depends on only a few control indices (e.g., ``u_3^2 + u_4^2``

--- a/src/control/constraints.jl
+++ b/src/control/constraints.jl
@@ -99,6 +99,49 @@ function FinalCoherentKetFidelityConstraint(
     )
 end
 
+"""
+    FinalCoherentKetFidelityConstraint(goals_fn, ψ̃_names, θ_names, final_fidelity, traj)
+
+Free-phase version: `goals_fn(θ)` returns phase-adjusted goal kets.
+Uses `NonlinearGlobalKnotPointConstraint` to include global phase variables.
+"""
+function FinalCoherentKetFidelityConstraint(
+    goals_fn::Function,
+    ψ̃_names::Vector{Symbol},
+    θ_names::AbstractVector{Symbol},
+    final_fidelity::Float64,
+    traj::NamedTrajectory,
+)
+    n_states = length(ψ̃_names)
+    state_dims = [traj.dims[name] for name in ψ̃_names]
+    total_state_dim = sum(state_dims)
+
+    function terminal_constraint(z)
+        x = z[1:total_state_dim]
+        θ = z[total_state_dim+1:end]
+
+        # Extract each state from the concatenated vector
+        ψ̃s = Vector{Vector{eltype(x)}}(undef, n_states)
+        offset = 0
+        for i = 1:n_states
+            ψ̃s[i] = x[(offset+1):(offset+state_dims[i])]
+            offset += state_dims[i]
+        end
+
+        phased_goals = goals_fn(θ)
+        return [final_fidelity - coherent_ket_fidelity(ψ̃s, phased_goals)]
+    end
+
+    return NonlinearGlobalKnotPointConstraint(
+        terminal_constraint,
+        ψ̃_names,
+        θ_names,
+        traj,
+        equality = false,
+        times = [traj.N],
+    )
+end
+
 # ---------------------------------------------------------
 #                        Unitaries
 # ---------------------------------------------------------

--- a/src/control/templates/_problem_templates.jl
+++ b/src/control/templates/_problem_templates.jl
@@ -99,7 +99,7 @@ function apply_piccolo_options!(
 end
 
 """
-    setup_free_phase_globals!(n_qubits, global_data, global_bounds; verbose=false)
+    setup_free_phase_globals!(n_qubits, global_data, global_bounds; initial_phases=nothing, verbose=false)
 
 Add per-qubit Z-phase variables (`φ_1`, `φ_2`, …) to `global_data` and
 `global_bounds` dicts. Returns the vector of phase variable names and the
@@ -107,20 +107,30 @@ Add per-qubit Z-phase variables (`φ_1`, `φ_2`, …) to `global_data` and
 
 Mutates `global_data` and `global_bounds` in place if they are not `nothing`;
 otherwise creates new dicts.
+
+# Keyword Arguments
+- `initial_phases::Union{Nothing,Vector{Float64}}`: Initial values for the phase variables.
+  If `nothing`, all phases are initialized to 0. If provided, must have length `n_qubits`.
+- `verbose::Bool`: Print diagnostic information.
 """
 function setup_free_phase_globals!(
     n_qubits::Int,
     global_data::Union{Nothing,Dict{Symbol,Vector{Float64}}},
     global_bounds::Union{Nothing,Dict{Symbol,<:Union{Float64,Tuple{Float64,Float64}}}};
+    initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     verbose::Bool = false,
 )
     θ_names = [Symbol(:φ_, i) for i in 1:n_qubits]
 
+    if !isnothing(initial_phases)
+        @assert length(initial_phases) == n_qubits "initial_phases must have length $n_qubits"
+    end
+
     if isnothing(global_data)
         global_data = Dict{Symbol,Vector{Float64}}()
     end
-    for name in θ_names
-        global_data[name] = [0.0]
+    for (i, name) in enumerate(θ_names)
+        global_data[name] = [isnothing(initial_phases) ? 0.0 : initial_phases[i]]
     end
 
     if isnothing(global_bounds)

--- a/src/control/templates/minimum_time_problem.jl
+++ b/src/control/templates/minimum_time_problem.jl
@@ -86,6 +86,8 @@ function MinimumTimeProblem(
     goal::Union{Nothing,AbstractPiccoloOperator,AbstractVector} = nothing,
     final_fidelity::Float64 = 0.99,
     D::Float64 = 100.0,
+    Δt_bounds::Union{Nothing,Tuple{Float64,Float64}} = nothing,
+    subsystem_levels::Union{Nothing,Vector{Int}} = nothing,
     piccolo_options::PiccoloOptions = PiccoloOptions(),
 ) where {QT<:AbstractQuantumTrajectory}
 
@@ -98,6 +100,11 @@ function MinimumTimeProblem(
     # Copy trajectory and constraints from original problem
     traj = deepcopy(qcp.prob.trajectory)
     constraints = deepcopy(qcp.prob.constraints)
+
+    # Optionally update Δt bounds (e.g., widen for min-time after tight fidelity solve)
+    if !isnothing(Δt_bounds) && haskey(traj.bounds, :Δt)
+        traj.bounds = merge(traj.bounds, (Δt = ([Δt_bounds[1]], [Δt_bounds[2]]),))
+    end
 
     # Add minimum-time objective to existing objective
     J = qcp.prob.objective + MinimumTimeObjective(traj, D = D)
@@ -112,7 +119,8 @@ function MinimumTimeProblem(
 
     # Add final fidelity constraint - dispatches on QT type parameter!
     fidelity_constraint =
-        _final_fidelity_constraint(qtraj_for_constraint, final_fidelity, traj)
+        _final_fidelity_constraint(qtraj_for_constraint, final_fidelity, traj;
+            subsystem_levels=subsystem_levels)
 
     # Handle single constraint or multiple constraints
     if fidelity_constraint isa AbstractVector
@@ -152,7 +160,8 @@ end
 function _final_fidelity_constraint(
     qtraj::UnitaryTrajectory,
     final_fidelity::Float64,
-    traj::NamedTrajectory,
+    traj::NamedTrajectory;
+    subsystem_levels::Union{Nothing,Vector{Int}} = nothing,
 )
     U_goal = qtraj.goal
     state_sym = state_name(qtraj)
@@ -179,7 +188,8 @@ end
 function _final_fidelity_constraint(
     qtraj::KetTrajectory,
     final_fidelity::Float64,
-    traj::NamedTrajectory,
+    traj::NamedTrajectory;
+    subsystem_levels::Union{Nothing,Vector{Int}} = nothing,
 )
     ψ_goal = qtraj.goal
     state_sym = state_name(qtraj)
@@ -189,7 +199,8 @@ end
 function _final_fidelity_constraint(
     qtraj::DensityTrajectory,
     final_fidelity::Float64,
-    traj::NamedTrajectory,
+    traj::NamedTrajectory;
+    subsystem_levels::Union{Nothing,Vector{Int}} = nothing,
 )
     # TODO: Implement density matrix fidelity constraint when available
     throw(
@@ -217,13 +228,33 @@ essential when implementing a gate via state transfer (e.g., X gate via
 function _final_fidelity_constraint(
     qtraj::MultiKetTrajectory,
     final_fidelity::Float64,
-    traj::NamedTrajectory,
+    traj::NamedTrajectory;
+    subsystem_levels::Union{Nothing,Vector{Int}} = nothing,
 )
     snames = state_names(qtraj)
     goals = qtraj.goals
 
-    # Use coherent fidelity constraint for proper phase alignment
-    return FinalCoherentKetFidelityConstraint(goals, snames, final_fidelity, traj)
+    # Detect free-phase variables (φ_1, φ_2, ...) in global components
+    θ_names = Symbol[
+        name for name in keys(traj.global_components)
+        if startswith(string(name), "φ_")
+    ]
+    sort!(θ_names)  # ensure consistent ordering
+
+    if !isempty(θ_names)
+        # Free-phase: need subsystem_levels to build phase-adjusted goals
+        @assert !isnothing(subsystem_levels) (
+            "MinimumTimeProblem with MultiKetTrajectory + free_phase requires " *
+            "subsystem_levels kwarg (e.g., subsystem_levels=[3,3] for two 3-level atoms)"
+        )
+        goals_fn = _make_free_phase_ket_goals(goals, subsystem_levels)
+        return FinalCoherentKetFidelityConstraint(
+            goals_fn, snames, θ_names, final_fidelity, traj
+        )
+    else
+        # Fixed-phase: use static goals
+        return FinalCoherentKetFidelityConstraint(goals, snames, final_fidelity, traj)
+    end
 end
 
 function _ensemble_fidelity_constraint(

--- a/src/control/templates/smooth_pulse_problem.jl
+++ b/src/control/templates/smooth_pulse_problem.jl
@@ -7,32 +7,41 @@ export SmoothPulseProblem
 """
     _make_free_phase_ket_goals(goals, subsystem_levels)
 
-Build a function `θ -> Vector{Vector{ComplexF64}}` that applies single-qubit
-Z-phase rotations to ket goal states in the full Hilbert space.
+Build a function `θ -> Vector{Vector{ComplexF64}}` that applies per-subsystem
+frame rotations `e^{iθⱼ n̂ⱼ}` to ket goal states in the full Hilbert space.
 
-For an N-qubit system with levels `[l₁, l₂, ...]`, each basis element
-`|s₁,s₂,...,sₙ⟩` gets phase `exp(i·Σⱼ θⱼ·δ(sⱼ,1))` — only the `|1⟩`
-level of each qubit acquires a phase.
+Each basis element `|s₁, s₂, ..., sₙ⟩` acquires phase `exp(i·Σⱼ sⱼ·θⱼ)`,
+where `sⱼ` is the level index of subsystem `j`. This is a number-operator
+rotation `e^{iθ n̂}` on each subsystem — the natural "free" phase from frame
+tracking.
+
+For 2-level qubits this is identical to the Z gate: `diag(1, e^{iθ})`.
+For multi-level systems (transmon, cavity) it gives: `diag(1, e^{iθ}, e^{2iθ}, ...)`.
+
+For a transmon⊗cavity system with `levels=[3, 10]`:
+- `|e, 0⟩` (q=1, n=0) gets phase `e^{iθ₁}`
+- `|e, 1⟩` (q=1, n=1) gets phase `e^{i(θ₁ + θ₂)}`
+- `|e, 2⟩` (q=1, n=2) gets phase `e^{i(θ₁ + 2θ₂)}`
+- `|g, n⟩` (q=0, any n) gets phase `e^{inθ₂}`
+- `|f, n⟩` (q=2, any n) gets phase `e^{i(2θ₁ + nθ₂)}`
 """
 function _make_free_phase_ket_goals(
     goals::Vector{<:AbstractVector{<:Complex}},
     subsystem_levels::Vector{Int},
 )
     dim = prod(subsystem_levels)
-    n_qubits = length(subsystem_levels)
+    n_subsystems = length(subsystem_levels)
 
     # Type-generic for ForwardDiff compatibility (θ may contain Dual numbers)
     function goals_fn(θ)
         phase_diag = map(0:dim-1) do idx
             phase = zero(eltype(θ))
             remaining = idx
-            for j in 1:n_qubits
-                stride = prod(subsystem_levels[k] for k in j+1:n_qubits; init=1)
+            for j in 1:n_subsystems
+                stride = prod(subsystem_levels[k] for k in j+1:n_subsystems; init=1)
                 sj = remaining ÷ stride
                 remaining = remaining % stride
-                if sj == 1  # |1⟩ state of qubit j
-                    phase += θ[j]
-                end
+                phase += sj * θ[j]
             end
             return exp(im * phase)
         end
@@ -302,6 +311,7 @@ function SmoothPulseProblem(
     piccolo_options::PiccoloOptions = PiccoloOptions(),
     free_phase::Bool = false,
     subsystem_levels::Union{Nothing,Vector{Int}} = nothing,
+    initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     coherent::Bool = true,
 )
     if piccolo_options.verbose
@@ -324,7 +334,7 @@ function SmoothPulseProblem(
         nothing
     end
 
-    # Free-phase support: add single-qubit Z-phase variables as globals
+    # Free-phase support: add per-subsystem phase variables as globals
     θ_names = Symbol[]
     goals_fn = nothing
     if free_phase
@@ -332,7 +342,8 @@ function SmoothPulseProblem(
         n_qubits = length(subsystem_levels)
         goals_fn = _make_free_phase_ket_goals(goals, subsystem_levels)
         θ_names, global_data, global_bounds = setup_free_phase_globals!(
-            n_qubits, global_data, global_bounds; verbose=piccolo_options.verbose
+            n_qubits, global_data, global_bounds;
+            initial_phases=initial_phases, verbose=piccolo_options.verbose
         )
     end
 

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -75,7 +75,8 @@ Both pulse types always have `:du` components in the trajectory, simplifying int
 - `integrator::Union{Nothing, AbstractIntegrator, Vector{<:AbstractIntegrator}}=nothing`: Optional custom integrator(s). If not provided, uses `BilinearIntegrator` (which does not support global variables). A custom integrator is required when `global_names` is specified.
 - `global_names::Union{Nothing, Vector{Symbol}}=nothing`: Names of global variables to optimize. Requires a custom integrator (e.g., `SplineIntegrator` from Piccolissimo) that supports global variables.
 - `global_bounds::Union{Nothing, Dict{Symbol, Union{Float64, Tuple{Float64, Float64}}}}=nothing`: Bounds for global variables. Keys are variable names, values are either a scalar (symmetric bounds ±value) or a tuple (lower, upper).
-- `du_bound::Float64=Inf`: Bound on derivative (slope) magnitude
+- `du_bound::Float64=Inf`: Uniform bound on derivative (slope) magnitude for all drives
+- `du_bounds::Union{Nothing, Vector{Float64}}=nothing`: Per-drive bounds on derivative magnitude (takes precedence over `du_bound`)
 - `Q::Float64=100.0`: Weight on infidelity/objective
 - `R::Float64=1e-2`: Weight on regularization terms
 - `R_u::Union{Float64, Vector{Float64}}=R`: Weight on control regularization
@@ -111,6 +112,7 @@ function SplinePulseProblem(
     global_names::Union{Nothing,Vector{Symbol}} = nothing,
     global_bounds::Union{Nothing,Dict{Symbol,<:Union{Float64,Tuple{Float64,Float64}}}} = nothing,
     du_bound::Float64 = Inf,
+    du_bounds::Union{Nothing,Vector{Float64}} = nothing,
     Δt_bounds::Union{Nothing,Tuple{Float64,Float64}} = nothing,
     Q::Float64 = 100.0,
     R::Float64 = 1e-2,
@@ -119,6 +121,7 @@ function SplinePulseProblem(
     constraints::Vector{<:AbstractConstraint} = AbstractConstraint[],
     piccolo_options::PiccoloOptions = PiccoloOptions(),
     free_phase::Bool = false,
+    initial_phases::Union{Nothing,Vector{Float64}} = nothing,
 )
     sys = get_system(qtraj)
     control_sym = drive_name(qtraj)
@@ -147,7 +150,8 @@ function SplinePulseProblem(
         n_qubits = length(goal.subsystem_levels)
         U_goal_fn = _make_free_phase_goal(goal)
         θ_names, global_data, global_bounds = setup_free_phase_globals!(
-            n_qubits, global_data, global_bounds; verbose=piccolo_options.verbose
+            n_qubits, global_data, global_bounds;
+            initial_phases=initial_phases, verbose=piccolo_options.verbose
         )
     end
 
@@ -163,26 +167,32 @@ function SplinePulseProblem(
     du_sym = Symbol(:d, control_sym)
     is_linear_spline = !haskey(base_traj.components, du_sym)
 
+    # Resolve per-drive du bounds: du_bounds (vector) takes precedence over du_bound (scalar)
+    _du_bounds_vec = if !isnothing(du_bounds)
+        du_bounds
+    elseif isfinite(du_bound)
+        fill(du_bound, sys.n_drives)
+    else
+        nothing
+    end
+
     traj = if haskey(base_traj.components, du_sym)
         # CubicSplinePulse already has derivative DOFs, but bounds default to (-Inf, Inf)
-        # We need to update them if du_bound is specified
-        if isfinite(du_bound)
-            # Use update_bound! to set the bounds properly
-            update_bound!(base_traj, du_sym, (-du_bound, du_bound))
+        if !isnothing(_du_bounds_vec)
+            update_bound!(base_traj, du_sym, (-_du_bounds_vec, _du_bounds_vec))
             if piccolo_options.verbose
-                println("    set du bounds to ±$du_bound for CubicSplinePulse")
+                println("    set du bounds to ±$(_du_bounds_vec) for CubicSplinePulse")
             end
         end
         base_traj
     else
         # LinearSplinePulse: always add derivatives
-        du_bounds_vec = isfinite(du_bound) ? fill(du_bound, sys.n_drives) : Float64[]
-        if !isempty(du_bounds_vec)
+        if !isnothing(_du_bounds_vec)
             add_control_derivatives(
                 base_traj,
                 1;  # Only 1 derivative for spline pulses
                 control_name = control_sym,
-                derivative_bounds = (du_bounds_vec,),
+                derivative_bounds = (_du_bounds_vec,),
             )
         else
             add_control_derivatives(base_traj, 1; control_name = control_sym)
@@ -289,6 +299,7 @@ function SplinePulseProblem(
     global_names::Union{Nothing,Vector{Symbol}} = nothing,
     global_bounds::Union{Nothing,Dict{Symbol,<:Union{Float64,Tuple{Float64,Float64}}}} = nothing,
     du_bound::Float64 = Inf,
+    du_bounds::Union{Nothing,Vector{Float64}} = nothing,
     Δt_bounds::Union{Nothing,Tuple{Float64,Float64}} = nothing,
     Q::Float64 = 100.0,
     R::Float64 = 1e-2,
@@ -298,6 +309,7 @@ function SplinePulseProblem(
     piccolo_options::PiccoloOptions = PiccoloOptions(),
     free_phase::Bool = false,
     subsystem_levels::Union{Nothing,Vector{Int}} = nothing,
+    initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     coherent::Bool = true,
 )
     sys = get_system(qtraj)
@@ -321,7 +333,7 @@ function SplinePulseProblem(
         nothing
     end
 
-    # Free-phase support: add single-qubit Z-phase variables as globals
+    # Free-phase support: add per-subsystem phase variables as globals
     θ_names = Symbol[]
     goals_fn = nothing
     if free_phase
@@ -329,7 +341,8 @@ function SplinePulseProblem(
         n_qubits = length(subsystem_levels)
         goals_fn = _make_free_phase_ket_goals(goals, subsystem_levels)
         θ_names, global_data, global_bounds = setup_free_phase_globals!(
-            n_qubits, global_data, global_bounds; verbose=piccolo_options.verbose
+            n_qubits, global_data, global_bounds;
+            initial_phases=initial_phases, verbose=piccolo_options.verbose
         )
     end
 
@@ -345,26 +358,32 @@ function SplinePulseProblem(
     du_sym = Symbol(:d, control_sym)
     is_linear_spline = !haskey(base_traj.components, du_sym)
 
+    # Resolve per-drive du bounds: du_bounds (vector) takes precedence over du_bound (scalar)
+    _du_bounds_vec = if !isnothing(du_bounds)
+        du_bounds
+    elseif isfinite(du_bound)
+        fill(du_bound, sys.n_drives)
+    else
+        nothing
+    end
+
     traj = if haskey(base_traj.components, du_sym)
         # CubicSplinePulse already has derivative DOFs, but bounds default to (-Inf, Inf)
-        # We need to update them if du_bound is specified
-        if isfinite(du_bound)
-            # Use update_bound! to set the bounds properly
-            update_bound!(base_traj, du_sym, (-du_bound, du_bound))
+        if !isnothing(_du_bounds_vec)
+            update_bound!(base_traj, du_sym, (-_du_bounds_vec, _du_bounds_vec))
             if piccolo_options.verbose
-                println("    set du bounds to ±$du_bound for CubicSplinePulse")
+                println("    set du bounds to ±$(_du_bounds_vec) for CubicSplinePulse")
             end
         end
         base_traj
     else
         # LinearSplinePulse: always add derivatives
-        du_bounds_vec = isfinite(du_bound) ? fill(du_bound, sys.n_drives) : Float64[]
-        if !isempty(du_bounds_vec)
+        if !isnothing(_du_bounds_vec)
             add_control_derivatives(
                 base_traj,
                 1;  # Only 1 derivative for spline pulses
                 control_name = control_sym,
-                derivative_bounds = (du_bounds_vec,),
+                derivative_bounds = (_du_bounds_vec,),
             )
         else
             add_control_derivatives(base_traj, 1; control_name = control_sym)

--- a/src/quantum/primitives/pulses.jl
+++ b/src/quantum/primitives/pulses.jl
@@ -17,7 +17,7 @@ All pulses are callable: `pulse(t)` returns the control vector at time `t`.
 
 export AbstractPulse, AbstractSplinePulse
 export ZeroOrderPulse,
-    LinearSplinePulse, CubicSplinePulse, GaussianPulse, ErfPulse, CompositePulse
+    LinearSplinePulse, CubicSplinePulse, GaussianPulse, ErfPulse, CompositePulse, FunctionPulse
 export duration, n_drives, sample, drive_name
 
 using DataInterpolations: ConstantInterpolation, LinearInterpolation, CubicHermiteSpline
@@ -800,8 +800,49 @@ end
 
 evaluate(p::CompositePulse, t) = p.f(t)
 
+# ============================================================================ #
+# FunctionPulse (arbitrary user-defined function)
+# ============================================================================ #
+
+"""
+    FunctionPulse{F<:Function} <: AbstractPulse
+
+Pulse defined by an arbitrary function `f(t) -> Vector{Float64}`.
+
+Useful for testing analytic pulse shapes (e.g. sin² envelopes) with the
+`rollout` / `fidelity` interface without discretizing into spline knots.
+
+# Fields
+- `f::F`: Function mapping time to control vector
+- `duration::Float64`: Total pulse duration
+- `n_drives::Int`: Number of control drives
+- `drive_name::Symbol`: Name of the drive variable (default `:u`)
+
+# Example
+```julia
+T = 1000.0
+pulse = FunctionPulse(t -> [0.0, 0.0, 1.5 * sin(π*t/T)^2, 0.0], T, 4)
+qtraj = MultiKetTrajectory(sys, pulse, initials, goals)
+qtraj_out = rollout(qtraj)
+fid = fidelity(qtraj_out)
+```
+"""
+struct FunctionPulse{F<:Function} <: AbstractPulse
+    f::F
+    duration::Float64
+    n_drives::Int
+    drive_name::Symbol
+end
+
+function FunctionPulse(f::Function, duration::Real, n_drives::Int; drive_name::Symbol=:u)
+    return FunctionPulse(f, Float64(duration), n_drives, drive_name)
+end
+
+evaluate(p::FunctionPulse, t) = p.f(t)
+
 # Knot time accessors for analytic and composite pulses
 # (defined here because GaussianPulse, ErfPulse, CompositePulse are defined above)
+get_knot_times(p::FunctionPulse) = [0.0, p.duration]
 get_knot_times(p::GaussianPulse) = [0.0, p.duration]
 get_knot_times(p::ErfPulse) = [0.0, p.duration]
 get_knot_times(p::CompositePulse) =

--- a/src/quantum/systems/_quantum_systems.jl
+++ b/src/quantum/systems/_quantum_systems.jl
@@ -7,10 +7,11 @@ export VariationalQuantumSystem
 export CompositeQuantumSystem
 
 export AbstractDrive, LinearDrive, NonlinearDrive
-export drive_coeff, drive_coeff_jac
+export drive_coeff, drive_coeff_jac, drive_coeff_hess
+export drive_matrix, drive_dim
 export active_controls
 export has_nonlinear_drives
-export validate_drive_jacobian
+export validate_drive_jacobian, validate_drive_hessian
 
 export get_drift
 export get_drives
@@ -117,7 +118,7 @@ basis vector evaluation.
 """
 function get_drives(sys::AbstractQuantumSystem)
     if hasproperty(sys, :H_drives) && !isempty(sys.H_drives)
-        return [d.H for d in sys.H_drives]
+        return [drive_matrix(d) for d in sys.H_drives]
     end
     H_drift = get_drift(sys)
     # Basis vectors for controls will extract drive operators (linear systems only)

--- a/src/quantum/systems/drives.jl
+++ b/src/quantum/systems/drives.jl
@@ -9,6 +9,8 @@
 #
 # For analytical sensitivity equations (e.g., spline integrators), the chain
 # rule requires: ∂H/∂u_j = Σ_d drive_coeff_jac(d, u, j) * d.H
+# For second-order sensitivity equations (exact Hessian):
+# ∂²H/∂u_i∂u_j = Σ_d drive_coeff_hess(d, u, i, j) * d.H
 # ----------------------------------------------------------------------------- #
 
 """
@@ -24,6 +26,7 @@ control vector `u`. The full Hamiltonian is:
 Subtypes must implement:
 - `drive_coeff(d, u)` — compute the scalar coefficient
 - `drive_coeff_jac(d, u, j)` — compute ∂coeff/∂u_j
+- `drive_coeff_hess(d, u, i, j)` — compute ∂²coeff/∂u_i∂u_j
 - `active_controls(d)` — return indices where ∂coeff/∂u_j can be nonzero
 
 See [`LinearDrive`](@ref) and [`NonlinearDrive`](@ref).
@@ -31,14 +34,14 @@ See [`LinearDrive`](@ref) and [`NonlinearDrive`](@ref).
 abstract type AbstractDrive end
 
 """
-    LinearDrive <: AbstractDrive
+    LinearDrive{H} <: AbstractDrive
 
 Standard linear drive: coefficient is `u[index]`.
 
 This is the default representation when constructing `QuantumSystem(H_drift, H_drives, bounds)`.
 
 # Fields
-- `H::SparseMatrixCSC{ComplexF64,Int}`: The Hermitian drive operator
+- `H::H`: The Hermitian drive operator (matrix or `AbstractDynamicsOperator`)
 - `index::Int`: Index into the control vector `u`
 
 # Example
@@ -46,25 +49,29 @@ This is the default representation when constructing `QuantumSystem(H_drift, H_d
 LinearDrive(sparse(PAULIS.X), 1)  # u[1] * σx
 ```
 """
-struct LinearDrive <: AbstractDrive
-    H::SparseMatrixCSC{ComplexF64,Int}
+struct LinearDrive{H} <: AbstractDrive
+    H::H
     index::Int
 end
 
 """
-    NonlinearDrive{F,DF} <: AbstractDrive
+    NonlinearDrive{H,F,DF,HF} <: AbstractDrive
 
 Drive term with a nonlinear scalar coefficient: `f(u) * H`.
 
 The user provides either:
 1. Both the coefficient function and its Jacobian (3-arg form), or
-2. Just the coefficient function (2-arg form) — the Jacobian is computed
-   automatically via ForwardDiff.
+2. Just the coefficient function (2-arg form) — the Jacobian and Hessian are
+   computed automatically via ForwardDiff.
+
+The Hessian (`coeff_hess`) is used by the second-order sensitivity ODE for exact
+Hessian computation in SplineIntegrator (`exact_hessian=true`).
 
 # Fields
-- `H::SparseMatrixCSC{ComplexF64,Int}`: The Hermitian drive operator
+- `H::H`: The Hermitian drive operator (matrix or `AbstractDynamicsOperator`)
 - `coeff::F`: `(u::AbstractVector) -> scalar` — coefficient function
 - `coeff_jac::DF`: `(u::AbstractVector, j::Int) -> scalar` — ∂coeff/∂u_j
+- `coeff_hess::HF`: `(u::AbstractVector, i::Int, j::Int) -> scalar` — ∂²coeff/∂u_i∂u_j
 - `active_controls::Vector{Int}`: Control indices where ∂coeff/∂u_j can be nonzero.
   Empty means "all controls" (no structural sparsity info).
 
@@ -83,26 +90,30 @@ NonlinearDrive(
 )
 ```
 """
-struct NonlinearDrive{F,DF} <: AbstractDrive
-    H::SparseMatrixCSC{ComplexF64,Int}
+struct NonlinearDrive{H,F,DF,HF} <: AbstractDrive
+    H::H
     coeff::F
     coeff_jac::DF
+    coeff_hess::HF
     active_controls::Vector{Int}
 end
 
 """
-    NonlinearDrive(H::AbstractMatrix, coeff, coeff_jac; active_controls=Int[])
+    NonlinearDrive(H::AbstractMatrix, coeff, coeff_jac; active_controls=Int[], coeff_hess=nothing)
 
 Construct a `NonlinearDrive` with an explicit Jacobian function.
 `active_controls` lists which control indices have nonzero ∂coeff/∂u_j (empty = all).
+If `coeff_hess` is not provided, it is auto-generated via ForwardDiff from `coeff`.
 """
 function NonlinearDrive(
     H::AbstractMatrix,
     coeff::F,
     coeff_jac::DF;
     active_controls::Vector{Int} = Int[],
+    coeff_hess = nothing,
 ) where {F,DF}
-    return NonlinearDrive(sparse(ComplexF64.(H)), coeff, coeff_jac, active_controls)
+    hess = isnothing(coeff_hess) ? _forwarddiff_hessian(coeff) : coeff_hess
+    return NonlinearDrive(sparse(ComplexF64.(H)), coeff, coeff_jac, hess, active_controls)
 end
 
 """
@@ -125,7 +136,42 @@ function NonlinearDrive(
     active_controls::Vector{Int} = Int[],
 ) where {F}
     coeff_jac = _forwarddiff_jacobian(coeff)
-    return NonlinearDrive(sparse(ComplexF64.(H)), coeff, coeff_jac, active_controls)
+    coeff_hess = _forwarddiff_hessian(coeff)
+    return NonlinearDrive(sparse(ComplexF64.(H)), coeff, coeff_jac, coeff_hess, active_controls)
+end
+
+# ── Generic constructors (for structured operators or any non-matrix Hamiltonian) ──
+
+"""
+    NonlinearDrive(H, coeff; active_controls=Int[])
+
+Construct a `NonlinearDrive` with any Hamiltonian type (e.g., `AbstractDynamicsOperator`).
+The Hamiltonian is stored as-is (not materialized or sparsified).
+"""
+function NonlinearDrive(
+    H,
+    coeff::F;
+    active_controls::Vector{Int} = Int[],
+) where {F}
+    coeff_jac = _forwarddiff_jacobian(coeff)
+    coeff_hess = _forwarddiff_hessian(coeff)
+    return NonlinearDrive(H, coeff, coeff_jac, coeff_hess, active_controls)
+end
+
+"""
+    NonlinearDrive(H, coeff, coeff_jac; active_controls=Int[], coeff_hess=nothing)
+
+Construct a `NonlinearDrive` with any Hamiltonian type and explicit Jacobian.
+"""
+function NonlinearDrive(
+    H,
+    coeff::F,
+    coeff_jac::DF;
+    active_controls::Vector{Int} = Int[],
+    coeff_hess = nothing,
+) where {F,DF}
+    hess = isnothing(coeff_hess) ? _forwarddiff_hessian(coeff) : coeff_hess
+    return NonlinearDrive(H, coeff, coeff_jac, hess, active_controls)
 end
 
 """
@@ -135,6 +181,15 @@ Create a Jacobian function from a scalar-valued function `f(u)` using ForwardDif
 """
 function _forwarddiff_jacobian(f::F) where {F}
     return (u, j) -> ForwardDiff.gradient(f, u)[j]
+end
+
+"""
+    _forwarddiff_hessian(f) -> (u, i, j) -> ∂²f/∂u_i∂u_j
+
+Create a Hessian function from a scalar-valued function `f(u)` using ForwardDiff.
+"""
+function _forwarddiff_hessian(f::F) where {F}
+    return (u, i, j) -> ForwardDiff.hessian(f, u)[i, j]
 end
 
 # ----------------------------------------------------------------------------- #
@@ -161,6 +216,17 @@ For `NonlinearDrive`: evaluates the Jacobian function (user-provided or auto-gen
 @inline drive_coeff_jac(d::NonlinearDrive, u::AbstractVector, j::Int) = d.coeff_jac(u, j)
 
 """
+    drive_coeff_hess(d::AbstractDrive, u::AbstractVector, i::Int, j::Int) -> Number
+
+Compute ∂²coeff/∂u_i∂u_j at controls `u`.
+
+For `LinearDrive`: always returns 0.0 (linear coefficient has zero Hessian).
+For `NonlinearDrive`: evaluates the Hessian function (user-provided or auto-generated).
+"""
+@inline drive_coeff_hess(d::LinearDrive, ::AbstractVector, ::Int, ::Int) = 0.0
+@inline drive_coeff_hess(d::NonlinearDrive, u::AbstractVector, i::Int, j::Int) = d.coeff_hess(u, i, j)
+
+"""
     active_controls(d::AbstractDrive) -> Vector{Int}
 
 Return the control indices where `drive_coeff_jac(d, u, j)` can be nonzero.
@@ -181,6 +247,36 @@ has_nonlinear_drives(drives::AbstractVector{<:AbstractDrive}) =
     any(d -> d isa NonlinearDrive, drives)
 
 # ----------------------------------------------------------------------------- #
+# Matrix access
+# ----------------------------------------------------------------------------- #
+
+"""
+    _ensure_matrix(H) -> AbstractMatrix
+
+Convert `H` to a matrix if it isn't one already. For `AbstractMatrix` inputs,
+returns `H` directly. For operator types (e.g., from Piccolissimo's operators
+module), falls back to `Matrix(H)` — operator packages should define
+`Base.Matrix(op)` to return a dense matrix representation.
+"""
+_ensure_matrix(H::AbstractMatrix) = H
+_ensure_matrix(H) = Matrix(H)
+
+"""
+    drive_matrix(d::AbstractDrive) -> AbstractMatrix
+
+Return the drive operator as a matrix. Use this instead of `d.H` when a matrix
+is required (e.g., for `Isomorphisms.G`, Hermiticity checks, or `H(u,t)` closures).
+"""
+drive_matrix(d::AbstractDrive) = _ensure_matrix(d.H)
+
+"""
+    drive_dim(d::AbstractDrive) -> Int
+
+Return the Hilbert space dimension of the drive operator.
+"""
+drive_dim(d::AbstractDrive) = size(drive_matrix(d), 1)
+
+# ----------------------------------------------------------------------------- #
 # Isomorphism dispatch for drives
 # ----------------------------------------------------------------------------- #
 
@@ -190,7 +286,7 @@ has_nonlinear_drives(drives::AbstractVector{<:AbstractDrive}) =
 Delegate `G` to the underlying Hamiltonian matrix `d.H`, so that broadcasting
 `G.(sys.H_drives)` works when `H_drives` contains `AbstractDrive` objects.
 """
-Isomorphisms.G(d::AbstractDrive) = Isomorphisms.G(d.H)
+Isomorphisms.G(d::AbstractDrive) = Isomorphisms.G(drive_matrix(d))
 
 # ----------------------------------------------------------------------------- #
 # Jacobian Validation
@@ -224,6 +320,31 @@ function validate_drive_jacobian(
     end
 end
 
+"""
+    validate_drive_hessian(d::NonlinearDrive, n_controls::Int; atol=1e-6, n_samples=3)
+
+Spot-check the Hessian of a `NonlinearDrive` against ForwardDiff at random control vectors.
+Throws an `AssertionError` if the user-provided Hessian disagrees with the AD Hessian.
+"""
+function validate_drive_hessian(
+    d::NonlinearDrive,
+    n_controls::Int;
+    atol::Float64 = 1e-6,
+    n_samples::Int = 3,
+)
+    for _ = 1:n_samples
+        u = randn(n_controls)
+        hess_ad = ForwardDiff.hessian(d.coeff, u)
+        for i = 1:n_controls, j = i:n_controls
+            user_val = d.coeff_hess(u, i, j)
+            @assert abs(user_val - hess_ad[i, j]) < atol (
+                "NonlinearDrive Hessian mismatch at u=$u, (i,j)=($i,$j): " *
+                "user=$(user_val), ForwardDiff=$(hess_ad[i, j])"
+            )
+        end
+    end
+end
+
 # ----------------------------------------------------------------------------- #
 # Tests
 # ----------------------------------------------------------------------------- #
@@ -241,6 +362,11 @@ end
     @test drive_coeff_jac(d, u, 2) == 1.0
     @test drive_coeff_jac(d, u, 3) == 0.0
     @test d.H === H
+
+    # Hessian is always zero for linear drives
+    @test drive_coeff_hess(d, u, 1, 1) == 0.0
+    @test drive_coeff_hess(d, u, 2, 2) == 0.0
+    @test drive_coeff_hess(d, u, 1, 2) == 0.0
 
     # active_controls
     @test active_controls(d) == [2]
@@ -267,12 +393,24 @@ end
     @test d.H == H
     @test isempty(active_controls(d))  # default: empty = all controls
 
+    # Hessian: ∂²(u₁² + u₂²)/∂u_i∂u_j
+    @test drive_coeff_hess(d, u, 1, 1) ≈ 2.0  # ∂²/∂u₁² = 2
+    @test drive_coeff_hess(d, u, 2, 2) ≈ 2.0  # ∂²/∂u₂² = 2
+    @test drive_coeff_hess(d, u, 1, 2) ≈ 0.0  # ∂²/∂u₁∂u₂ = 0
+    @test drive_coeff_hess(d, u, 3, 3) ≈ 0.0  # u₃ not involved
+
     # Product: u[1] * u[2]
     d2 = NonlinearDrive(H, u -> u[1] * u[2], (u, j) -> j == 1 ? u[2] : j == 2 ? u[1] : 0.0)
 
     @test drive_coeff(d2, u) == 12.0
     @test drive_coeff_jac(d2, u, 1) == 4.0
     @test drive_coeff_jac(d2, u, 2) == 3.0
+
+    # Hessian: ∂²(u₁u₂)/∂u_i∂u_j
+    @test drive_coeff_hess(d2, u, 1, 2) ≈ 1.0  # ∂²/∂u₁∂u₂ = 1
+    @test drive_coeff_hess(d2, u, 2, 1) ≈ 1.0  # symmetric
+    @test drive_coeff_hess(d2, u, 1, 1) ≈ 0.0  # ∂²/∂u₁² = 0
+    @test drive_coeff_hess(d2, u, 2, 2) ≈ 0.0  # ∂²/∂u₂² = 0
 
     # With active_controls
     d3 = NonlinearDrive(
@@ -307,11 +445,17 @@ end
     # Cubic term
     d3 = NonlinearDrive(H, u -> u[1]^3)
     @test drive_coeff_jac(d3, [2.0], 1) ≈ 12.0
+    @test drive_coeff_hess(d3, [2.0], 1, 1) ≈ 12.0  # ∂²(u³)/∂u² = 6u = 12
+
+    # Hessian of auto-generated quadratic
+    @test drive_coeff_hess(d, [3.0, 4.0, 0.0], 1, 1) ≈ 2.0
+    @test drive_coeff_hess(d, [3.0, 4.0, 0.0], 1, 2) ≈ 0.0
 
     # With active_controls
     d4 = NonlinearDrive(H, u -> u[2]^2; active_controls = [2])
     @test active_controls(d4) == [2]
     @test drive_coeff_jac(d4, [1.0, 3.0], 2) ≈ 6.0
+    @test drive_coeff_hess(d4, [1.0, 3.0], 2, 2) ≈ 2.0
 end
 
 @testitem "NonlinearDrive accepts dense matrix" begin
@@ -330,6 +474,37 @@ end
     @test d2.H isa SparseMatrixCSC
     @test drive_coeff(d2, [3.0]) == 9.0
     @test drive_coeff_jac(d2, [3.0], 1) ≈ 6.0
+    @test drive_coeff_hess(d2, [3.0], 1, 1) ≈ 2.0
+end
+
+@testitem "NonlinearDrive with explicit Hessian" begin
+    using Piccolo
+    using SparseArrays
+
+    H = sparse([1.0+0im 0.0+0im; 0.0+0im -1.0+0im])
+
+    # Provide all three: coeff, jac, hess
+    d = NonlinearDrive(
+        H,
+        u -> u[1]^2 + u[2]^2,
+        (u, j) -> j == 1 ? 2u[1] : j == 2 ? 2u[2] : 0.0;
+        coeff_hess = (u, i, j) -> (i == j && i <= 2) ? 2.0 : 0.0,
+    )
+
+    u = [3.0, 4.0]
+    @test drive_coeff_hess(d, u, 1, 1) == 2.0
+    @test drive_coeff_hess(d, u, 2, 2) == 2.0
+    @test drive_coeff_hess(d, u, 1, 2) == 0.0
+
+    # Cubic with explicit hess: u[1]^3
+    d2 = NonlinearDrive(
+        H,
+        u -> u[1]^3,
+        (u, j) -> j == 1 ? 3u[1]^2 : 0.0;
+        coeff_hess = (u, i, j) -> (i == 1 && j == 1) ? 6u[1] : 0.0,
+    )
+    @test drive_coeff_hess(d2, [2.0], 1, 1) == 12.0
+    @test drive_coeff_hess(d2, [5.0], 1, 1) == 30.0
 end
 
 @testitem "validate_drive_jacobian" begin
@@ -357,6 +532,35 @@ end
     # Auto-Jacobian should always pass validation
     d_auto = NonlinearDrive(H, u -> u[1]^2 + u[2]^2)
     validate_drive_jacobian(d_auto, 2)
+end
+
+@testitem "validate_drive_hessian" begin
+    using Piccolo
+    using SparseArrays
+
+    H = sparse([1.0+0im 0.0+0im; 0.0+0im -1.0+0im])
+
+    # Auto-Hessian should always pass
+    d_auto = NonlinearDrive(H, u -> u[1]^2 + u[2]^2)
+    validate_drive_hessian(d_auto, 2)
+
+    # Correct explicit Hessian should pass
+    d_correct = NonlinearDrive(
+        H,
+        u -> u[1]^2 + u[2]^2,
+        (u, j) -> j == 1 ? 2u[1] : j == 2 ? 2u[2] : 0.0;
+        coeff_hess = (u, i, j) -> (i == j && i <= 2) ? 2.0 : 0.0,
+    )
+    validate_drive_hessian(d_correct, 2)
+
+    # Wrong explicit Hessian should fail
+    d_wrong = NonlinearDrive(
+        H,
+        u -> u[1]^2 + u[2]^2,
+        (u, j) -> j == 1 ? 2u[1] : j == 2 ? 2u[2] : 0.0;
+        coeff_hess = (u, i, j) -> 0.0,  # wrong: should be 2.0 on diagonal
+    )
+    @test_throws AssertionError validate_drive_hessian(d_wrong, 2)
 end
 
 @testitem "G works on AbstractDrive types" begin

--- a/src/quantum/systems/open_quantum_systems.jl
+++ b/src/quantum/systems/open_quantum_systems.jl
@@ -168,7 +168,7 @@ function OpenQuantumSystem(
 
     # Check that all drive operators are Hermitian
     for (i, d) in enumerate(drives)
-        @assert is_hermitian(d.H) "Drive operator drives[$i].H is not Hermitian"
+        @assert is_hermitian(drive_matrix(d)) "Drive operator drives[$i].H is not Hermitian"
     end
 
     H_drift_sparse = sparse(ComplexF64.(H_drift))
@@ -189,9 +189,12 @@ function OpenQuantumSystem(
         end
     end
 
+    # Materialize drive operators for closures
+    H_drive_mats = [sparse(ComplexF64.(drive_matrix(d))) for d in drives]
+
     # Build H(u,t) and 𝒢(u) from drives
     𝒢_drift = Isomorphisms.G(Isomorphisms.ad_vec(H_drift_sparse))
-    𝒢_drive_mats = [Isomorphisms.G(Isomorphisms.ad_vec(d.H)) for d in drives]
+    𝒢_drive_mats = [Isomorphisms.G(Isomorphisms.ad_vec(H_d)) for H_d in H_drive_mats]
 
     # Build dissipator
     if isempty(dissipation_operators)
@@ -204,7 +207,7 @@ function OpenQuantumSystem(
         H_fn = (u, t) -> H_drift_sparse
         𝒢_fn = u -> 𝒢_drift + 𝒟
     else
-        H_fn = (u, t) -> H_drift_sparse + sum(drive_coeff(d, u) * d.H for d in drives)
+        H_fn = (u, t) -> H_drift_sparse + sum(drive_coeff(d, u) * H_d for (d, H_d) in zip(drives, H_drive_mats))
         𝒢_fn =
             u ->
                 𝒢_drift +
@@ -369,7 +372,7 @@ function compact_lindbladian_generators(sys::OpenQuantumSystem)
 
     # Reconstruct full Lindbladian components from stored fields
     𝒢_drift = Isomorphisms.G(Isomorphisms.ad_vec(sys.H_drift))
-    𝒢_drive_terms = [Isomorphisms.G(Isomorphisms.ad_vec(d.H)) for d in sys.H_drives]
+    𝒢_drive_terms = [Isomorphisms.G(Isomorphisms.ad_vec(drive_matrix(d))) for d in sys.H_drives]
 
     if isempty(sys.dissipation_operators)
         𝒟 = spzeros(size(𝒢_drift))

--- a/src/quantum/systems/quantum_systems.jl
+++ b/src/quantum/systems/quantum_systems.jl
@@ -20,7 +20,7 @@ A struct for storing quantum dynamics.
 # Fields
 - `H::Function`: The Hamiltonian function: (u, t) -> H(u, t), where u is the control vector and t is time
 - `G::Function`: The isomorphic generator function: (u, t) -> G(u, t), including the Hamiltonian mapped to superoperator space
-- `H_drift::SparseMatrixCSC{ComplexF64, Int}`: The drift Hamiltonian (time-independent component)
+- `H_drift`: The drift Hamiltonian (time-independent component). Typically `SparseMatrixCSC{ComplexF64,Int}` for matrix-based systems, but can be any type (e.g., an `AbstractDynamicsOperator` from Piccolissimo) for structured operator acceleration.
 - `H_drives::Vector{AbstractDrive}`: The canonical drive terms, each pairing an operator with a coefficient function. Matrix-based constructors auto-populate this with `LinearDrive` objects; function-based systems leave it empty.
 - `drive_bounds::Vector{Tuple{Float64, Float64}}`: Drive amplitude bounds for each control (lower, upper)
 - `n_drives::Int`: The number of control channels (length of the control vector `u`)
@@ -30,10 +30,10 @@ A struct for storing quantum dynamics.
 
 See also [`OpenQuantumSystem`](@ref), [`VariationalQuantumSystem`](@ref).
 """
-struct QuantumSystem{F1<:Function,F2<:Function,PT<:NamedTuple} <: AbstractQuantumSystem
+struct QuantumSystem{F1<:Function,F2<:Function,PT<:NamedTuple,HD} <: AbstractQuantumSystem
     H::F1
     G::F2
-    H_drift::SparseMatrixCSC{ComplexF64,Int}
+    H_drift::HD
     H_drives::Vector{AbstractDrive}
     drive_bounds::Vector{Tuple{Float64,Float64}}
     n_drives::Int
@@ -249,7 +249,7 @@ function QuantumSystem(
     global_params::NamedTuple = NamedTuple(),
 )
     @assert !isempty(drives) "At least one drive is required"
-    levels = size(first(drives).H, 1)
+    levels = drive_dim(first(drives))
     return QuantumSystem(
         spzeros(ComplexF64, levels, levels),
         drives,
@@ -338,7 +338,7 @@ function QuantumSystem(
 
     # Check that all drive operators are Hermitian
     for (i, d) in enumerate(drives)
-        @assert is_hermitian(d.H) "Drive operator drives[$i].H is not Hermitian"
+        @assert is_hermitian(drive_matrix(d)) "Drive operator drives[$i].H is not Hermitian"
     end
 
     H_drift = sparse(ComplexF64.(H_drift))
@@ -361,13 +361,14 @@ function QuantumSystem(
 
     # Build H(u,t) and G(u,t) from drives
     G_drift = sparse(Isomorphisms.G(H_drift))
-    G_drive_mats = [sparse(Isomorphisms.G(d.H)) for d in drives]
+    H_drive_mats = [sparse(ComplexF64.(drive_matrix(d))) for d in drives]
+    G_drive_mats = [sparse(Isomorphisms.G(H_d)) for H_d in H_drive_mats]
 
     if isempty(drives)
         H_fn = (u, t) -> H_drift
         G_fn = (u, t) -> G_drift
     else
-        H_fn = (u, t) -> H_drift + sum(drive_coeff(d, u) * d.H for d in drives)
+        H_fn = (u, t) -> H_drift + sum(drive_coeff(d, u) * H_d for (d, H_d) in zip(drives, H_drive_mats))
         G_fn =
             (u, t) ->
                 G_drift +
@@ -378,6 +379,96 @@ function QuantumSystem(
         H_fn,
         G_fn,
         H_drift,
+        collect(AbstractDrive, drives),
+        drive_bounds,
+        n_drives,
+        levels,
+        time_dependent,
+        _float_params(global_params),
+    )
+end
+
+"""
+    QuantumSystem(
+        H_drift,
+        drives::Vector{<:AbstractDrive},
+        drive_bounds::Vector;
+        time_dependent::Bool=false,
+        global_params::NamedTuple=NamedTuple()
+    )
+
+Construct a QuantumSystem from a non-matrix drift Hamiltonian (e.g., a structured
+operator from Piccolissimo) and typed drive terms.
+
+The drift is stored directly without sparse conversion, enabling structured operator
+acceleration in the spline integrator. The `H(u,t)` and `G(u,t)` closures are built
+from materialized matrices for backward compatibility with function-based paths.
+
+# Example
+```julia
+using Piccolissimo: DiagonalOperator
+H_drift_op = DiagonalOperator(ComplexF64[0.0, 1.0, 2.0])
+sys = QuantumSystem(H_drift_op, [LinearDrive(H_x_op, 1)], [1.0])
+```
+"""
+function QuantumSystem(
+    H_drift_op,
+    drives::Vector{<:AbstractDrive},
+    drive_bounds::Vector{<:Union{Tuple{Float64,Float64},Float64}};
+    time_dependent::Bool = false,
+    global_params::NamedTuple = NamedTuple(),
+)
+    # Only dispatch here for non-AbstractMatrix types; matrices use the method above
+    H_drift_op isa AbstractMatrix && return QuantumSystem(
+        convert(AbstractMatrix{ComplexF64}, H_drift_op), drives, drive_bounds;
+        time_dependent=time_dependent, global_params=global_params
+    )
+
+    drive_bounds = normalize_drive_bounds(drive_bounds)
+
+    # Check that all drive operators are Hermitian (drive_matrix materializes)
+    for (i, d) in enumerate(drives)
+        @assert is_hermitian(drive_matrix(d)) "Drive operator drives[$i].H is not Hermitian"
+    end
+
+    n_drives = length(drive_bounds)
+    levels = size(H_drift_op, 1)
+
+    # Validate LinearDrive indices
+    for (i, d) in enumerate(drives)
+        if d isa LinearDrive
+            @assert 1 <= d.index <= n_drives "LinearDrive at drives[$i] has index $(d.index) but control dimension is $n_drives"
+        end
+    end
+
+    # Validate NonlinearDrive Jacobians
+    for d in drives
+        if d isa NonlinearDrive
+            validate_drive_jacobian(d, n_drives)
+        end
+    end
+
+    # Build H(u,t) and G(u,t) from materialized matrices (for backward-compat closures)
+    H_drift_mat = sparse(ComplexF64.(_ensure_matrix(H_drift_op)))
+    G_drift = sparse(Isomorphisms.G(H_drift_mat))
+    H_drive_mats = [sparse(ComplexF64.(drive_matrix(d))) for d in drives]
+    G_drive_mats = [sparse(Isomorphisms.G(H_d)) for H_d in H_drive_mats]
+
+    if isempty(drives)
+        H_fn = (u, t) -> H_drift_mat
+        G_fn = (u, t) -> G_drift
+    else
+        H_fn = (u, t) -> H_drift_mat + sum(drive_coeff(d, u) * H_d for (d, H_d) in zip(drives, H_drive_mats))
+        G_fn =
+            (u, t) ->
+                G_drift +
+                sum(drive_coeff(d, u) * G_d for (d, G_d) in zip(drives, G_drive_mats))
+    end
+
+    return QuantumSystem(
+        H_fn,
+        G_fn,
+        H_drift_op,    # store the structured operator, not the sparse matrix
         collect(AbstractDrive, drives),
         drive_bounds,
         n_drives,

--- a/src/quantum/trajectories/density_trajectory.jl
+++ b/src/quantum/trajectories/density_trajectory.jl
@@ -88,7 +88,7 @@ function DensityTrajectory(
 end
 
 # Callable: sample solution at any time
-(traj::DensityTrajectory)(t::Real) = traj.solution(t)
+(qtraj::DensityTrajectory)(t::Real) = qtraj.solution(t)
 
 # ============================================================================ #
 # Tests

--- a/src/quantum/trajectories/ensemble_trajectory.jl
+++ b/src/quantum/trajectories/ensemble_trajectory.jl
@@ -131,11 +131,11 @@ function MultiKetTrajectory(
 end
 
 # Callable: sample all solutions at time t
-(traj::MultiKetTrajectory)(t::Real) = [sol(t) for sol in traj.solution]
+(qtraj::MultiKetTrajectory)(t::Real) = [sol(t) for sol in qtraj.solution]
 
 # Indexing: get individual trajectory solution
-Base.getindex(traj::MultiKetTrajectory, i::Int) = traj.solution[i]
-Base.length(traj::MultiKetTrajectory) = length(traj.initials)
+Base.getindex(qtraj::MultiKetTrajectory, i::Int) = qtraj.solution[i]
+Base.length(qtraj::MultiKetTrajectory) = length(qtraj.initials)
 
 # ============================================================================ #
 # Tests

--- a/src/quantum/trajectories/interface.jl
+++ b/src/quantum/trajectories/interface.jl
@@ -3,45 +3,45 @@
 # ============================================================================ #
 
 """
-    get_system(traj)
+    get_system(qtraj)
 
 Get the quantum system from a trajectory.
 """
-get_system(traj::AbstractQuantumTrajectory) = traj.system
+get_system(qtraj::AbstractQuantumTrajectory) = qtraj.system
 
 """
-    get_pulse(traj)
+    get_pulse(qtraj)
 
 Get the control pulse from a trajectory.
 """
-get_pulse(traj::AbstractQuantumTrajectory) = traj.pulse
+get_pulse(qtraj::AbstractQuantumTrajectory) = qtraj.pulse
 
 """
-    get_initial(traj)
+    get_initial(qtraj)
 
 Get the initial state/operator from a trajectory.
 """
-get_initial(traj::UnitaryTrajectory) = traj.initial
-get_initial(traj::KetTrajectory) = traj.initial
-get_initial(traj::MultiKetTrajectory) = traj.initials
-get_initial(traj::DensityTrajectory) = traj.initial
+get_initial(qtraj::UnitaryTrajectory) = qtraj.initial
+get_initial(qtraj::KetTrajectory) = qtraj.initial
+get_initial(qtraj::MultiKetTrajectory) = qtraj.initials
+get_initial(qtraj::DensityTrajectory) = qtraj.initial
 
 """
-    get_goal(traj)
+    get_goal(qtraj)
 
 Get the goal state/operator from a trajectory.
 """
-get_goal(traj::UnitaryTrajectory) = traj.goal
-get_goal(traj::KetTrajectory) = traj.goal
-get_goal(traj::MultiKetTrajectory) = traj.goals
-get_goal(traj::DensityTrajectory) = traj.goal
+get_goal(qtraj::UnitaryTrajectory) = qtraj.goal
+get_goal(qtraj::KetTrajectory) = qtraj.goal
+get_goal(qtraj::MultiKetTrajectory) = qtraj.goals
+get_goal(qtraj::DensityTrajectory) = qtraj.goal
 
 """
-    get_solution(traj)
+    get_solution(qtraj)
 
 Get the ODE solution from a trajectory.
 """
-get_solution(traj::AbstractQuantumTrajectory) = traj.solution
+get_solution(qtraj::AbstractQuantumTrajectory) = qtraj.solution
 
 # ============================================================================ #
 # Fixed Name Accessors (for NamedTrajectory conversion)
@@ -62,21 +62,21 @@ state_name(::MultiKetTrajectory) = :ψ̃  # prefix for :ψ̃1, :ψ̃2, etc.
 state_name(::DensityTrajectory) = :ρ⃗̃
 
 """
-    state_names(traj::MultiKetTrajectory)
+    state_names(qtraj::MultiKetTrajectory)
 
 Get all state names for an ensemble trajectory (`:ψ̃1`, `:ψ̃2`, etc.)
 """
-function state_names(traj::MultiKetTrajectory)
-    prefix = state_name(traj)
-    return [Symbol(prefix, i) for i = 1:length(traj.initials)]
+function state_names(qtraj::MultiKetTrajectory)
+    prefix = state_name(qtraj)
+    return [Symbol(prefix, i) for i = 1:length(qtraj.initials)]
 end
 
 """
-    drive_name(traj::AbstractQuantumTrajectory)
+    drive_name(qtraj::AbstractQuantumTrajectory)
 
 Get the drive/control variable name from the trajectory's pulse.
 """
-drive_name(traj::AbstractQuantumTrajectory) = drive_name(traj.pulse)
+drive_name(qtraj::AbstractQuantumTrajectory) = drive_name(qtraj.pulse)
 
 """
     time_name(::AbstractQuantumTrajectory)
@@ -93,11 +93,11 @@ Get the timestep variable name (always `:Δt`).
 timestep_name(::AbstractQuantumTrajectory) = :Δt
 
 """
-    duration(traj)
+    duration(qtraj)
 
 Get the duration of a trajectory (from its pulse).
 """
-duration(traj::AbstractQuantumTrajectory) = duration(traj.pulse)
+duration(qtraj::AbstractQuantumTrajectory) = duration(qtraj.pulse)
 
 # ============================================================================ #
 # Rollout - Re-solve ODE with new pulse or different ODE parameters
@@ -727,7 +727,7 @@ end
 # ============================================================================ #
 
 """
-    fidelity(traj::UnitaryTrajectory; subspace=nothing, phases=nothing)
+    fidelity(qtraj::UnitaryTrajectory; subspace=nothing, phases=nothing)
 
 Compute the fidelity between the final unitary and the goal.
 
@@ -748,17 +748,17 @@ decomposition of the basis index). This matches the free-phase objective used
 during optimization.
 """
 function Rollouts.fidelity(
-    traj::UnitaryTrajectory;
+    qtraj::UnitaryTrajectory;
     subspace::Union{Nothing,AbstractVector{Int}} = nothing,
     phases::Union{Nothing,AbstractVector{<:Real}} = nothing,
 )
-    U_final = traj.solution.u[end]
-    if traj.goal isa EmbeddedOperator && isnothing(subspace)
+    U_final = qtraj.solution.u[end]
+    if qtraj.goal isa EmbeddedOperator && isnothing(subspace)
         U_goal_sub = if isnothing(phases)
-            unembed(traj.goal)
+            unembed(qtraj.goal)
         else
             # Apply free phases: same convention as _make_free_phase_goal
-            U_base = unembed(traj.goal)
+            U_base = unembed(qtraj.goal)
             n_sub = size(U_base, 1)
             n_qubits = length(phases)
             phase_diag = map(1:n_sub) do i
@@ -773,15 +773,15 @@ function Rollouts.fidelity(
             Diagonal(phase_diag) * U_base
         end
         # Use Pedersen formula, consistent with unitary_fidelity_loss(Ũ⃗, ::EmbeddedOperator)
-        U_sub = U_final[traj.goal.subspace, traj.goal.subspace]
-        n = length(traj.goal.subspace)
+        U_sub = U_final[qtraj.goal.subspace, qtraj.goal.subspace]
+        n = length(qtraj.goal.subspace)
         M = U_goal_sub' * U_sub
         return 1 / (n * (n + 1)) * (abs(tr(M' * M)) + abs2(tr(M)))
     else
         if !isnothing(phases)
             @warn "`phases` kwarg is ignored when goal is not an EmbeddedOperator or when `subspace` is provided"
         end
-        U_goal = traj.goal isa EmbeddedOperator ? traj.goal.operator : traj.goal
+        U_goal = qtraj.goal isa EmbeddedOperator ? qtraj.goal.operator : qtraj.goal
         if isnothing(subspace)
             return unitary_fidelity(U_final, U_goal)
         else
@@ -791,49 +791,55 @@ function Rollouts.fidelity(
 end
 
 """
-    fidelity(traj::KetTrajectory)
+    fidelity(qtraj::KetTrajectory)
 
 Compute the fidelity between the final state and the goal.
 """
-function Rollouts.fidelity(traj::KetTrajectory)
-    ψ_final = traj.solution.u[end]
-    return abs2(ψ_final' * traj.goal)
+function Rollouts.fidelity(qtraj::KetTrajectory)
+    ψ_final = qtraj.solution.u[end]
+    return abs2(ψ_final' * qtraj.goal)
 end
 
 """
-    fidelity(traj::MultiKetTrajectory)
+    fidelity(qtraj::MultiKetTrajectory)
 
-Compute the weighted average fidelity across all state transfers.
+Compute the coherent fidelity across all state transfers:
+
+    F = |1/n ∑ᵢ ⟨ψᵢ_goal|ψᵢ⟩|²
+
+This matches the `CoherentKetInfidelityObjective` used by the optimizer,
+requiring all state overlaps to have aligned phases (necessary for gates).
 """
-function Rollouts.fidelity(traj::MultiKetTrajectory)
-    fids = map(zip(traj.solution, traj.goals)) do (sol, goal)
-        abs2(sol.u[end]' * goal)
-    end
-    return sum(traj.weights .* fids)
+function Rollouts.fidelity(qtraj::MultiKetTrajectory)
+    n = length(qtraj.goals)
+    overlap_sum = sum(
+        qtraj.goals[i]' * qtraj.solution[i].u[end] for i in 1:n
+    )
+    return abs2(overlap_sum / n)
 end
 
 """
-    fidelity(traj::DensityTrajectory)
+    fidelity(qtraj::DensityTrajectory)
 
 Compute the fidelity between the final density matrix and the goal.
 Uses trace fidelity: F = tr(ρ_final * ρ_goal)
 """
-function Rollouts.fidelity(traj::DensityTrajectory)
-    ρ_final = traj.solution.u[end]
-    return real(tr(ρ_final * traj.goal))
+function Rollouts.fidelity(qtraj::DensityTrajectory)
+    ρ_final = qtraj.solution.u[end]
+    return real(tr(ρ_final * qtraj.goal))
 end
 
 """
-    fidelity(traj::SamplingTrajectory; kwargs...)
+    fidelity(qtraj::SamplingTrajectory; kwargs...)
 
 Compute the fidelity for each system in the sampling trajectory.
 
 Returns a vector of fidelities, one per system, by rolling out the current pulse
 with each system and computing the fidelity against the goal.
 """
-function Rollouts.fidelity(traj::SamplingTrajectory; kwargs...)
-    base = traj.base_trajectory
-    return [Rollouts.fidelity(_swap_system(base, sys); kwargs...) for sys in traj.systems]
+function Rollouts.fidelity(qtraj::SamplingTrajectory; kwargs...)
+    base = qtraj.base_trajectory
+    return [Rollouts.fidelity(_swap_system(base, sys); kwargs...) for sys in qtraj.systems]
 end
 
 # Helpers to create a trajectory with a different system (for per-system fidelity evaluation)

--- a/src/quantum/trajectories/ket_trajectory.jl
+++ b/src/quantum/trajectories/ket_trajectory.jl
@@ -100,7 +100,7 @@ function KetTrajectory(
 end
 
 # Callable: sample solution at any time
-(traj::KetTrajectory)(t::Real) = traj.solution(t)
+(qtraj::KetTrajectory)(t::Real) = qtraj.solution(t)
 
 # ============================================================================ #
 # Tests

--- a/src/quantum/trajectories/multi_density_trajectory.jl
+++ b/src/quantum/trajectories/multi_density_trajectory.jl
@@ -1,0 +1,250 @@
+# ============================================================================ #
+# MultiDensityTrajectory
+# ============================================================================ #
+
+"""
+    MultiDensityTrajectory{P<:AbstractPulse, S} <: AbstractQuantumTrajectory{P}
+
+Trajectory for multi-state open quantum system optimization with a shared pulse.
+Evolves multiple density matrices under the same Lindblad master equation.
+
+# Fields
+- `system::OpenQuantumSystem`: The open quantum system
+- `pulse::P`: The shared control pulse
+- `initials::Vector{Matrix{ComplexF64}}`: Initial density matrices
+- `goals::Vector{Matrix{ComplexF64}}`: Target density matrices
+- `weights::Vector{Float64}`: Weights for fidelity calculation
+- `solution::S`: Pre-computed ensemble solution
+
+# Callable
+`traj(t)` returns a vector of density matrices at time `t`.
+`traj[i]` returns the i-th trajectory's solution.
+"""
+mutable struct MultiDensityTrajectory{P<:AbstractPulse,S} <: AbstractQuantumTrajectory{P}
+    system::OpenQuantumSystem
+    pulse::P
+    initials::Vector{Matrix{ComplexF64}}
+    goals::Vector{Matrix{ComplexF64}}
+    weights::Vector{Float64}
+    solution::S
+end
+
+"""
+    MultiDensityTrajectory(system, pulse, initials, goals; weights=..., algorithm=Tsit5(), abstol=1e-8, reltol=1e-8, n_save=101)
+
+Create a multi-density trajectory by solving multiple Lindblad master equations.
+
+# Arguments
+- `system::OpenQuantumSystem`: The open quantum system
+- `pulse::AbstractPulse`: The shared control pulse
+- `initials::Vector{<:AbstractMatrix}`: Initial density matrices
+- `goals::Vector{<:AbstractMatrix}`: Target density matrices
+
+# Keyword Arguments
+- `weights`: Weights for fidelity (default: uniform)
+- `algorithm`: ODE solver algorithm (default: Tsit5())
+- `abstol`: Absolute tolerance for adaptive integration (default: 1e-8)
+- `reltol`: Relative tolerance for adaptive integration (default: 1e-8)
+- `n_save`: Number of output time points (default: 101)
+"""
+function MultiDensityTrajectory(
+    system::OpenQuantumSystem,
+    pulse::AbstractPulse,
+    initials::Vector{<:AbstractMatrix{<:Number}},
+    goals::Vector{<:AbstractMatrix{<:Number}};
+    weights::AbstractVector{<:Real} = fill(1.0 / length(initials), length(initials)),
+    algorithm = Tsit5(),
+    abstol::Real = 1e-8,
+    reltol::Real = 1e-8,
+    n_save::Int = 101,
+)
+    @assert n_drives(pulse) == system.n_drives "Pulse has $(n_drives(pulse)) drives, system has $(system.n_drives)"
+    @assert length(initials) == length(goals) == length(weights) "initials, goals, and weights must have same length"
+
+    ρ0s = [Matrix{ComplexF64}(ρ) for ρ in initials]
+    ρgs = [Matrix{ComplexF64}(ρ) for ρ in goals]
+    ws = Vector{Float64}(weights)
+
+    knot_times = get_knot_times(pulse)
+    save_times = collect(range(0.0, duration(pulse), length = n_save))
+    tstops = sort(unique(vcat(knot_times, save_times)))
+
+    # Build ensemble problem
+    dummy = zeros(ComplexF64, system.levels, system.levels)
+    base_prob = DensityODEProblem(system, pulse, dummy, tstops)
+    prob_func(prob, i, repeat) = remake(prob, u0 = ρ0s[i])
+    ensemble_prob = EnsembleProblem(base_prob; prob_func = prob_func)
+    sol = solve(
+        ensemble_prob,
+        algorithm;
+        trajectories = length(initials),
+        saveat = save_times,
+        abstol = abstol,
+        reltol = reltol,
+    )
+
+    return MultiDensityTrajectory{typeof(pulse),typeof(sol)}(system, pulse, ρ0s, ρgs, ws, sol)
+end
+
+"""
+    MultiDensityTrajectory(system, initials, goals, T::Real; weights=..., drive_name=:u, algorithm=Tsit5(), abstol=1e-8, reltol=1e-8)
+
+Convenience constructor that creates a zero pulse of duration T.
+
+# Arguments
+- `system::OpenQuantumSystem`: The open quantum system
+- `initials::Vector{<:AbstractMatrix}`: Initial density matrices
+- `goals::Vector{<:AbstractMatrix}`: Target density matrices
+- `T::Real`: Duration of the pulse
+
+# Keyword Arguments
+- `weights`: Weights for fidelity (default: uniform)
+- `drive_name::Symbol`: Name of the drive variable (default: `:u`)
+- `algorithm`: ODE solver algorithm (default: Tsit5())
+- `abstol`: Absolute tolerance (default: 1e-8)
+- `reltol`: Relative tolerance (default: 1e-8)
+"""
+function MultiDensityTrajectory(
+    system::OpenQuantumSystem,
+    initials::Vector{<:AbstractMatrix{<:Number}},
+    goals::Vector{<:AbstractMatrix{<:Number}},
+    T::Real;
+    weights::AbstractVector{<:Real} = fill(1.0 / length(initials), length(initials)),
+    drive_name::Symbol = :u,
+    algorithm = Tsit5(),
+    abstol::Real = 1e-8,
+    reltol::Real = 1e-8,
+)
+    times = [0.0, T]
+    controls = vcat([rand(Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
+    pulse = ZeroOrderPulse(controls, times; drive_name)
+    return MultiDensityTrajectory(
+        system,
+        pulse,
+        initials,
+        goals;
+        weights,
+        algorithm,
+        abstol,
+        reltol,
+    )
+end
+
+# Callable: sample all solutions at time t
+(qtraj::MultiDensityTrajectory)(t::Real) = [sol(t) for sol in qtraj.solution]
+
+# Indexing: get individual trajectory solution
+Base.getindex(qtraj::MultiDensityTrajectory, i::Int) = qtraj.solution[i]
+Base.length(qtraj::MultiDensityTrajectory) = length(qtraj.initials)
+
+# ============================================================================ #
+# Tests
+# ============================================================================ #
+
+@testitem "MultiDensityTrajectory construction" begin
+    using LinearAlgebra
+
+    # Simple 2-level open system
+    L = ComplexF64[0.1 0.0; 0.0 0.0]
+    system = OpenQuantumSystem(PAULIS.Z, [PAULIS.X], [1.0]; dissipation_operators = [L])
+
+    # Create with duration
+    T = 1.0
+    ρ0s = [ComplexF64[1.0 0.0; 0.0 0.0], ComplexF64[0.0 0.0; 0.0 1.0]]
+    ρgs = [ComplexF64[0.0 0.0; 0.0 1.0], ComplexF64[1.0 0.0; 0.0 0.0]]
+
+    qtraj = MultiDensityTrajectory(system, ρ0s, ρgs, T)
+
+    @test qtraj isa MultiDensityTrajectory
+    @test qtraj.system === system
+    @test length(qtraj.initials) == 2
+    @test length(qtraj.goals) == 2
+    @test length(qtraj.weights) == 2
+    @test sum(qtraj.weights) ≈ 1.0  # Default uniform weights
+
+    # Create with explicit pulse and weights
+    times = [0.0, 0.5, 1.0]
+    controls = 0.1 * randn(1, 3)
+    pulse = ZeroOrderPulse(controls, times)
+    weights = [0.7, 0.3]
+
+    qtraj2 = MultiDensityTrajectory(system, pulse, ρ0s, ρgs; weights = weights)
+
+    @test qtraj2 isa MultiDensityTrajectory
+    @test qtraj2.weights ≈ weights
+end
+
+@testitem "MultiDensityTrajectory callable and indexing" begin
+    using LinearAlgebra
+
+    L = ComplexF64[0.1 0.0; 0.0 0.0]
+    system = OpenQuantumSystem(PAULIS.Z, [PAULIS.X], [1.0]; dissipation_operators = [L])
+
+    T = 1.0
+    ρ0s = [ComplexF64[1.0 0.0; 0.0 0.0], ComplexF64[0.0 0.0; 0.0 1.0]]
+    ρgs = [ComplexF64[0.0 0.0; 0.0 1.0], ComplexF64[1.0 0.0; 0.0 0.0]]
+
+    qtraj = MultiDensityTrajectory(system, ρ0s, ρgs, T)
+
+    # Test length
+    @test length(qtraj) == 2
+
+    # Test callable - returns all states at time t
+    states_0 = qtraj(0.0)
+    @test length(states_0) == 2
+    @test states_0[1] ≈ ρ0s[1]
+    @test states_0[2] ≈ ρ0s[2]
+
+    # Test indexing - returns individual solution
+    sol1 = qtraj[1]
+    @test sol1 isa ODESolution
+    @test sol1(0.0) ≈ ρ0s[1]
+
+    sol2 = qtraj[2]
+    @test sol2(0.0) ≈ ρ0s[2]
+end
+
+@testitem "MultiDensityTrajectory fidelity" begin
+    using LinearAlgebra
+
+    # Open system without dissipation (to test fidelity calculation)
+    σx = ComplexF64[0 1; 1 0]
+    system = OpenQuantumSystem([σx], [1.0])
+
+    # Pulse to rotate |0⟩ → |1⟩
+    T = π / 2
+    times = [0.0, T]
+    controls = ones(1, 2)
+    pulse = ZeroOrderPulse(controls, times)
+
+    ρ0s = [ComplexF64[1.0 0.0; 0.0 0.0], ComplexF64[0.0 0.0; 0.0 1.0]]
+    ρgs = [ComplexF64[0.0 0.0; 0.0 1.0], ComplexF64[1.0 0.0; 0.0 0.0]]
+
+    qtraj = MultiDensityTrajectory(system, pulse, ρ0s, ρgs)
+
+    # Both transfers should have high fidelity
+    fid = fidelity(qtraj)
+    @test fid > 0.99
+end
+
+@testitem "MultiDensityTrajectory state_names" begin
+    using LinearAlgebra
+
+    system = OpenQuantumSystem([PAULIS.X], [1.0])
+
+    ρ0s = [
+        ComplexF64[1.0 0.0; 0.0 0.0],
+        ComplexF64[0.0 0.0; 0.0 1.0],
+        ComplexF64[0.5 0.5; 0.5 0.5],
+    ]
+    ρgs = [
+        ComplexF64[0.0 0.0; 0.0 1.0],
+        ComplexF64[1.0 0.0; 0.0 0.0],
+        ComplexF64[0.5 -0.5; -0.5 0.5],
+    ]
+
+    qtraj = MultiDensityTrajectory(system, ρ0s, ρgs, 1.0)
+
+    @test state_name(qtraj) == :ρ⃗̃
+    @test state_names(qtraj) == [:ρ⃗̃1, :ρ⃗̃2, :ρ⃗̃3]
+end

--- a/src/quantum/trajectories/sampling_trajectory.jl
+++ b/src/quantum/trajectories/sampling_trajectory.jl
@@ -65,48 +65,48 @@ function SamplingTrajectory(
 end
 
 # Interface implementations for SamplingTrajectory
-get_system(traj::SamplingTrajectory) = get_system(traj.base_trajectory)  # Nominal system
-get_pulse(traj::SamplingTrajectory) = get_pulse(traj.base_trajectory)
-get_initial(traj::SamplingTrajectory) = get_initial(traj.base_trajectory)
-get_goal(traj::SamplingTrajectory) = get_goal(traj.base_trajectory)
-get_solution(traj::SamplingTrajectory) = get_solution(traj.base_trajectory)
-duration(traj::SamplingTrajectory) = duration(traj.base_trajectory)
+get_system(qtraj::SamplingTrajectory) = get_system(qtraj.base_trajectory)  # Nominal system
+get_pulse(qtraj::SamplingTrajectory) = get_pulse(qtraj.base_trajectory)
+get_initial(qtraj::SamplingTrajectory) = get_initial(qtraj.base_trajectory)
+get_goal(qtraj::SamplingTrajectory) = get_goal(qtraj.base_trajectory)
+get_solution(qtraj::SamplingTrajectory) = get_solution(qtraj.base_trajectory)
+duration(qtraj::SamplingTrajectory) = duration(qtraj.base_trajectory)
 
 # Name accessors
-state_name(traj::SamplingTrajectory) = state_name(traj.base_trajectory)
-drive_name(traj::SamplingTrajectory) = drive_name(traj.base_trajectory)
-time_name(traj::SamplingTrajectory) = time_name(traj.base_trajectory)
-timestep_name(traj::SamplingTrajectory) = timestep_name(traj.base_trajectory)
+state_name(qtraj::SamplingTrajectory) = state_name(qtraj.base_trajectory)
+drive_name(qtraj::SamplingTrajectory) = drive_name(qtraj.base_trajectory)
+time_name(qtraj::SamplingTrajectory) = time_name(qtraj.base_trajectory)
+timestep_name(qtraj::SamplingTrajectory) = timestep_name(qtraj.base_trajectory)
 
 """
-    state_names(sampling::SamplingTrajectory)
+    state_names(qtraj::SamplingTrajectory)
 
 Get the state variable names for all systems (e.g., [:Ũ⃗1, :Ũ⃗2, :Ũ⃗3]).
 """
-function state_names(traj::SamplingTrajectory)
-    base = state_name(traj)
-    return [Symbol(base, i) for i = 1:length(traj.systems)]
+function state_names(qtraj::SamplingTrajectory)
+    base = state_name(qtraj)
+    return [Symbol(base, i) for i = 1:length(qtraj.systems)]
 end
 
 """
-    get_systems(sampling::SamplingTrajectory)
+    get_systems(qtraj::SamplingTrajectory)
 
 Get all systems in the sampling trajectory.
 """
-get_systems(traj::SamplingTrajectory) = traj.systems
+get_systems(qtraj::SamplingTrajectory) = qtraj.systems
 
 """
-    get_weights(sampling::SamplingTrajectory)
+    get_weights(qtraj::SamplingTrajectory)
 
 Get the weights for each system.
 """
-get_weights(traj::SamplingTrajectory) = traj.weights
+get_weights(qtraj::SamplingTrajectory) = qtraj.weights
 
 # Length for iteration
-Base.length(traj::SamplingTrajectory) = length(traj.systems)
+Base.length(qtraj::SamplingTrajectory) = length(qtraj.systems)
 
 # Callable - sample base trajectory at time t
-(traj::SamplingTrajectory)(t::Real) = traj.base_trajectory(t)
+(qtraj::SamplingTrajectory)(t::Real) = qtraj.base_trajectory(t)
 
 # ============================================================================ #
 # SamplingTrajectory NamedTrajectory Conversion

--- a/src/quantum/trajectories/unitary_trajectory.jl
+++ b/src/quantum/trajectories/unitary_trajectory.jl
@@ -100,7 +100,7 @@ function UnitaryTrajectory(
 end
 
 # Callable: sample solution at any time
-(traj::UnitaryTrajectory)(t::Real) = traj.solution(t)
+(qtraj::UnitaryTrajectory)(t::Real) = qtraj.solution(t)
 
 # ============================================================================ #
 # Tests

--- a/src/visualizations/quantum_objects/_quantum_object_plots.jl
+++ b/src/visualizations/quantum_objects/_quantum_object_plots.jl
@@ -4,6 +4,7 @@ export plot_unitary_populations
 export plot_state_populations
 export plot_weyl_trajectory
 export plot_name!
+export plot_pulse, plot_pulse!, plot_pulse_IQ, plot_pulse_phases
 
 using LaTeXStrings
 using Makie
@@ -32,5 +33,6 @@ end
 include("unitary_populations.jl")
 include("state_populations.jl")
 include("weyl_trajectory.jl")
+include("pulse_plots.jl")
 
 end

--- a/src/visualizations/quantum_objects/pulse_plots.jl
+++ b/src/visualizations/quantum_objects/pulse_plots.jl
@@ -1,0 +1,182 @@
+export plot_pulse, plot_pulse!
+
+using Makie
+using Piccolo: AbstractPulse, AbstractSplinePulse, CubicSplinePulse,
+    duration, n_drives, sample, get_knot_times, get_knot_values, drive_name
+
+"""
+    plot_pulse(pulse::AbstractPulse; n_samples=500, labels=nothing, title=nothing, kwargs...)
+
+Plot a pulse's control channels over time.
+
+Returns a Makie `Figure` with one axis showing all drive channels as lines.
+For spline pulses, knot points are overlaid as scatter markers.
+
+# Arguments
+- `pulse::AbstractPulse`: The pulse to plot
+
+# Keyword Arguments
+- `n_samples::Int=500`: Number of time samples for smooth curves
+- `labels::Union{Nothing, Vector{String}}=nothing`: Labels for each drive channel
+- `title::Union{Nothing, String}=nothing`: Plot title
+- `figsize::Tuple=(800, 400)`: Figure size
+- `show_knots::Bool=true`: Show knot points for spline pulses
+- `kwargs...`: Additional keyword arguments passed to `lines!`
+"""
+function plot_pulse(
+    pulse::AbstractPulse;
+    n_samples::Int = 500,
+    labels::Union{Nothing, Vector{String}} = nothing,
+    title::Union{Nothing, String} = nothing,
+    figsize::Tuple = (800, 400),
+    show_knots::Bool = true,
+    kwargs...,
+)
+    fig = Figure(size = figsize)
+    ax = Axis(fig[1, 1];
+        xlabel = "Time (ns)",
+        ylabel = "Amplitude",
+        title = isnothing(title) ? "Pulse Controls" : title,
+    )
+    plot_pulse!(ax, pulse; n_samples, labels, show_knots, kwargs...)
+    if !isnothing(labels)
+        axislegend(ax; position = :rt)
+    end
+    return fig
+end
+
+"""
+    plot_pulse!(ax, pulse::AbstractPulse; n_samples=500, labels=nothing, show_knots=true, kwargs...)
+
+Plot a pulse's control channels onto an existing Makie axis.
+"""
+function plot_pulse!(
+    ax,
+    pulse::AbstractPulse;
+    n_samples::Int = 500,
+    labels::Union{Nothing, Vector{String}} = nothing,
+    show_knots::Bool = true,
+    kwargs...,
+)
+    controls, times = sample(pulse; n_samples)
+    nd = n_drives(pulse)
+
+    for i in 1:nd
+        label = isnothing(labels) ? nothing : labels[i]
+        lines!(ax, times, controls[i, :]; label, kwargs...)
+    end
+
+    # Overlay knot points for spline pulses
+    if show_knots && pulse isa AbstractSplinePulse
+        knot_times = get_knot_times(pulse)
+        knot_controls = sample(pulse, knot_times)
+        for i in 1:nd
+            scatter!(ax, knot_times, knot_controls[i, :];
+                markersize = 6, color = :black)
+        end
+    end
+end
+
+"""
+    plot_pulse_IQ(pulse::AbstractPulse; n_samples=500, drive_labels=nothing, title=nothing, kwargs...)
+
+Plot a 4-drive pulse as two IQ pairs: drives (Ω_I, Ω_Q) and displacement (α_I, α_Q),
+with magnitude envelopes.
+
+Returns a Makie `Figure` with 2 rows: drive IQ and displacement IQ.
+"""
+function plot_pulse_IQ(
+    pulse::AbstractPulse;
+    n_samples::Int = 500,
+    title::Union{Nothing, String} = nothing,
+    figsize::Tuple = (900, 600),
+    show_knots::Bool = true,
+)
+    @assert n_drives(pulse) == 4 "plot_pulse_IQ requires exactly 4 drives (Ω_I, Ω_Q, α_I, α_Q)"
+
+    controls, times = sample(pulse; n_samples)
+
+    Ω_I, Ω_Q = controls[1, :], controls[2, :]
+    α_I, α_Q = controls[3, :], controls[4, :]
+    Ω_mag = sqrt.(Ω_I.^2 .+ Ω_Q.^2)
+    α_mag = sqrt.(α_I.^2 .+ α_Q.^2)
+
+    fig = Figure(size = figsize)
+    if !isnothing(title)
+        Label(fig[0, 1:2], title; fontsize = 16, tellwidth = false)
+    end
+
+    # Drive IQ
+    ax1 = Axis(fig[1, 1]; xlabel = "Time (ns)", ylabel = "Amplitude (rad⋅GHz)",
+        title = "Drive (Ω)")
+    lines!(ax1, times, Ω_I; label = "Ω_I", color = :blue)
+    lines!(ax1, times, Ω_Q; label = "Ω_Q", color = :red)
+    lines!(ax1, times, Ω_mag; label = "|Ω|", color = :black, linestyle = :dash)
+    axislegend(ax1; position = :rt)
+
+    # Displacement IQ
+    ax2 = Axis(fig[2, 1]; xlabel = "Time (ns)", ylabel = "Amplitude",
+        title = "Displacement (α)")
+    lines!(ax2, times, α_I; label = "α_I", color = :blue)
+    lines!(ax2, times, α_Q; label = "α_Q", color = :red)
+    lines!(ax2, times, α_mag; label = "|α|", color = :black, linestyle = :dash)
+    axislegend(ax2; position = :rt)
+
+    # Overlay knot points
+    if show_knots && pulse isa AbstractSplinePulse
+        knot_times = get_knot_times(pulse)
+        knot_controls = sample(pulse, knot_times)
+        for (ax_row, idxs) in [(ax1, 1:2), (ax2, 3:4)]
+            for i in idxs
+                scatter!(ax_row, knot_times, knot_controls[i, :];
+                    markersize = 5, color = :black)
+            end
+        end
+    end
+
+    return fig
+end
+
+"""
+    plot_pulse_phases(pulse::AbstractPulse; n_samples=500, title=nothing, kwargs...)
+
+Plot a 4-drive pulse in polar form: magnitude and phase for drive and displacement.
+
+Returns a Makie `Figure` with 4 subplots: |Ω|, φ_Ω, |α|, φ_α.
+"""
+function plot_pulse_phases(
+    pulse::AbstractPulse;
+    n_samples::Int = 500,
+    title::Union{Nothing, String} = nothing,
+    figsize::Tuple = (900, 600),
+)
+    @assert n_drives(pulse) == 4 "plot_pulse_phases requires exactly 4 drives"
+
+    controls, times = sample(pulse; n_samples)
+
+    Ω_I, Ω_Q = controls[1, :], controls[2, :]
+    α_I, α_Q = controls[3, :], controls[4, :]
+    Ω_mag = sqrt.(Ω_I.^2 .+ Ω_Q.^2)
+    α_mag = sqrt.(α_I.^2 .+ α_Q.^2)
+    Ω_phase = atan.(Ω_Q, Ω_I) ./ π
+    α_phase = atan.(α_Q, α_I) ./ π
+
+    fig = Figure(size = figsize)
+    if !isnothing(title)
+        Label(fig[0, 1:2], title; fontsize = 16, tellwidth = false)
+    end
+
+    ax1 = Axis(fig[1, 1]; ylabel = "|Ω| (rad⋅GHz)", title = "Drive magnitude")
+    lines!(ax1, times, Ω_mag; color = :blue)
+
+    ax2 = Axis(fig[1, 2]; ylabel = "φ_Ω / π", title = "Drive phase")
+    lines!(ax2, times, Ω_phase; color = :blue)
+
+    ax3 = Axis(fig[2, 1]; xlabel = "Time (ns)", ylabel = "|α|", title = "Displacement magnitude")
+    lines!(ax3, times, α_mag; color = :red)
+
+    ax4 = Axis(fig[2, 2]; xlabel = "Time (ns)", ylabel = "φ_α / π", title = "Displacement phase")
+    lines!(ax4, times, α_phase; color = :red)
+
+    return fig
+end


### PR DESCRIPTION
## Summary
- Add `drive_coeff_hess` for second-order sensitivity equations (exact Hessian in SplineIntegrator)
- Parametrize `LinearDrive`/`NonlinearDrive` on `H` type to support structured operators (e.g. `AbstractDynamicsOperator`)
- Add `drive_matrix`/`drive_dim` accessors and `_ensure_matrix` conversion layer
- Add per-drive `du_bounds` vector in `SplinePulseProblem` (takes precedence over scalar `du_bound`)
- Generalize free-phase rotation from qubit-only `Z` to number-operator `e^{iθn̂}` (supports multi-level subsystems like transmon⊗cavity)
- Add `initial_phases` kwarg to `SmoothPulseProblem` and `SplinePulseProblem`
- Add `FunctionPulse` for analytic pulse rollouts without discretization
- Add free-phase `FinalCoherentKetFidelityConstraint` for `MinimumTimeProblem` with `MultiKetTrajectory`
- Add `Δt_bounds` and `subsystem_levels` kwargs to `MinimumTimeProblem`
- Rename `traj` → `qtraj` in trajectory callable methods for consistency
- Add `pulse_plots.jl` visualization module (`plot_pulse`, `plot_pulse_IQ`, `plot_pulse_phases`)

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)