### PR TITLE
Feat/pulse construct and print

### DIFF
--- a/src/quantum/primitives/pulses.jl
+++ b/src/quantum/primitives/pulses.jl
@@ -25,10 +25,13 @@ export ZeroOrderPulse,
     FunctionPulse
 export duration, n_drives, sample, drive_name
 
+using DataInterpolations
 using DataInterpolations: ConstantInterpolation, LinearInterpolation, CubicHermiteSpline
 using ForwardDiff
 using SpecialFunctions: erf
 using TestItems
+
+const DEFAULT_SAMPLES::Int = 100
 
 # ============================================================================ #
 # Abstract type
@@ -84,13 +87,48 @@ function sample(pulse::AbstractPulse, times::AbstractVector)
 end
 
 """
-    sample(pulse::AbstractPulse; n_samples::Int=100)
+    sample(pulse::AbstractPulse, n_samples::Int)
 
 Sample the pulse uniformly with `n_samples` points. Returns `(controls, times)`.
 """
-function sample(pulse::AbstractPulse; n_samples::Int = 100)
+function sample(pulse::AbstractPulse, n_samples::Int)
     times = collect(range(0.0, duration(pulse), length = n_samples))
     return sample(pulse, times), times
+end
+
+"""
+    sample(bounds::AbstractVector{Tuple}, n_samples::Int)
+
+Sample the bounds uniformly with `n_samples` points.
+"""
+function sample(bounds::AbstractVector{Tuple{Float64,Float64}}, n_samples::Int)
+    return [(high - low) * rand() + low for (low, high) in bounds, _ in 1:n_samples]
+end
+
+"""
+    derivative(pulse::AbstractPulse, time::Real)
+
+Return the time derivative of the pulse at `time`.
+
+Falls back to ForwardDiff for generic pulses. Specialized pulse types may benefit from custom derivative methods (e.g., DataInterpolations.derivative) for better handling of knot points and boundaries.
+"""
+function derivative(pulse::AbstractPulse, time::Real)
+    return ForwardDiff.derivative(pulse, time)
+end
+
+Base.summary(io::IO, p::AbstractPulse) = print(
+    io,
+    "$(nameof(typeof(p)))(Number of drives = ",
+    n_drives(p), ", ",
+    "T = ", duration(p), ")"
+)
+
+Base.show(io::IO, p::AbstractPulse) = summary(io, p)
+
+function Base.show(io::IO, ::MIME"text/plain", p::AbstractPulse)
+    println(io, nameof(typeof(p)))
+    println(io, "  drives: ", n_drives(p))
+    print(io, "  duration: ", duration(p))
 end
 
 # ============================================================================ #
@@ -156,6 +194,8 @@ function ZeroOrderPulse(
     )
 end
 
+derivative(p::ZeroOrderPulse, t::Real) = DataInterpolations.derivative(p.controls, t)
+
 evaluate(p::ZeroOrderPulse, t) = p.controls(t)
 
 # ============================================================================ #
@@ -219,6 +259,8 @@ function LinearSplinePulse(
         final_val,
     )
 end
+
+derivative(p::LinearSplinePulse, t::Real) = DataInterpolations.derivative(p.controls, t)
 
 evaluate(p::LinearSplinePulse, t) = p.controls(t)
 
@@ -319,6 +361,9 @@ function CubicSplinePulse(
         final_value,
     )
 end
+
+# TODO: Unimplemented by DataInterpolations
+# derivative(p::CubicSplinePulse, t::Real) = DataInterpolations.derivative(p.controls, t)
 
 evaluate(p::CubicSplinePulse, t) = p.controls(t)
 
@@ -467,9 +512,7 @@ function CubicSplinePulse(
     final_value::Union{Nothing,Vector{<:Real}} = nothing,
 )
     controls = sample(pulse, times)
-
-    # Compute derivatives using ForwardDiff
-    derivatives = hcat([ForwardDiff.derivative(pulse, t) for t in times]...)
+    derivatives = stack(map(t ->derivative(pulse, t), times))
 
     init_val = isnothing(initial_value) ? pulse(times[1]) : initial_value
     final_val = isnothing(final_value) ? pulse(times[end]) : final_value
@@ -939,7 +982,8 @@ end
     @test pulse(1.0) ≈ [0.0, 0.0]
 
     # Test sampling
-    sampled, ts = sample(pulse; n_samples = 5)
+    n_samples = 5
+    sampled, ts = sample(pulse, n_samples)
     @test size(sampled) == (2, 5)
     @test length(ts) == 5
 
@@ -967,7 +1011,8 @@ end
     @test pulse(1.0) ≈ [0.0, 0.0]
 
     # Test sampling
-    sampled, ts = sample(pulse; n_samples = 5)
+    n_samples = 5
+    sampled, ts = sample(pulse, n_samples)
     @test size(sampled) == (2, 5)
 
     # Test custom drive_name
@@ -1005,6 +1050,41 @@ end
     # Test zero-derivative constructor
     pulse_zero_deriv = CubicSplinePulse(controls, times)
     @test pulse_zero_deriv(0.5) ≈ [1.0, -1.0]
+end
+
+@testitem "DataInterpolations derivative at boundaries" begin
+    using .Pulses: derivative, sample
+
+    n_samples = 100
+    bounds = [(-1e-3, 1e-3), (-1e3, 1e3)]
+    inits = sample(bounds, n_samples)
+    times = LinRange(0, 10.0, n_samples)
+
+    for P in [ZeroOrderPulse, LinearSplinePulse]
+
+        pulse = P(inits, times)
+
+        # The pulse itself should sample cleanly on the closed interval.
+        vals = sample(pulse, times)
+        @test size(vals) == (n_drives(pulse), length(times))
+
+        # The pulse-level derivative API should also work on the closed interval,
+        # including both boundaries.
+        derivs = [derivative(pulse, t) for t in times]
+        @test length(derivs) == length(times)
+        @test all(d -> length(d) == n_drives(pulse), derivs)
+
+        # Explicitly check the endpoints, since these are where ForwardDiff on the
+        # raw interpolation used to fail due to extrapolation.
+        @test derivative(pulse, first(times)) isa AbstractVector
+        @test derivative(pulse, last(times)) isa AbstractVector
+        @test length(derivative(pulse, first(times))) == n_drives(pulse)
+        @test length(derivative(pulse, last(times))) == n_drives(pulse)
+    end
+
+    # CubicHermiteSpline known failure mode
+    pulse = CubicSplinePulse(inits, times)
+    @test_broken derivative(pulse, last(times)) isa AbstractVector
 end
 
 @testitem "GaussianPulse" begin

--- a/src/quantum/primitives/pulses.jl
+++ b/src/quantum/primitives/pulses.jl
@@ -102,7 +102,7 @@ end
 Sample the bounds uniformly with `n_samples` points.
 """
 function sample(bounds::AbstractVector{Tuple{Float64,Float64}}, n_samples::Int)
-    return [(high - low) * rand() + low for (low, high) in bounds, _ in 1:n_samples]
+    return [(high - low) * rand() + low for (low, high) in bounds, _ = 1:n_samples]
 end
 
 """
@@ -119,8 +119,11 @@ end
 Base.summary(io::IO, p::AbstractPulse) = print(
     io,
     "$(nameof(typeof(p)))(Number of drives = ",
-    n_drives(p), ", ",
-    "T = ", duration(p), ")"
+    n_drives(p),
+    ", ",
+    "T = ",
+    duration(p),
+    ")",
 )
 
 Base.show(io::IO, p::AbstractPulse) = summary(io, p)
@@ -512,7 +515,7 @@ function CubicSplinePulse(
     final_value::Union{Nothing,Vector{<:Real}} = nothing,
 )
     controls = sample(pulse, times)
-    derivatives = stack(map(t ->derivative(pulse, t), times))
+    derivatives = stack(map(t -> derivative(pulse, t), times))
 
     init_val = isnothing(initial_value) ? pulse(times[1]) : initial_value
     final_val = isnothing(final_value) ? pulse(times[end]) : final_value

--- a/src/quantum/systems/_quantum_systems.jl
+++ b/src/quantum/systems/_quantum_systems.jl
@@ -156,11 +156,11 @@ end
 
 function build_pulse(
     ::Type{P},
-    sys::AbstractQuantumSystem, 
-    T::Real; 
+    sys::AbstractQuantumSystem,
+    T::Real;
     n_samples::Int = Pulses.DEFAULT_SAMPLES,
-    kwargs...
-) where P <: AbstractPulse
+    kwargs...,
+) where {P<:AbstractPulse}
     controls = Pulses.sample(sys.drive_bounds, n_samples)
     times = LinRange(0, T, n_samples)
     return P(controls, times; kwargs...)
@@ -170,27 +170,27 @@ function Pulses.ZeroOrderPulse(
     sys::AbstractQuantumSystem,
     T::Real;
     n_samples::Int = Pulses.DEFAULT_SAMPLES,
-    kwargs...
+    kwargs...,
 )
-    return build_pulse(ZeroOrderPulse, sys, T; n_samples=n_samples, kwargs...)
+    return build_pulse(ZeroOrderPulse, sys, T; n_samples = n_samples, kwargs...)
 end
 
 function Pulses.LinearSplinePulse(
     sys::AbstractQuantumSystem,
     T::Real;
     n_samples::Int = Pulses.DEFAULT_SAMPLES,
-    kwargs...
+    kwargs...,
 )
-    return build_pulse(LinearSplinePulse, sys, T; n_samples=n_samples, kwargs...)
+    return build_pulse(LinearSplinePulse, sys, T; n_samples = n_samples, kwargs...)
 end
 
 function Pulses.CubicSplinePulse(
     sys::AbstractQuantumSystem,
     T::Real;
     n_samples::Int = Pulses.DEFAULT_SAMPLES,
-    kwargs...
+    kwargs...,
 )
-    return build_pulse(CubicSplinePulse, sys, T; n_samples=n_samples, kwargs...)
+    return build_pulse(CubicSplinePulse, sys, T; n_samples = n_samples, kwargs...)
 end
 
 # ----------------------------------------------------------------------------- #

--- a/src/quantum/systems/_quantum_systems.jl
+++ b/src/quantum/systems/_quantum_systems.jl
@@ -22,6 +22,7 @@ export get_c_ops
 export compact_lindbladian_generators
 
 using ..Isomorphisms
+using ..Pulses
 using ..QuantumObjectUtils
 using ..LiftedOperators
 
@@ -147,6 +148,49 @@ end
 
 function Base.show(io::IO, sys::AbstractQuantumSystem)
     print(io, "$(nameof(typeof(sys))): levels = $(sys.levels), n_drives = $(sys.n_drives)")
+end
+
+# ----------------------------------------------------------------------------- #
+# Build Pulses from Systems
+# ----------------------------------------------------------------------------- #
+
+function build_pulse(
+    ::Type{P},
+    sys::AbstractQuantumSystem, 
+    T::Real; 
+    n_samples::Int = Pulses.DEFAULT_SAMPLES,
+    kwargs...
+) where P <: AbstractPulse
+    controls = Pulses.sample(sys.drive_bounds, n_samples)
+    times = LinRange(0, T, n_samples)
+    return P(controls, times; kwargs...)
+end
+
+function Pulses.ZeroOrderPulse(
+    sys::AbstractQuantumSystem,
+    T::Real;
+    n_samples::Int = Pulses.DEFAULT_SAMPLES,
+    kwargs...
+)
+    return build_pulse(ZeroOrderPulse, sys, T; n_samples=n_samples, kwargs...)
+end
+
+function Pulses.LinearSplinePulse(
+    sys::AbstractQuantumSystem,
+    T::Real;
+    n_samples::Int = Pulses.DEFAULT_SAMPLES,
+    kwargs...
+)
+    return build_pulse(LinearSplinePulse, sys, T; n_samples=n_samples, kwargs...)
+end
+
+function Pulses.CubicSplinePulse(
+    sys::AbstractQuantumSystem,
+    T::Real;
+    n_samples::Int = Pulses.DEFAULT_SAMPLES,
+    kwargs...
+)
+    return build_pulse(CubicSplinePulse, sys, T; n_samples=n_samples, kwargs...)
 end
 
 # ----------------------------------------------------------------------------- #


### PR DESCRIPTION
* Adds default print statements for pulses.

* Creates new system-level constructors, e.g.,
  ```Julia
  function Piccolo.ZeroOrderPulse(
      sys::AbstractQuantumSystem,
      T::Real;
      n_samples::Int = Piccolo.Pulses.DEFAULT_SAMPLES,
      kwargs...
  )
      ...
  end
  ```
  but this must infer bounds from the system. Pulse is denote as a primitive type, while system is higher level. Still, we can put this in the systems class, similar to how rollouts are defined over quantum trajectories.

* Fixes some issues with pulse derivatives at boundaries. Cross-reference with #113