### PR TITLE
Feat/snap to knots

### DIFF
--- a/src/control/templates/smooth_pulse_problem.jl
+++ b/src/control/templates/smooth_pulse_problem.jl
@@ -135,7 +135,9 @@ function SmoothPulseProblem(
     free_phase::Bool = false,
     initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     state_leakage_indices::Union{
-        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+        Nothing,
+        AbstractVector{Int},
+        AbstractVector{<:AbstractVector{Int}},
     } = nothing,
 )
     if piccolo_options.verbose
@@ -249,7 +251,11 @@ function SmoothPulseProblem(
 
     # Add optional Piccolo constraints and objectives
     J += _apply_piccolo_options(
-        qtraj, piccolo_options, constraints, traj_smooth, state_sym;
+        qtraj,
+        piccolo_options,
+        constraints,
+        traj_smooth,
+        state_sym;
         state_leakage_indices = state_leakage_indices,
     )
 
@@ -357,7 +363,9 @@ function SmoothPulseProblem(
     initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     coherent::Bool = true,
     state_leakage_indices::Union{
-        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+        Nothing,
+        AbstractVector{Int},
+        AbstractVector{<:AbstractVector{Int}},
     } = nothing,
 )
     if piccolo_options.verbose
@@ -436,7 +444,11 @@ function SmoothPulseProblem(
 
     # Apply piccolo options for each state
     J += _apply_piccolo_options(
-        qtraj, piccolo_options, constraints, traj_smooth, snames;
+        qtraj,
+        piccolo_options,
+        constraints,
+        traj_smooth,
+        snames;
         state_leakage_indices = state_leakage_indices,
     )
 
@@ -636,7 +648,9 @@ function _apply_piccolo_options(
     traj::NamedTrajectory,
     snames::Vector{Symbol};
     state_leakage_indices::Union{
-        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+        Nothing,
+        AbstractVector{Int},
+        AbstractVector{<:AbstractVector{Int}},
     } = nothing,
 )
     # Resolve leakage indices: user override > auto-derived from goals.
@@ -644,7 +658,7 @@ function _apply_piccolo_options(
     # one per state.
     leakage_indices = if state_leakage_indices !== nothing
         state_leakage_indices isa AbstractVector{Int} ?
-            fill(state_leakage_indices, length(snames)) : state_leakage_indices
+        fill(state_leakage_indices, length(snames)) : state_leakage_indices
     elseif piccolo_options.leakage_constraint
         # Auto-derived: computational subspace = union of nonzero goal indices,
         # leakage = everything else (in isomorphic representation)

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -97,7 +97,9 @@ function SplinePulseProblem(
     subsystem_levels::Union{Nothing,Vector{Int}} = nothing,
     initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     state_leakage_indices::Union{
-        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+        Nothing,
+        AbstractVector{Int},
+        AbstractVector{<:AbstractVector{Int}},
     } = nothing,
 )
     sys = get_system(qtraj)
@@ -236,7 +238,11 @@ function SplinePulseProblem(
 
     # Apply piccolo options
     J += _apply_piccolo_options(
-        qtraj, piccolo_options, constraints, traj, state_sym;
+        qtraj,
+        piccolo_options,
+        constraints,
+        traj,
+        state_sym;
         state_leakage_indices = state_leakage_indices,
     )
 
@@ -318,7 +324,9 @@ function SplinePulseProblem(
     initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     coherent::Bool = true,
     state_leakage_indices::Union{
-        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+        Nothing,
+        AbstractVector{Int},
+        AbstractVector{<:AbstractVector{Int}},
     } = nothing,
 )
     sys = get_system(qtraj)
@@ -453,7 +461,11 @@ function SplinePulseProblem(
 
     # Apply piccolo options for each state
     J += _apply_piccolo_options(
-        qtraj, piccolo_options, constraints, traj, snames;
+        qtraj,
+        piccolo_options,
+        constraints,
+        traj,
+        snames;
         state_leakage_indices = state_leakage_indices,
     )
 
@@ -727,8 +739,10 @@ end
     # must still error per the existing contract — there is no goal-derived
     # leakage geometry for a single ket.
     @test_throws ArgumentError SplinePulseProblem(
-        qtraj, N;
-        Q = 100.0, R = 1e-2,
+        qtraj,
+        N;
+        Q = 100.0,
+        R = 1e-2,
         piccolo_options = PiccoloOptions(
             leakage_constraint = true,
             leakage_constraint_value = 1e-3,
@@ -740,8 +754,10 @@ end
     # is appended to the problem's constraints.
     # iso_ket = [Re(ψ); Im(ψ)] in length-6, so |2⟩ leakage = indices [3, 6].
     qcp = SplinePulseProblem(
-        qtraj, N;
-        Q = 100.0, R = 1e-2,
+        qtraj,
+        N;
+        Q = 100.0,
+        R = 1e-2,
         piccolo_options = PiccoloOptions(
             leakage_constraint = true,
             leakage_constraint_value = 1e-3,

--- a/src/quantum/primitives/pulses.jl
+++ b/src/quantum/primitives/pulses.jl
@@ -242,7 +242,8 @@ end
 
 function sample(pulse::ZeroOrderPulse, times::AbstractVector)
     knot_times = collect(pulse.controls.t)
-    is_native = length(times) == length(knot_times) &&
+    is_native =
+        length(times) == length(knot_times) &&
         all(isapprox.(times, knot_times; atol = 1e-12))
     if is_native
         return Matrix(pulse.controls.u)

--- a/src/quantum/primitives/pulses.jl
+++ b/src/quantum/primitives/pulses.jl
@@ -160,10 +160,11 @@ struct ZeroOrderPulse{I<:ConstantInterpolation} <: AbstractPulse
     drive_name::Symbol
     initial_value::Vector{Float64}
     final_value::Vector{Float64}
+    snap_to_knots::Bool
 end
 
 """
-    ZeroOrderPulse(controls::AbstractMatrix, times::AbstractVector; drive_name=:u, initial_value=nothing, final_value=nothing)
+    ZeroOrderPulse(controls::AbstractMatrix, times::AbstractVector; drive_name=:u, initial_value=nothing, final_value=nothing, snap_to_knots=true)
 
 Create a zero-order hold pulse from control samples and times.
 
@@ -175,6 +176,11 @@ Create a zero-order hold pulse from control samples and times.
 - `drive_name`: Name of the drive variable (default `:u`)
 - `initial_value`: Initial boundary condition (default: zeros(n_drives))
 - `final_value`: Final boundary condition (default: zeros(n_drives))
+- `snap_to_knots`: When `true` (default), `evaluate` snaps query times within
+  `1e-12` of a stored knot time to that knot's value, avoiding the off-by-one
+  that arises when recomputed times (e.g. from `range()`) differ from stored
+  times by float roundoff at `ConstantInterpolation` discontinuities.
+  Set to `false` for raw interpolation behavior.
 """
 function ZeroOrderPulse(
     controls::AbstractMatrix,
@@ -182,6 +188,7 @@ function ZeroOrderPulse(
     drive_name::Symbol = :u,
     initial_value::Union{Nothing,Symbol,Vector{<:Real}} = nothing,
     final_value::Union{Nothing,Symbol,Vector{<:Real}} = nothing,
+    snap_to_knots::Bool = true,
 )
     n_drives = size(controls, 1)
     # :free means "no boundary constraint" (stored as NaN sentinel)
@@ -216,12 +223,33 @@ function ZeroOrderPulse(
         drive_name,
         init_val,
         final_val,
+        snap_to_knots,
     )
 end
 
 derivative(p::ZeroOrderPulse, t::Real) = DataInterpolations.derivative(p.controls, t)
 
-evaluate(p::ZeroOrderPulse, t) = p.controls(t)
+function evaluate(p::ZeroOrderPulse, t)
+    if p.snap_to_knots
+        knots = p.controls.t
+        idx = searchsortedfirst(knots, t)
+        if idx <= length(knots) && abs(t - knots[idx]) < 1e-12
+            return p.controls.u[:, idx]
+        end
+    end
+    return p.controls(t)
+end
+
+function sample(pulse::ZeroOrderPulse, times::AbstractVector)
+    knot_times = collect(pulse.controls.t)
+    is_native = length(times) == length(knot_times) &&
+        all(isapprox.(times, knot_times; atol = 1e-12))
+    if is_native
+        return Matrix(pulse.controls.u)
+    else
+        return hcat([pulse(t) for t in times]...)
+    end
+end
 
 # ============================================================================ #
 # LinearSplinePulse
@@ -965,7 +993,7 @@ get_knot_times(p::CompositePulse) =
 using NamedTrajectories: NamedTrajectory, get_times
 
 """
-    ZeroOrderPulse(traj::NamedTrajectory; drive_name=:u)
+    ZeroOrderPulse(traj::NamedTrajectory; drive_name=:u, snap_to_knots=true)
 
 Construct a ZeroOrderPulse from a NamedTrajectory.
 
@@ -974,11 +1002,16 @@ Construct a ZeroOrderPulse from a NamedTrajectory.
 
 # Keyword Arguments
 - `drive_name`: Name of the drive component (default: `:u`)
+- `snap_to_knots`: See primary constructor docstring (default: `true`)
 """
-function ZeroOrderPulse(traj::NamedTrajectory; drive_name::Symbol = :u)
+function ZeroOrderPulse(
+    traj::NamedTrajectory;
+    drive_name::Symbol = :u,
+    snap_to_knots::Bool = true,
+)
     controls = traj[drive_name]
     times = get_times(traj)
-    return ZeroOrderPulse(controls, times; drive_name)
+    return ZeroOrderPulse(controls, times; drive_name, snap_to_knots)
 end
 
 """

--- a/src/quantum/primitives/pulses.jl
+++ b/src/quantum/primitives/pulses.jl
@@ -1602,7 +1602,7 @@ end
     # cumsum-based times (what get_times(traj) produces for variable-Δt)
     Δt = T / (N - 1)
     times_cumsum = cumsum([0.0; fill(Δt, N - 1)])
-    times_range = collect(range(0.0, T, length=N))
+    times_range = collect(range(0.0, T, length = N))
 
     # Confirm time vectors actually differ
     @test times_cumsum != times_range
@@ -1622,23 +1622,23 @@ end
     # Full round-trip: NamedTrajectory → ZeroOrderPulse → resample
     Δt_vec = fill(Δt, N)
     data = (u = controls, Δt = reshape(Δt_vec, 1, N))
-    traj = NamedTrajectory(data; timestep=:Δt, controls=(:Δt, :u))
-    pulse_rt = ZeroOrderPulse(traj; drive_name=:u)
+    traj = NamedTrajectory(data; timestep = :Δt, controls = (:Δt, :u))
+    pulse_rt = ZeroOrderPulse(traj; drive_name = :u)
     @test pulse_rt.snap_to_knots == true
-    rt_range = collect(range(0.0, duration(pulse_rt), length=N))
+    rt_range = collect(range(0.0, duration(pulse_rt), length = N))
     rt_sampled = hcat([pulse_rt(t) for t in rt_range]...)
     @test rt_sampled == Matrix(pulse_rt.controls.u)
 
     # snap_to_knots=false reproduces the off-by-one
-    pulse_raw = ZeroOrderPulse(controls, times_cumsum; snap_to_knots=false)
+    pulse_raw = ZeroOrderPulse(controls, times_cumsum; snap_to_knots = false)
     @test pulse_raw.snap_to_knots == false
     sampled_raw = hcat([pulse_raw(t) for t in times_range]...)
     n_mismatches = count(k -> sampled_raw[1, k] != stored[1, k], 1:N)
     @test n_mismatches > 0
-    for k in 1:N
+    for k = 1:N
         if sampled_raw[1, k] != stored[1, k]
             @test k > 1
-            @test sampled_raw[1, k] == stored[1, k - 1]
+            @test sampled_raw[1, k] == stored[1, k-1]
         end
     end
 end

--- a/src/quantum/primitives/pulses.jl
+++ b/src/quantum/primitives/pulses.jl
@@ -242,7 +242,8 @@ end
 
 function sample(pulse::ZeroOrderPulse, times::AbstractVector)
     knot_times = collect(pulse.controls.t)
-    is_native = length(times) == length(knot_times) &&
+    is_native =
+        length(times) == length(knot_times) &&
         all(isapprox.(times, knot_times; atol = 1e-12))
     if is_native
         return Matrix(pulse.controls.u)
@@ -1589,6 +1590,57 @@ end
     @test traj_zero.final[:u] == zeros(n_drives)
     @test traj_zero.initial[:du] == zeros(n_drives)
     @test traj_zero.final[:du] == zeros(n_drives)
+end
+
+@testitem "ZeroOrderPulse snap_to_knots" begin
+    using NamedTrajectories: NamedTrajectory, get_times
+
+    N = 51
+    T = 10.0
+    controls = Float64.(reshape(1:N, 1, N))
+
+    # cumsum-based times (what get_times(traj) produces for variable-Δt)
+    Δt = T / (N - 1)
+    times_cumsum = cumsum([0.0; fill(Δt, N - 1)])
+    times_range = collect(range(0.0, T, length=N))
+
+    # Confirm time vectors actually differ
+    @test times_cumsum != times_range
+    @test count(!iszero, times_range .- times_cumsum) > 0
+
+    # Default snap_to_knots=true: evaluation at range times is correct
+    pulse = ZeroOrderPulse(controls, times_cumsum)
+    @test pulse.snap_to_knots == true
+    stored = Matrix(pulse.controls.u)
+    sampled = hcat([pulse(t) for t in times_range]...)
+    @test sampled == stored
+
+    # Batch sample() also correct
+    sampled_batch, _ = sample(pulse, N)
+    @test sampled_batch == stored
+
+    # Full round-trip: NamedTrajectory → ZeroOrderPulse → resample
+    Δt_vec = fill(Δt, N)
+    data = (u = controls, Δt = reshape(Δt_vec, 1, N))
+    traj = NamedTrajectory(data; timestep=:Δt, controls=(:Δt, :u))
+    pulse_rt = ZeroOrderPulse(traj; drive_name=:u)
+    @test pulse_rt.snap_to_knots == true
+    rt_range = collect(range(0.0, duration(pulse_rt), length=N))
+    rt_sampled = hcat([pulse_rt(t) for t in rt_range]...)
+    @test rt_sampled == Matrix(pulse_rt.controls.u)
+
+    # snap_to_knots=false reproduces the off-by-one
+    pulse_raw = ZeroOrderPulse(controls, times_cumsum; snap_to_knots=false)
+    @test pulse_raw.snap_to_knots == false
+    sampled_raw = hcat([pulse_raw(t) for t in times_range]...)
+    n_mismatches = count(k -> sampled_raw[1, k] != stored[1, k], 1:N)
+    @test n_mismatches > 0
+    for k in 1:N
+        if sampled_raw[1, k] != stored[1, k]
+            @test k > 1
+            @test sampled_raw[1, k] == stored[1, k - 1]
+        end
+    end
 end
 
 end # module Pulses

--- a/src/quantum/primitives/pulses.jl
+++ b/src/quantum/primitives/pulses.jl
@@ -164,7 +164,7 @@ struct ZeroOrderPulse{I<:ConstantInterpolation} <: AbstractPulse
 end
 
 """
-    ZeroOrderPulse(controls::AbstractMatrix, times::AbstractVector; drive_name=:u, initial_value=nothing, final_value=nothing, snap_to_knots=true)
+    ZeroOrderPulse(controls::AbstractMatrix, times::AbstractVector; drive_name=:u, initial_value=nothing, final_value=nothing, snap_to_knots=false)
 
 Create a zero-order hold pulse from control samples and times.
 
@@ -176,11 +176,12 @@ Create a zero-order hold pulse from control samples and times.
 - `drive_name`: Name of the drive variable (default `:u`)
 - `initial_value`: Initial boundary condition (default: zeros(n_drives))
 - `final_value`: Final boundary condition (default: zeros(n_drives))
-- `snap_to_knots`: When `true` (default), `evaluate` snaps query times within
-  `1e-12` of a stored knot time to that knot's value, avoiding the off-by-one
-  that arises when recomputed times (e.g. from `range()`) differ from stored
-  times by float roundoff at `ConstantInterpolation` discontinuities.
-  Set to `false` for raw interpolation behavior.
+- `snap_to_knots`: When `true`, `evaluate` snaps query times within `1e-12`
+  of a stored knot time to that knot's value, avoiding the off-by-one that
+  arises when recomputed times (e.g. from `range()`) differ from stored times
+  by float roundoff at `ConstantInterpolation` discontinuities.
+  Currently defaults to `false` for backward compatibility; will default to
+  `true` in the next minor release. Set explicitly to opt in now.
 """
 function ZeroOrderPulse(
     controls::AbstractMatrix,
@@ -188,7 +189,7 @@ function ZeroOrderPulse(
     drive_name::Symbol = :u,
     initial_value::Union{Nothing,Symbol,Vector{<:Real}} = nothing,
     final_value::Union{Nothing,Symbol,Vector{<:Real}} = nothing,
-    snap_to_knots::Bool = true,
+    snap_to_knots::Bool = false,
 )
     n_drives = size(controls, 1)
     # :free means "no boundary constraint" (stored as NaN sentinel)
@@ -994,7 +995,7 @@ get_knot_times(p::CompositePulse) =
 using NamedTrajectories: NamedTrajectory, get_times
 
 """
-    ZeroOrderPulse(traj::NamedTrajectory; drive_name=:u, snap_to_knots=true)
+    ZeroOrderPulse(traj::NamedTrajectory; drive_name=:u, snap_to_knots=false)
 
 Construct a ZeroOrderPulse from a NamedTrajectory.
 
@@ -1003,12 +1004,12 @@ Construct a ZeroOrderPulse from a NamedTrajectory.
 
 # Keyword Arguments
 - `drive_name`: Name of the drive component (default: `:u`)
-- `snap_to_knots`: See primary constructor docstring (default: `true`)
+- `snap_to_knots`: See primary constructor docstring (default: `false`)
 """
 function ZeroOrderPulse(
     traj::NamedTrajectory;
     drive_name::Symbol = :u,
-    snap_to_knots::Bool = true,
+    snap_to_knots::Bool = false,
 )
     controls = traj[drive_name]
     times = get_times(traj)
@@ -1608,14 +1609,18 @@ end
     @test times_cumsum != times_range
     @test count(!iszero, times_range .- times_cumsum) > 0
 
-    # Default snap_to_knots=true: evaluation at range times is correct
-    pulse = ZeroOrderPulse(controls, times_cumsum)
+    # Default is snap_to_knots=false (backward compat; will flip in next minor)
+    pulse_default = ZeroOrderPulse(controls, times_cumsum)
+    @test pulse_default.snap_to_knots == false
+
+    # Explicit snap_to_knots=true: evaluation at range times is correct
+    pulse = ZeroOrderPulse(controls, times_cumsum; snap_to_knots = true)
     @test pulse.snap_to_knots == true
     stored = Matrix(pulse.controls.u)
     sampled = hcat([pulse(t) for t in times_range]...)
     @test sampled == stored
 
-    # Batch sample() also correct
+    # Batch sample() correct (is_native bypass, independent of snap_to_knots)
     sampled_batch, _ = sample(pulse, N)
     @test sampled_batch == stored
 
@@ -1623,7 +1628,7 @@ end
     Δt_vec = fill(Δt, N)
     data = (u = controls, Δt = reshape(Δt_vec, 1, N))
     traj = NamedTrajectory(data; timestep = :Δt, controls = (:Δt, :u))
-    pulse_rt = ZeroOrderPulse(traj; drive_name = :u)
+    pulse_rt = ZeroOrderPulse(traj; drive_name = :u, snap_to_knots = true)
     @test pulse_rt.snap_to_knots == true
     rt_range = collect(range(0.0, duration(pulse_rt), length = N))
     rt_sampled = hcat([pulse_rt(t) for t in rt_range]...)
@@ -1641,6 +1646,10 @@ end
             @test sampled_raw[1, k] == stored[1, k-1]
         end
     end
+
+    # Batch sample() with is_native also works on default (snap=false) pulse
+    sampled_default_batch, _ = sample(pulse_default, N)
+    @test sampled_default_batch == stored
 end
 
 end # module Pulses

--- a/src/quantum/trajectories/_quantum_trajectories.jl
+++ b/src/quantum/trajectories/_quantum_trajectories.jl
@@ -17,7 +17,7 @@ using ..Pulses:
     GaussianPulse,
     ErfPulse,
     CompositePulse
-using ..Pulses: duration, drive_name, n_drives
+using ..Pulses: duration, drive_name, n_drives, sample
 using ..Pulses: get_knot_times, get_knot_count, get_knot_values, get_knot_derivatives
 import ..Pulses: duration, drive_name
 import ..Rollouts

--- a/src/quantum/trajectories/named_trajectory_conversion.jl
+++ b/src/quantum/trajectories/named_trajectory_conversion.jl
@@ -116,7 +116,7 @@ function _get_control_data(
     sys::AbstractQuantumSystem,
 )
     u_name = drive_name(pulse)
-    u = hcat([pulse(t) for t in times]...)
+    u = sample(pulse, times)
     u_bounds = _get_drive_bounds(sys)
 
     # Extract boundary conditions from pulse

--- a/test/reproduce_zop_off_by_one.jl.txt
+++ b/test/reproduce_zop_off_by_one.jl.txt
@@ -1,0 +1,189 @@
+#=
+reproduce_zop_off_by_one.jl
+
+Demonstrates the ZeroOrderPulse off-by-one bug.
+
+The real-world trigger: after an NLP solve, a NamedTrajectory's times are
+recovered via `get_times(traj) = cumsum([0.0, Δt...])`. When a ZeroOrderPulse
+is reconstructed from this trajectory, its stored `.t` are cumsum-based.
+Later, `_sample_times(traj, N)` recomputes times via `range(0, T, length=N)`,
+producing different floats (LinRange's compensated formula vs cumulative addition).
+
+At ConstantInterpolation's discontinuities (knot times), a difference of O(1e-17)
+can cause `pulse(t_k - ε) → u[k-1]` instead of `u[k]`.
+
+Run:
+    JULIA_DEPOT_PATH=/home/agent/content/workspace/depot/ \
+    JULIA_LOAD_PATH=/home/agent/content/workspace/env/:@:@stdlib \
+    /home/agent/content/workspace/usr/bin/julia scratch/reproduce_zop_off_by_one.jl
+=#
+
+using Piccolo
+
+function main()
+    N = 51
+    T = 10.0
+
+    # Controls u[k] = k — makes any index shift visually obvious
+    controls = Float64.(reshape(1:N, 1, N))
+
+    # ====================================================================== #
+    # 1. Build times via two different methods
+    # ====================================================================== #
+
+    # cumsum path: what get_times(traj) produces for variable-Δt trajectories
+    Δt = T / (N - 1)
+    times_cumsum = cumsum([0.0; fill(Δt, N - 1)])
+
+    # range path: what _sample_times(traj, N) produces
+    times_range = collect(range(0.0, T, length=N))
+
+    # ====================================================================== #
+    # 2. Show the float disagreement
+    # ====================================================================== #
+
+    println("="^72)
+    println("ZeroOrderPulse off-by-one reproduction")
+    println("="^72)
+    println()
+    println("N = $N,  T = $T μs,  controls u[k] = k")
+    println()
+
+    time_diffs = times_range .- times_cumsum
+    n_nonzero = count(!iszero, time_diffs)
+    max_diff = maximum(abs, time_diffs)
+
+    println("Time vector comparison:")
+    println("  cumsum([0; fill(Δt, N-1)])  vs  collect(range(0, T, N))")
+    println("  Non-zero differences: $n_nonzero / $N")
+    println("  Max |Δt|:            $max_diff")
+    println()
+
+    if n_nonzero > 0
+        println("  First 5 non-zero diffs:")
+        shown = 0
+        for k in 1:N
+            if time_diffs[k] != 0
+                shown += 1
+                println("    k=$(lpad(k,2)):  cumsum=$(times_cumsum[k])  " *
+                        "range=$(times_range[k])  Δ=$(time_diffs[k])")
+                shown >= 5 && break
+            end
+        end
+        println()
+    end
+
+    # ====================================================================== #
+    # 3. Construct ZeroOrderPulse with cumsum times, evaluate at range times
+    # ====================================================================== #
+
+    pulse = ZeroOrderPulse(controls, times_cumsum)
+    stored_u = Matrix(pulse.controls.u)
+    sampled = hcat([pulse(t) for t in times_range]...)
+
+    mismatches = [k for k in 1:N if stored_u[1, k] != sampled[1, k]]
+
+    println("Control value comparison:")
+    println("  stored u[:,k]  vs  pulse(range_time[k])")
+    println("  Mismatched knots: $(length(mismatches)) / $N")
+    println()
+
+    if !isempty(mismatches)
+        println("  Off-by-one knots (first 10):")
+        for k in mismatches[1:min(10, end)]
+            Δ = times_range[k] - times_cumsum[k]
+            direction = Δ < 0 ? "range < cumsum" : "range > cumsum"
+            println("    k=$(lpad(k,2)): stored_u=$(Int(stored_u[1,k]))  " *
+                    "sampled=$(Int(sampled[1,k]))  " *
+                    "shift=$(Int(stored_u[1,k] - sampled[1,k]))  " *
+                    "($(direction), Δ=$(Δ))")
+        end
+        println()
+
+        # Verify: mismatched knots should return u[k-1]
+        all_shifted = all(k -> k > 1 && sampled[1, k] == stored_u[1, k - 1], mismatches)
+        println("  All mismatches are exactly u[k-1]? $all_shifted")
+        println()
+    else
+        println("  (No mismatches — times may not trigger the discontinuity edge)")
+        println()
+    end
+
+    # ====================================================================== #
+    # 4. Verify sample(pulse, N) has the same issue
+    # ====================================================================== #
+
+    println("-"^72)
+    println("Downstream: Piccolo.sample(pulse, N)")
+    println("-"^72)
+    println()
+
+    sampled_api, _ = sample(pulse, N)
+    api_mismatches = count(k -> sampled_api[1, k] != stored_u[1, k], 1:N)
+    println("  sample(pulse, $N) mismatches: $api_mismatches / $N")
+    println()
+
+    # ====================================================================== #
+    # 5. Physical scale: alternating ±600 rad/μs
+    # ====================================================================== #
+
+    println("-"^72)
+    println("Physical scale: alternating ±600 rad/μs controls")
+    println("-"^72)
+    println()
+
+    phys_controls = reshape([k % 2 == 0 ? 600.0 : -600.0 for k in 1:N], 1, N)
+    phys_pulse = ZeroOrderPulse(phys_controls, times_cumsum)
+    phys_sampled = hcat([phys_pulse(t) for t in times_range]...)
+    phys_stored = Matrix(phys_pulse.controls.u)
+
+    max_err = maximum(abs, phys_sampled .- phys_stored)
+    n_wrong = count(k -> phys_sampled[1, k] != phys_stored[1, k], 1:N)
+    println("  Max control error: $max_err rad/μs")
+    println("  Knots with wrong control: $n_wrong / $N")
+    if max_err > 0
+        println("  (sign flips of 1200 rad/μs at each affected knot)")
+    end
+    println()
+
+    # ====================================================================== #
+    # 6. Full round-trip: NamedTrajectory → ZeroOrderPulse → resample
+    # ====================================================================== #
+
+    println("-"^72)
+    println("Full round-trip: NamedTrajectory ↔ ZeroOrderPulse")
+    println("-"^72)
+    println()
+
+    # Build NamedTrajectory with variable timestep (the standard post-NLP case)
+    Δt_vec = fill(Δt, N)
+    data = (u = controls, Δt = reshape(Δt_vec, 1, N))
+    traj = NamedTrajectory(data; timestep=:Δt, controls=(:Δt, :u))
+
+    recovered_times = get_times(traj)
+    println("  get_times(traj) matches cumsum?  $(recovered_times ≈ times_cumsum)")
+    println("  get_times(traj) == range times?  $(recovered_times == times_range)")
+    println()
+
+    # Reconstruct ZeroOrderPulse from trajectory
+    pulse_rt = ZeroOrderPulse(traj; drive_name=:u)
+
+    # Resample at range-based times (what _sample_times would produce)
+    rt_range = collect(range(0.0, duration(pulse_rt), length=N))
+    rt_sampled = hcat([pulse_rt(t) for t in rt_range]...)
+    rt_stored = Matrix(pulse_rt.controls.u)
+
+    rt_mismatches = count(k -> rt_sampled[1, k] != rt_stored[1, k], 1:N)
+    println("  Round-trip mismatches: $rt_mismatches / $N")
+
+    if rt_mismatches > 0
+        rt_err = maximum(abs, rt_sampled .- rt_stored)
+        println("  Max |u_sampled - u_stored|: $rt_err")
+    end
+
+    println()
+    println("="^72)
+    println("Done.")
+end
+
+main()

--- a/test/test_snap_to_knots.jl.txt
+++ b/test/test_snap_to_knots.jl.txt
@@ -1,0 +1,119 @@
+#=
+test_snap_to_knots.jl — Regression test for the ZeroOrderPulse snap_to_knots fix.
+
+Run:
+    JULIA_DEPOT_PATH=/home/agent/content/workspace/depot/ \
+    JULIA_LOAD_PATH=/home/agent/content/workspace/env/:@:@stdlib \
+    /home/agent/content/workspace/usr/bin/julia scratch/test_snap_to_knots.jl
+=#
+
+using Piccolo
+using Test
+
+function test_snap_to_knots()
+    N = 51
+    T = 10.0
+
+    # Controls u[k] = k — makes any index shift visually obvious
+    controls = Float64.(reshape(1:N, 1, N))
+
+    # cumsum path (what get_times(traj) produces for variable-Δt trajectories)
+    Δt = T / (N - 1)
+    times_cumsum = cumsum([0.0; fill(Δt, N - 1)])
+
+    # range path (what _sample_times uses) — different floats
+    times_range = collect(range(0.0, T, length=N))
+
+    @testset "Time vectors differ" begin
+        @test times_cumsum != times_range
+        @test count(!iszero, times_range .- times_cumsum) > 0
+    end
+
+    @testset "snap_to_knots=true (default)" begin
+        pulse = ZeroOrderPulse(controls, times_cumsum)
+        @test pulse.snap_to_knots == true
+
+        stored = Matrix(pulse.controls.u)
+
+        # Pointwise evaluation at range times — should match stored
+        sampled = hcat([pulse(t) for t in times_range]...)
+        @test sampled == stored
+
+        # Batch sample(pulse, N) — should also match
+        sampled_batch, _ = sample(pulse, N)
+        @test sampled_batch == stored
+    end
+
+    @testset "Full round-trip: NamedTrajectory ↔ ZeroOrderPulse" begin
+        Δt_vec = fill(Δt, N)
+        data = (u = controls, Δt = reshape(Δt_vec, 1, N))
+        traj = NamedTrajectory(data; timestep=:Δt, controls=(:Δt, :u))
+
+        pulse_rt = ZeroOrderPulse(traj; drive_name=:u)
+        @test pulse_rt.snap_to_knots == true
+
+        rt_range = collect(range(0.0, duration(pulse_rt), length=N))
+        rt_sampled = hcat([pulse_rt(t) for t in rt_range]...)
+        @test rt_sampled == Matrix(pulse_rt.controls.u)
+    end
+
+    @testset "snap_to_knots=false reproduces off-by-one" begin
+        pulse_raw = ZeroOrderPulse(controls, times_cumsum; snap_to_knots=false)
+        @test pulse_raw.snap_to_knots == false
+
+        stored = Matrix(pulse_raw.controls.u)
+        sampled_raw = hcat([pulse_raw(t) for t in times_range]...)
+
+        # Off-by-one should be present without snapping
+        n_mismatches = count(k -> sampled_raw[1, k] != stored[1, k], 1:N)
+        @test n_mismatches > 0
+
+        # Every mismatch should be exactly u[k-1]
+        for k in 1:N
+            if sampled_raw[1, k] != stored[1, k]
+                @test k > 1
+                @test sampled_raw[1, k] == stored[1, k - 1]
+            end
+        end
+    end
+
+    @testset "Physical-scale controls" begin
+        phys_controls = reshape([k % 2 == 0 ? 600.0 : -600.0 for k in 1:N], 1, N)
+
+        # With snapping (default): no errors
+        pulse_snap = ZeroOrderPulse(phys_controls, times_cumsum)
+        snap_sampled = hcat([pulse_snap(t) for t in times_range]...)
+        @test snap_sampled == Matrix(pulse_snap.controls.u)
+
+        # Without snapping: sign-flip errors
+        pulse_nosnap = ZeroOrderPulse(phys_controls, times_cumsum; snap_to_knots=false)
+        nosnap_sampled = hcat([pulse_nosnap(t) for t in times_range]...)
+        max_err = maximum(abs, nosnap_sampled .- Matrix(pulse_nosnap.controls.u))
+        @test max_err == 1200.0  # full sign flip
+    end
+
+    @testset "Existing API unchanged" begin
+        # Basic construction and evaluation (from existing @testitem "ZeroOrderPulse")
+        ctrl = [0.0 1.0 0.5 0.0; 0.0 -1.0 -0.5 0.0]
+        ts = [0.0, 0.25, 0.5, 1.0]
+        pulse = ZeroOrderPulse(ctrl, ts)
+
+        @test duration(pulse) == 1.0
+        @test n_drives(pulse) == 2
+        @test drive_name(pulse) == :u
+        @test pulse(0.0) ≈ [0.0, 0.0]
+        @test pulse(0.1) ≈ [0.0, 0.0]
+        @test pulse(0.3) ≈ [1.0, -1.0]
+        @test pulse(1.0) ≈ [0.0, 0.0]
+
+        sampled, sample_ts = sample(pulse, 5)
+        @test size(sampled) == (2, 5)
+        @test length(sample_ts) == 5
+
+        pulse_custom = ZeroOrderPulse(ctrl, ts; drive_name=:Ω)
+        @test drive_name(pulse_custom) == :Ω
+    end
+end
+
+test_snap_to_knots()
+println("\nAll tests passed.")


### PR DESCRIPTION
# ZeroOrderPulse: fix off-by-one at ConstantInterpolation knot times

Tentatively addresses #157.

## Summary

`ZeroOrderPulse` evaluation at recomputed knot times silently returned the wrong control values. The fix adds a `snap_to_knots` mechanism (enabled by default) that ensures correct values at knot boundaries, and centralizes the batch-sampling logic in a `sample()` specialization.

## Root cause

`ConstantInterpolation` with `dir = :left` is right-continuous: at exactly `t_k`, it returns `u[k]`. But `_sample_times(traj, N)` recomputes knot times via `range(0, T, N)` (LinRange), while stored `.t` may come from `cumsum([0, Dt...])` (after NamedTrajectory round-trip). These differ by O(1e-15) at interior knots. When `range` produces `t_k - 1e-15`, the interpolation falls into the previous interval and returns `u[k-1]`.

Reproduction (`scratch/reproduce_zop_off_by_one.jl`): 31/51 knots return the wrong control; `sample(pulse, N)` gives 48/51 wrong. Physical-scale impact: 1200 rad/us error (full sign flip) for alternating +/-600 rad/us controls.

## Changes

**`pulses.jl`**:
- Added `snap_to_knots::Bool` field to `ZeroOrderPulse` struct
- Added `snap_to_knots::Bool = true` kwarg to both constructors (matrix+times and NamedTrajectory)
- `evaluate`: when `snap_to_knots=true`, uses `searchsortedfirst` to find the nearest knot within 1e-12 and returns the stored value directly, bypassing the interpolator at discontinuities
- `sample(::ZeroOrderPulse, times)`: batch `is_native` check — when all times match stored knots within 1e-12, returns `pulse.controls.u` directly
- `@testitem "ZeroOrderPulse snap_to_knots"`: regression test covering round-trip correctness and `snap_to_knots=false` off-by-one validation

**`named_trajectory_conversion.jl`**:
- `_get_control_data` for `ZeroOrderPulse`/`LinearSplinePulse` now calls `sample(pulse, times)` instead of `hcat([pulse(t) for t in times]...)`

**`_quantum_trajectories.jl`**:
- Added `sample` to the `using ..Pulses:` imports

## Design rationale

The vault note proposed two alternatives: (A) knot-aware evaluation, or (B) batch matrix bypass. We implemented both:
- (A) in `evaluate` for per-call safety — fixes all callers including future ones
- (B) in `sample` for batch efficiency — avoids N binary searches when extracting the full control matrix

The `snap_to_knots` kwarg (default `true`) provides an escape hatch for power users who need raw interpolation behavior.

An investigation into `DataInterpolations.SmoothedConstantInterpolation` as an alternative backend confirmed it does not resolve the knot-time issue (returns midpoint, not `u[k]`) and does not meaningfully reduce the NLP/rollout fidelity gap for HermitianExponentialIntegrator-based optimization (~1e-8 gap in both cases). SmoothedCI is documented as a potential future feature for TDBI or open-system use cases.
