### PR TITLE
Expose state_leakage_indices kwarg for ket / density / multiket problems

### DIFF
--- a/src/control/templates/smooth_pulse_problem.jl
+++ b/src/control/templates/smooth_pulse_problem.jl
@@ -134,6 +134,9 @@ function SmoothPulseProblem(
     piccolo_options::PiccoloOptions = PiccoloOptions(),
     free_phase::Bool = false,
     initial_phases::Union{Nothing,Vector{Float64}} = nothing,
+    state_leakage_indices::Union{
+        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+    } = nothing,
 )
     if piccolo_options.verbose
         traj_type = split(string(typeof(qtraj).name.name), ".")[end]
@@ -245,7 +248,10 @@ function SmoothPulseProblem(
     J += QuadraticRegularizer(control_names[3], traj_smooth, R_ddu)
 
     # Add optional Piccolo constraints and objectives
-    J += _apply_piccolo_options(qtraj, piccolo_options, constraints, traj_smooth, state_sym)
+    J += _apply_piccolo_options(
+        qtraj, piccolo_options, constraints, traj_smooth, state_sym;
+        state_leakage_indices = state_leakage_indices,
+    )
 
     # Start with dynamics integrators
     integrators = copy(dynamics_integrators)
@@ -350,6 +356,9 @@ function SmoothPulseProblem(
     subsystem_levels::Union{Nothing,Vector{Int}} = nothing,
     initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     coherent::Bool = true,
+    state_leakage_indices::Union{
+        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+    } = nothing,
 )
     if piccolo_options.verbose
         println(
@@ -426,7 +435,10 @@ function SmoothPulseProblem(
     J += QuadraticRegularizer(control_names[3], traj_smooth, R_ddu)
 
     # Apply piccolo options for each state
-    J += _apply_piccolo_options(qtraj, piccolo_options, constraints, traj_smooth, snames)
+    J += _apply_piccolo_options(
+        qtraj, piccolo_options, constraints, traj_smooth, snames;
+        state_leakage_indices = state_leakage_indices,
+    )
 
     # Build integrators: one dynamics integrator per state
     if isnothing(integrator)
@@ -521,16 +533,23 @@ function _apply_piccolo_options(
     piccolo_options::PiccoloOptions,
     constraints::Vector{<:AbstractConstraint},
     traj::NamedTrajectory,
-    state_sym::Symbol,
+    state_sym::Symbol;
+    state_leakage_indices::Union{Nothing,AbstractVector{Int}} = nothing,
 )
     U_goal = qtraj.goal
+    indices = if state_leakage_indices !== nothing
+        state_leakage_indices
+    elseif U_goal isa EmbeddedOperator
+        get_iso_vec_leakage_indices(U_goal)
+    else
+        nothing
+    end
     return apply_piccolo_options!(
         piccolo_options,
         constraints,
         traj;
         state_names = state_sym,
-        state_leakage_indices = U_goal isa EmbeddedOperator ?
-                                get_iso_vec_leakage_indices(U_goal) : nothing,
+        state_leakage_indices = indices,
     )
 end
 
@@ -539,13 +558,15 @@ function _apply_piccolo_options(
     piccolo_options::PiccoloOptions,
     constraints::Vector{<:AbstractConstraint},
     traj::NamedTrajectory,
-    state_sym::Symbol,
+    state_sym::Symbol;
+    state_leakage_indices::Union{Nothing,AbstractVector{Int}} = nothing,
 )
     return apply_piccolo_options!(
         piccolo_options,
         constraints,
         traj;
         state_names = state_sym,
+        state_leakage_indices = state_leakage_indices,
     )
 end
 
@@ -554,13 +575,15 @@ function _apply_piccolo_options(
     piccolo_options::PiccoloOptions,
     constraints::Vector{<:AbstractConstraint},
     traj::NamedTrajectory,
-    state_sym::Symbol,
+    state_sym::Symbol;
+    state_leakage_indices::Union{Nothing,AbstractVector{Int}} = nothing,
 )
     return apply_piccolo_options!(
         piccolo_options,
         constraints,
         traj;
         state_names = state_sym,
+        state_leakage_indices = state_leakage_indices,
     )
 end
 
@@ -611,12 +634,20 @@ function _apply_piccolo_options(
     piccolo_options::PiccoloOptions,
     constraints::Vector{<:AbstractConstraint},
     traj::NamedTrajectory,
-    snames::Vector{Symbol},
+    snames::Vector{Symbol};
+    state_leakage_indices::Union{
+        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+    } = nothing,
 )
-    # Compute ket leakage indices from goal states:
-    # Computational subspace = union of nonzero indices across all goals
-    # Leakage indices = everything else, in isomorphic representation
-    leakage_indices = if piccolo_options.leakage_constraint
+    # Resolve leakage indices: user override > auto-derived from goals.
+    # User can pass a single iso_leak vector (broadcast to all states) or
+    # one per state.
+    leakage_indices = if state_leakage_indices !== nothing
+        state_leakage_indices isa AbstractVector{Int} ?
+            fill(state_leakage_indices, length(snames)) : state_leakage_indices
+    elseif piccolo_options.leakage_constraint
+        # Auto-derived: computational subspace = union of nonzero goal indices,
+        # leakage = everything else (in isomorphic representation)
         dim = length(qtraj.goals[1])
         comp = sort(union([findall(!iszero, g) for g in qtraj.goals]...))
         leak = setdiff(1:dim, comp)

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -96,6 +96,9 @@ function SplinePulseProblem(
     free_phase::Bool = false,
     subsystem_levels::Union{Nothing,Vector{Int}} = nothing,
     initial_phases::Union{Nothing,Vector{Float64}} = nothing,
+    state_leakage_indices::Union{
+        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+    } = nothing,
 )
     sys = get_system(qtraj)
     control_sym = drive_name(qtraj)
@@ -232,7 +235,10 @@ function SplinePulseProblem(
     J += QuadraticRegularizer(du_sym, traj, R_du)
 
     # Apply piccolo options
-    J += _apply_piccolo_options(qtraj, piccolo_options, constraints, traj, state_sym)
+    J += _apply_piccolo_options(
+        qtraj, piccolo_options, constraints, traj, state_sym;
+        state_leakage_indices = state_leakage_indices,
+    )
 
     # Start with dynamics integrators
     integrators = copy(dynamics_integrators)
@@ -311,6 +317,9 @@ function SplinePulseProblem(
     subsystem_levels::Union{Nothing,Vector{Int}} = nothing,
     initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     coherent::Bool = true,
+    state_leakage_indices::Union{
+        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+    } = nothing,
 )
     sys = get_system(qtraj)
     control_sym = drive_name(qtraj)
@@ -443,7 +452,10 @@ function SplinePulseProblem(
     J += QuadraticRegularizer(du_sym, traj, R_du)
 
     # Apply piccolo options for each state
-    J += _apply_piccolo_options(qtraj, piccolo_options, constraints, traj, snames)
+    J += _apply_piccolo_options(
+        qtraj, piccolo_options, constraints, traj, snames;
+        state_leakage_indices = state_leakage_indices,
+    )
 
     # Start with dynamics integrators
     integrators = copy(dynamics_integrators)
@@ -687,6 +699,66 @@ end
     traj = get_trajectory(qcp)
     @test haskey(traj.components, :ψ̃)
     @test !haskey(traj.components, :ddu)  # No second derivative for splines
+end
+
+@testitem "SplinePulseProblem KetTrajectory leakage_indices kwarg" begin
+    using NamedTrajectories
+    using DirectTrajOpt
+    using LinearAlgebra
+
+    # 3-level system; computational subspace = {|0⟩, |1⟩}, leak = |2⟩
+    H_drift = ComplexF64[0 0 0; 0 0.01 0; 0 0 0.05]
+    H_drives = [ComplexF64[0 1 0; 1 0 sqrt(2); 0 sqrt(2) 0]]
+    T = 10.0
+    N = 51
+
+    sys = QuantumSystem(H_drift, H_drives, [1.0])
+
+    times = collect(range(0.0, T, length = N))
+    amps = 0.1 * randn(1, N)
+    pulse = LinearSplinePulse(amps, times)
+
+    ψ_init = ComplexF64[1.0, 0.0, 0.0]
+    ψ_goal = ComplexF64[0.0, 1.0, 0.0]
+
+    qtraj = KetTrajectory(sys, pulse, ψ_init, ψ_goal)
+
+    # Without state_leakage_indices, KetTrajectory + leakage_constraint=true
+    # must still error per the existing contract — there is no goal-derived
+    # leakage geometry for a single ket.
+    @test_throws ArgumentError SplinePulseProblem(
+        qtraj, N;
+        Q = 100.0, R = 1e-2,
+        piccolo_options = PiccoloOptions(
+            leakage_constraint = true,
+            leakage_constraint_value = 1e-3,
+            leakage_cost = 1.0,
+        ),
+    )
+
+    # With user-supplied indices, construction succeeds and a LeakageConstraint
+    # is appended to the problem's constraints.
+    # iso_ket = [Re(ψ); Im(ψ)] in length-6, so |2⟩ leakage = indices [3, 6].
+    qcp = SplinePulseProblem(
+        qtraj, N;
+        Q = 100.0, R = 1e-2,
+        piccolo_options = PiccoloOptions(
+            leakage_constraint = true,
+            leakage_constraint_value = 1e-3,
+            leakage_cost = 1.0,
+            verbose = false,
+        ),
+        state_leakage_indices = [3, 6],
+    )
+
+    @test qcp isa QuantumControlProblem
+    # LeakageConstraint is a constructor that returns a NonlinearKnotPointConstraint
+    # parametrized by a closure named `leakage_constraint`. Detect via the closure
+    # field name to confirm the leakage path actually fired.
+    @test any(qcp.prob.constraints) do c
+        c isa DirectTrajOpt.NonlinearKnotPointConstraint &&
+            occursin("leakage_constraint", string(typeof(c).parameters[1]))
+    end
 end
 
 @testitem "SplinePulseProblem with MultiKetTrajectory" begin


### PR DESCRIPTION
## Summary

Previously `PiccoloOptions(leakage_constraint=true)` only worked for `UnitaryTrajectory` with `EmbeddedOperator` goals (auto-derived) or for `MultiKetTrajectory` ensembles (auto-derived from the union of nonzero goal indices). For single `KetTrajectory` / `DensityTrajectory` problems the dispatcher dropped `state_leakage_indices` on the floor and `apply_piccolo_options!` threw `ArgumentError` — making leakage suppression unreachable from these templates.

Adds a `state_leakage_indices` kwarg through:

- All four `_apply_piccolo_options` dispatches (Unitary / Ket / Density / MultiKet) — supplied indices override auto-derivation where applicable
- `SplinePulseProblem(::AbstractQuantumTrajectory{<:AbstractSplinePulse}, ...)` (single-state body)
- `SplinePulseProblem(::MultiKetTrajectory{<:AbstractSplinePulse}, ...)` (multi-state body)
- `SmoothPulseProblem(::AbstractQuantumTrajectory{<:ZeroOrderPulse}, ...)`
- `SmoothPulseProblem(::MultiKetTrajectory{<:ZeroOrderPulse}, ...)`

## Use case

Bosonic state-prep where the user knows specific cavity Fock levels to suppress (e.g. top 1–2 levels) to make truncation self-consistent. For ket goals, "everything outside the goal's nonzero indices" is too aggressive — the optimizer legitimately uses intermediate states during the trajectory.

## API

```julia
qcp = SplinePulseProblem(
    qtraj, N;
    piccolo_options = PiccoloOptions(
        leakage_constraint = true,
        leakage_constraint_value = 1e-3,
        leakage_cost = 1.0,
    ),
    state_leakage_indices = top_cavity_iso_indices,
)
```

Accepts either `AbstractVector{Int}` (single set, broadcast to all state names) or `AbstractVector{<:AbstractVector{Int}}` (per-state). Default `nothing` preserves existing behavior.

## Tests

- New testitem `SplinePulseProblem KetTrajectory leakage_indices kwarg` covers both the preserved `ArgumentError` contract (no indices supplied) and the new path (indices supplied → `LeakageConstraint` installed).
- Filtered `SplinePulseProblem` + `SmoothPulseProblem` + `leakage` test sweep: **132 pass / 0 fail / 0 error**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)