### PR TITLE
fix(trajectories): default_algorithm method for CompositeQuantumSystem

### DIFF
--- a/src/quantum/trajectories/_quantum_trajectories.jl
+++ b/src/quantum/trajectories/_quantum_trajectories.jl
@@ -7,7 +7,8 @@ using OrdinaryDiffEqTsit5
 using TestItems
 using ForwardDiff
 
-using ..QuantumSystems: AbstractQuantumSystem, QuantumSystem, OpenQuantumSystem
+using ..QuantumSystems:
+    AbstractQuantumSystem, QuantumSystem, CompositeQuantumSystem, OpenQuantumSystem
 using ..Pulses:
     AbstractPulse,
     AbstractSplinePulse,
@@ -39,13 +40,52 @@ import ..QuantumSystems: default_algorithm
 
 """
     default_algorithm(sys::QuantumSystem)
+    default_algorithm(sys::CompositeQuantumSystem)
 
 Return the default ODE algorithm for trajectory rollouts.
 Uses `Tsit5()` for non-Hermitian systems (where Magnus adaptive error
 control fails), `MagnusAdapt4()` for Hermitian systems.
+
+For `CompositeQuantumSystem`, Hermiticity is derived from the subsystems —
+Hermitian iff every subsystem is Hermitian. The coupling drift and drives are
+assumed Hermitian (the typical closed-system case).
 """
 function default_algorithm(sys::QuantumSystem)
     return sys.hermitian ? MagnusAdapt4() : Tsit5()
+end
+
+function default_algorithm(sys::CompositeQuantumSystem)
+    return all(s -> s.hermitian, sys.subsystems) ? MagnusAdapt4() : Tsit5()
+end
+
+@testitem "default_algorithm — CompositeQuantumSystem dispatches via subsystems" begin
+    using OrdinaryDiffEqLinear: MagnusAdapt4
+    using OrdinaryDiffEqTsit5: Tsit5
+    using Piccolo.Quantum.QuantumSystems: default_algorithm
+
+    sys_h = QuantumSystem(PAULIS[:Z], [PAULIS[:X]], [(-1.0, 1.0)])
+    sys_nh = QuantumSystem(
+        PAULIS[:Z],
+        [PAULIS[:X]],
+        [(-1.0, 1.0)];
+        hermitian = false,
+    )
+
+    csys_h = CompositeQuantumSystem(
+        zeros(ComplexF64, 4, 4),
+        Matrix{ComplexF64}[],
+        [sys_h, sys_h],
+        Float64[],
+    )
+    csys_nh = CompositeQuantumSystem(
+        zeros(ComplexF64, 4, 4),
+        Matrix{ComplexF64}[],
+        [sys_h, sys_nh],
+        Float64[],
+    )
+
+    @test default_algorithm(csys_h) isa MagnusAdapt4
+    @test default_algorithm(csys_nh) isa Tsit5
 end
 
 # Abstract type and common interface

--- a/src/quantum/trajectories/_quantum_trajectories.jl
+++ b/src/quantum/trajectories/_quantum_trajectories.jl
@@ -64,12 +64,7 @@ end
     using Piccolo.Quantum.QuantumSystems: default_algorithm
 
     sys_h = QuantumSystem(PAULIS[:Z], [PAULIS[:X]], [(-1.0, 1.0)])
-    sys_nh = QuantumSystem(
-        PAULIS[:Z],
-        [PAULIS[:X]],
-        [(-1.0, 1.0)];
-        hermitian = false,
-    )
+    sys_nh = QuantumSystem(PAULIS[:Z], [PAULIS[:X]], [(-1.0, 1.0)]; hermitian = false)
 
     csys_h = CompositeQuantumSystem(
         zeros(ComplexF64, 4, 4),


### PR DESCRIPTION
## Summary
- Adds \`default_algorithm(::CompositeQuantumSystem)\` mirroring the \`QuantumSystem\` logic.
- Derives Hermiticity from \`sys.subsystems\` — \`MagnusAdapt4\` if all subsystems are Hermitian, else \`Tsit5\`.
- Imports \`CompositeQuantumSystem\` in \`_quantum_trajectories.jl\` so the method lives next to its sibling.

## Why
\`UnitaryTrajectory\` accepts \`::AbstractQuantumSystem\` but \`default_algorithm\` was only defined for \`::QuantumSystem\`. Any \`rollout!\` call inside \`sync_trajectory!\`/\`solve!\` on a \`CompositeQuantumSystem\` (e.g., a \`MultiTransmonSystem\`) hits \`MethodError: no method matching default_algorithm(::CompositeQuantumSystem)\`. This blocks every multi-transmon Stretto compile that doesn't pass an explicit \`algorithm\` kwarg.

The dispatch gap is internal to Piccolo's own type hierarchy (one Piccolo type accepted at the entry, another required by the implementation), so the fix belongs here.

## Test plan
- [x] New testitem \`default_algorithm — CompositeQuantumSystem dispatches via subsystems\` covers both Hermitian and non-Hermitian subsystem mixes.
- [ ] CI green on Julia 1.10 / 1.11 / 1.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)