### PR TITLE
style: fix format drift in spline/smooth_pulse_problem

### DIFF
--- a/src/control/templates/smooth_pulse_problem.jl
+++ b/src/control/templates/smooth_pulse_problem.jl
@@ -135,7 +135,9 @@ function SmoothPulseProblem(
     free_phase::Bool = false,
     initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     state_leakage_indices::Union{
-        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+        Nothing,
+        AbstractVector{Int},
+        AbstractVector{<:AbstractVector{Int}},
     } = nothing,
 )
     if piccolo_options.verbose
@@ -249,7 +251,11 @@ function SmoothPulseProblem(
 
     # Add optional Piccolo constraints and objectives
     J += _apply_piccolo_options(
-        qtraj, piccolo_options, constraints, traj_smooth, state_sym;
+        qtraj,
+        piccolo_options,
+        constraints,
+        traj_smooth,
+        state_sym;
         state_leakage_indices = state_leakage_indices,
     )
 
@@ -357,7 +363,9 @@ function SmoothPulseProblem(
     initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     coherent::Bool = true,
     state_leakage_indices::Union{
-        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+        Nothing,
+        AbstractVector{Int},
+        AbstractVector{<:AbstractVector{Int}},
     } = nothing,
 )
     if piccolo_options.verbose
@@ -436,7 +444,11 @@ function SmoothPulseProblem(
 
     # Apply piccolo options for each state
     J += _apply_piccolo_options(
-        qtraj, piccolo_options, constraints, traj_smooth, snames;
+        qtraj,
+        piccolo_options,
+        constraints,
+        traj_smooth,
+        snames;
         state_leakage_indices = state_leakage_indices,
     )
 
@@ -636,7 +648,9 @@ function _apply_piccolo_options(
     traj::NamedTrajectory,
     snames::Vector{Symbol};
     state_leakage_indices::Union{
-        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+        Nothing,
+        AbstractVector{Int},
+        AbstractVector{<:AbstractVector{Int}},
     } = nothing,
 )
     # Resolve leakage indices: user override > auto-derived from goals.
@@ -644,7 +658,7 @@ function _apply_piccolo_options(
     # one per state.
     leakage_indices = if state_leakage_indices !== nothing
         state_leakage_indices isa AbstractVector{Int} ?
-            fill(state_leakage_indices, length(snames)) : state_leakage_indices
+        fill(state_leakage_indices, length(snames)) : state_leakage_indices
     elseif piccolo_options.leakage_constraint
         # Auto-derived: computational subspace = union of nonzero goal indices,
         # leakage = everything else (in isomorphic representation)

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -97,7 +97,9 @@ function SplinePulseProblem(
     subsystem_levels::Union{Nothing,Vector{Int}} = nothing,
     initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     state_leakage_indices::Union{
-        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+        Nothing,
+        AbstractVector{Int},
+        AbstractVector{<:AbstractVector{Int}},
     } = nothing,
 )
     sys = get_system(qtraj)
@@ -236,7 +238,11 @@ function SplinePulseProblem(
 
     # Apply piccolo options
     J += _apply_piccolo_options(
-        qtraj, piccolo_options, constraints, traj, state_sym;
+        qtraj,
+        piccolo_options,
+        constraints,
+        traj,
+        state_sym;
         state_leakage_indices = state_leakage_indices,
     )
 
@@ -318,7 +324,9 @@ function SplinePulseProblem(
     initial_phases::Union{Nothing,Vector{Float64}} = nothing,
     coherent::Bool = true,
     state_leakage_indices::Union{
-        Nothing,AbstractVector{Int},AbstractVector{<:AbstractVector{Int}},
+        Nothing,
+        AbstractVector{Int},
+        AbstractVector{<:AbstractVector{Int}},
     } = nothing,
 )
     sys = get_system(qtraj)
@@ -453,7 +461,11 @@ function SplinePulseProblem(
 
     # Apply piccolo options for each state
     J += _apply_piccolo_options(
-        qtraj, piccolo_options, constraints, traj, snames;
+        qtraj,
+        piccolo_options,
+        constraints,
+        traj,
+        snames;
         state_leakage_indices = state_leakage_indices,
     )
 
@@ -727,8 +739,10 @@ end
     # must still error per the existing contract — there is no goal-derived
     # leakage geometry for a single ket.
     @test_throws ArgumentError SplinePulseProblem(
-        qtraj, N;
-        Q = 100.0, R = 1e-2,
+        qtraj,
+        N;
+        Q = 100.0,
+        R = 1e-2,
         piccolo_options = PiccoloOptions(
             leakage_constraint = true,
             leakage_constraint_value = 1e-3,
@@ -740,8 +754,10 @@ end
     # is appended to the problem's constraints.
     # iso_ket = [Re(ψ); Im(ψ)] in length-6, so |2⟩ leakage = indices [3, 6].
     qcp = SplinePulseProblem(
-        qtraj, N;
-        Q = 100.0, R = 1e-2,
+        qtraj,
+        N;
+        Q = 100.0,
+        R = 1e-2,
         piccolo_options = PiccoloOptions(
             leakage_constraint = true,
             leakage_constraint_value = 1e-3,


### PR DESCRIPTION
## Summary
Pure JuliaFormatter pass on \`src/control/templates/{smooth,spline}_pulse_problem.jl\`. Fixes the failing Formatter check on main (broken since commit on 2026-04-29).

## Why
Formatter has been failing on main for a day, blocking all PR merges that include those files via base. This PR fixes it standalone so subsequent feature PRs can merge cleanly.

## Test plan
- [x] No behavioral changes (formatter-only)
- [ ] CI Formatter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)