### PR TITLE
feat: add calibration_targets kwarg to pulse problem templates

### DIFF
--- a/src/control/templates/_problem_templates.jl
+++ b/src/control/templates/_problem_templates.jl
@@ -227,6 +227,45 @@ function add_global_bounds_constraints!(
     end
 end
 
+"""
+    apply_calibration_targets!(constraints, calibration_targets, traj; verbose=false)
+
+For each global variable name in `calibration_targets`, pin it at its current
+value in `traj.global_data` via `fix_global_variable!`. Removes any existing
+`GlobalBoundsConstraint`/`GlobalEqualityConstraint` on the name to avoid MOI
+conflicts (so calling sites can pass `global_bounds` and `calibration_targets`
+together — the latter wins, which is the intended semantics).
+
+This implements the "calibration target" semantics: a global declared here is
+a knob managed by an external calibration step, not a free NLP variable. It is
+held at nominal during the QCP solve so the optimizer cannot drift it as a slack
+variable. Downstream tools (e.g. QILC) selectively unpin individual targets at
+their own discretion.
+
+Modifies `constraints` in place. No-op when `calibration_targets` is empty.
+"""
+function apply_calibration_targets!(
+    constraints::AbstractVector{<:AbstractConstraint},
+    calibration_targets::Vector{Symbol},
+    traj::NamedTrajectory;
+    verbose::Bool = false,
+)
+    isempty(calibration_targets) && return
+    for name in calibration_targets
+        if !haskey(traj.global_components, name)
+            error(
+                "calibration_targets entry :$name not found in trajectory globals. " *
+                "Available: $(keys(traj.global_components))",
+            )
+        end
+        value = collect(Float64, traj.global_data[traj.global_components[name]])
+        fix_global_variable!(constraints, name, value)
+        if verbose
+            println("    pinned :$name as calibration_target at value $value")
+        end
+    end
+end
+
 @testitem "add_global_bounds_constraints! helper function" begin
     using NamedTrajectories
     using DirectTrajOpt
@@ -282,6 +321,72 @@ end
     constraints6 = AbstractConstraint[]
     add_global_bounds_constraints!(constraints6, Dict(:δ => 0.5), traj; verbose = true)
     @test length(constraints6) == 1
+end
+
+@testitem "apply_calibration_targets! pins globals at nominal" begin
+    using NamedTrajectories
+    using DirectTrajOpt
+    using Piccolo.Control.ProblemTemplates:
+        apply_calibration_targets!, add_global_bounds_constraints!
+
+    N = 5
+    traj = NamedTrajectory(
+        (x = rand(2, N), u = rand(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+        global_data = [0.7, 1.2, 0.3],
+        global_components = (a = 1:1, b = 2:2, c = 3:3),
+    )
+
+    # Test 1: empty → no-op
+    constraints = AbstractConstraint[]
+    apply_calibration_targets!(constraints, Symbol[], traj)
+    @test isempty(constraints)
+
+    # Test 2: pin :b at its nominal value 1.2
+    apply_calibration_targets!(constraints, [:b], traj)
+    eq_cons = filter(
+        c -> c isa EqualityConstraint && c.var_names == :b && c.is_global,
+        constraints,
+    )
+    @test length(eq_cons) == 1
+    @test eq_cons[1].values ≈ [1.2]
+
+    # Test 3: replaces an existing GlobalBoundsConstraint on the same name
+    constraints2 = AbstractConstraint[]
+    add_global_bounds_constraints!(constraints2, Dict(:b => (-2.0, 2.0)), traj)
+    @test any(c -> c isa BoundsConstraint && c.var_names == :b && c.is_global, constraints2)
+    apply_calibration_targets!(constraints2, [:b], traj)
+    @test !any(
+        c -> c isa BoundsConstraint && c.var_names == :b && c.is_global,
+        constraints2,
+    )
+    @test count(
+        c -> c isa EqualityConstraint && c.var_names == :b && c.is_global,
+        constraints2,
+    ) == 1
+
+    # Test 4: error when name is not a global
+    constraints3 = AbstractConstraint[]
+    @test_throws ErrorException apply_calibration_targets!(
+        constraints3,
+        [:nonexistent],
+        traj,
+    )
+
+    # Test 5: pin multiple targets at once
+    constraints4 = AbstractConstraint[]
+    apply_calibration_targets!(constraints4, [:a, :c], traj)
+    eq_a = filter(
+        c -> c isa EqualityConstraint && c.var_names == :a && c.is_global,
+        constraints4,
+    )
+    eq_c = filter(
+        c -> c isa EqualityConstraint && c.var_names == :c && c.is_global,
+        constraints4,
+    )
+    @test length(eq_a) == 1 && eq_a[1].values ≈ [0.7]
+    @test length(eq_c) == 1 && eq_c[1].values ≈ [0.3]
 end
 
 @testitem "apply_piccolo_options! throws ArgumentError for missing leakage indices" begin

--- a/src/control/templates/bang_bang_pulse_problem.jl
+++ b/src/control/templates/bang_bang_pulse_problem.jl
@@ -27,6 +27,7 @@ At optimality, ``s = |du|``, giving the exact L1 norm.
 - `integrator::Union{Nothing, AbstractIntegrator, Vector{<:AbstractIntegrator}}=nothing`: Optional custom integrator(s). If not provided, uses BilinearIntegrator.
 - `global_names::Union{Nothing, Vector{Symbol}}=nothing`: Names of global variables to optimize. Requires a custom integrator.
 - `global_bounds::Union{Nothing, Dict{Symbol, Union{Float64, Tuple{Float64, Float64}}}}=nothing`: Bounds for global variables.
+- `calibration_targets::Vector{Symbol}=Symbol[]`: Names of globals declared as **calibration targets** — knobs an external calibration step manages, not free NLP variables. Each listed name is pinned at its nominal value via `GlobalEqualityConstraint` so the QCP solve cannot drift it as a slack variable. Default empty: globals stay free.
 - `du_bound::Float64=Inf`: Bound on discrete first derivative
 - `Δt_bounds::Union{Nothing, Tuple{Float64, Float64}}=nothing`: Timestep bounds
 - `Q::Float64=100.0`: Weight on infidelity/objective
@@ -59,6 +60,7 @@ function BangBangPulseProblem(
     integrator::Union{Nothing,AbstractIntegrator,Vector{<:AbstractIntegrator}} = nothing,
     global_names::Union{Nothing,Vector{Symbol}} = nothing,
     global_bounds::Union{Nothing,Dict{Symbol,<:Union{Float64,Tuple{Float64,Float64}}}} = nothing,
+    calibration_targets::Vector{Symbol} = Symbol[],
     du_bound::Float64 = Inf,
     Δt_bounds::Union{Nothing,Tuple{Float64,Float64}} = nothing,
     Q::Float64 = 100.0,
@@ -222,6 +224,13 @@ function BangBangPulseProblem(
         verbose = piccolo_options.verbose,
     )
 
+    apply_calibration_targets!(
+        all_constraints,
+        calibration_targets,
+        traj_bb;
+        verbose = piccolo_options.verbose,
+    )
+
     prob = DirectTrajOptProblem(traj_bb, J, integrators; constraints = all_constraints)
 
     return QuantumControlProblem(qtraj, prob)
@@ -245,6 +254,7 @@ function BangBangPulseProblem(
     integrator::Union{Nothing,AbstractIntegrator,Vector{<:AbstractIntegrator}} = nothing,
     global_names::Union{Nothing,Vector{Symbol}} = nothing,
     global_bounds::Union{Nothing,Dict{Symbol,<:Union{Float64,Tuple{Float64,Float64}}}} = nothing,
+    calibration_targets::Vector{Symbol} = Symbol[],
     du_bound::Float64 = Inf,
     Δt_bounds::Union{Nothing,Tuple{Float64,Float64}} = nothing,
     Q::Float64 = 100.0,
@@ -387,6 +397,13 @@ function BangBangPulseProblem(
     add_global_bounds_constraints!(
         all_constraints,
         global_bounds,
+        traj_bb;
+        verbose = piccolo_options.verbose,
+    )
+
+    apply_calibration_targets!(
+        all_constraints,
+        calibration_targets,
         traj_bb;
         verbose = piccolo_options.verbose,
     )

--- a/src/control/templates/smooth_pulse_problem.jl
+++ b/src/control/templates/smooth_pulse_problem.jl
@@ -85,6 +85,7 @@ The problem adds discrete derivative variables (du, ddu) that:
 - `integrator::Union{Nothing, AbstractIntegrator, Vector{<:AbstractIntegrator}}=nothing`: Optional custom integrator(s). If not provided, uses BilinearIntegrator (which does not support global variables). A custom integrator is required when `global_names` is specified.
 - `global_names::Union{Nothing, Vector{Symbol}}=nothing`: Names of global variables to optimize. Requires a custom integrator (e.g., HermitianExponentialIntegrator from Piccolissimo) that supports global variables.
 - `global_bounds::Union{Nothing, Dict{Symbol, Union{Float64, Tuple{Float64, Float64}}}}=nothing`: Bounds for global variables. Keys are variable names, values are either a scalar (symmetric bounds ±value) or a tuple (lower, upper).
+- `calibration_targets::Vector{Symbol}=Symbol[]`: Names of globals declared as **calibration targets** — knobs an external calibration step manages, not free NLP variables. Each listed name is pinned at its nominal value via `GlobalEqualityConstraint` so the QCP solve cannot drift it as a slack variable. Default empty: globals stay free.
 - `du_bound::Float64=Inf`: Bound on discrete first derivative (controls jump rate)
 - `ddu_bound::Float64=1.0`: Bound on discrete second derivative (controls acceleration)
 - `Q::Float64=100.0`: Weight on infidelity/objective
@@ -122,6 +123,7 @@ function SmoothPulseProblem(
     integrator::Union{Nothing,AbstractIntegrator,Vector{<:AbstractIntegrator}} = nothing,
     global_names::Union{Nothing,Vector{Symbol}} = nothing,
     global_bounds::Union{Nothing,Dict{Symbol,<:Union{Float64,Tuple{Float64,Float64}}}} = nothing,
+    calibration_targets::Vector{Symbol} = Symbol[],
     du_bound::Float64 = Inf,
     ddu_bound::Float64 = 1.0,
     Δt_bounds::Union{Nothing,Tuple{Float64,Float64}} = nothing,
@@ -284,6 +286,13 @@ function SmoothPulseProblem(
         verbose = piccolo_options.verbose,
     )
 
+    apply_calibration_targets!(
+        all_constraints,
+        calibration_targets,
+        traj_smooth;
+        verbose = piccolo_options.verbose,
+    )
+
     prob = DirectTrajOptProblem(traj_smooth, J, integrators; constraints = all_constraints)
 
     return QuantumControlProblem(qtraj, prob)
@@ -348,6 +357,7 @@ function SmoothPulseProblem(
     integrator::Union{Nothing,AbstractIntegrator,Vector{<:AbstractIntegrator}} = nothing,
     global_names::Union{Nothing,Vector{Symbol}} = nothing,
     global_bounds::Union{Nothing,Dict{Symbol,<:Union{Float64,Tuple{Float64,Float64}}}} = nothing,
+    calibration_targets::Vector{Symbol} = Symbol[],
     du_bound::Float64 = Inf,
     ddu_bound::Float64 = 1.0,
     Δt_bounds::Union{Nothing,Tuple{Float64,Float64}} = nothing,
@@ -490,6 +500,13 @@ function SmoothPulseProblem(
     add_global_bounds_constraints!(
         all_constraints,
         global_bounds,
+        traj_smooth;
+        verbose = piccolo_options.verbose,
+    )
+
+    apply_calibration_targets!(
+        all_constraints,
+        calibration_targets,
         traj_smooth;
         verbose = piccolo_options.verbose,
     )

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -45,6 +45,7 @@ Both pulse types always have `:du` components in the trajectory, simplifying int
 - `integrator::Union{Nothing, AbstractIntegrator, Vector{<:AbstractIntegrator}}=nothing`: Optional custom integrator(s). If not provided, uses `BilinearIntegrator` (which does not support global variables). A custom integrator is required when `global_names` is specified.
 - `global_names::Union{Nothing, Vector{Symbol}}=nothing`: Names of global variables to optimize. Requires a custom integrator (e.g., `SplineIntegrator` from Piccolissimo) that supports global variables.
 - `global_bounds::Union{Nothing, Dict{Symbol, Union{Float64, Tuple{Float64, Float64}}}}=nothing`: Bounds for global variables. Keys are variable names, values are either a scalar (symmetric bounds ±value) or a tuple (lower, upper).
+- `calibration_targets::Vector{Symbol}=Symbol[]`: Names of globals declared as **calibration targets** — knobs an external calibration step manages, not free NLP variables. Each listed name is pinned at its nominal value via `GlobalEqualityConstraint` so the QCP solve cannot drift it as a slack variable. Replaces any existing `GlobalBoundsConstraint` on the same name. Default empty: globals stay free.
 - `du_bound::Float64=Inf`: Uniform bound on derivative (slope) magnitude for all drives
 - `du_bounds::Union{Nothing, Vector{Float64}}=nothing`: Per-drive bounds on derivative magnitude (takes precedence over `du_bound`)
 - `Q::Float64=100.0`: Weight on infidelity/objective
@@ -84,6 +85,7 @@ function SplinePulseProblem(
     integrator::Union{Nothing,AbstractIntegrator,Vector{<:AbstractIntegrator}} = nothing,
     global_names::Union{Nothing,Vector{Symbol}} = nothing,
     global_bounds::Union{Nothing,Dict{Symbol,<:Union{Float64,Tuple{Float64,Float64}}}} = nothing,
+    calibration_targets::Vector{Symbol} = Symbol[],
     du_bound::Float64 = Inf,
     du_bounds::Union{Nothing,Vector{Float64}} = nothing,
     Δt_bounds::Union{Nothing,Tuple{Float64,Float64}} = nothing,
@@ -267,6 +269,15 @@ function SplinePulseProblem(
         verbose = piccolo_options.verbose,
     )
 
+    # Pin calibration targets at nominal — must run AFTER bounds, since
+    # apply_calibration_targets! removes any conflicting GlobalBoundsConstraint.
+    apply_calibration_targets!(
+        all_constraints,
+        calibration_targets,
+        traj;
+        verbose = piccolo_options.verbose,
+    )
+
     prob = DirectTrajOptProblem(traj, J, integrators; constraints = all_constraints)
 
     return QuantumControlProblem(qtraj, prob)
@@ -310,6 +321,7 @@ function SplinePulseProblem(
     parallel_backend::Symbol = :manual,  # :manual (default), :threads, :gpu
     global_names::Union{Nothing,Vector{Symbol}} = nothing,
     global_bounds::Union{Nothing,Dict{Symbol,<:Union{Float64,Tuple{Float64,Float64}}}} = nothing,
+    calibration_targets::Vector{Symbol} = Symbol[],
     du_bound::Float64 = Inf,
     du_bounds::Union{Nothing,Vector{Float64}} = nothing,
     Δt_bounds::Union{Nothing,Tuple{Float64,Float64}} = nothing,
@@ -486,6 +498,13 @@ function SplinePulseProblem(
     add_global_bounds_constraints!(
         all_constraints,
         global_bounds,
+        traj;
+        verbose = piccolo_options.verbose,
+    )
+
+    apply_calibration_targets!(
+        all_constraints,
+        calibration_targets,
         traj;
         verbose = piccolo_options.verbose,
     )


### PR DESCRIPTION
## Summary

Adds `calibration_targets::Vector{Symbol} = Symbol[]` to all six pulse-problem entrypoints (`SplinePulseProblem`, `SmoothPulseProblem`, `BangBangPulseProblem` × single + MultiKet variants). Each name listed is pinned at its nominal value via `fix_global_variable!` so the QCP solve cannot drift it as a slack variable.

This implements the **intent layer** that was previously missing: a global declared in `calibration_targets` is a knob managed by an external calibration step (e.g. QILC), not a free NLP variable.

## Background

Until this PR, listing a global in `global_names` made it a free NLP variable in the QCP — even when the user intended it to be held at nominal during the control solve and managed externally. The optimizer would silently drift that global as a slack variable, polluting any downstream calibration baseline. Documented in [Intonato.jl/docs/onboarding.md §\"Globals: how they're defined and what their lifecycle should be\"](https://github.com/harmoniqs/Intonato.jl/blob/main/docs/onboarding.md).

The new kwarg makes the intent explicit:

```julia
qcp = SplinePulseProblem(qtraj, N; integrator=integ,
    global_names = [:χ_scale, :K_q_scale, :drive_scale],
    global_bounds = Dict(...),
    calibration_targets = [:χ_scale, :K_q_scale, :drive_scale],  # held at nominal
)
```

Default empty preserves current free-global behavior — no breaking change.

## Implementation

- New helper `apply_calibration_targets!(constraints, calibration_targets, traj; verbose=false)` in `_problem_templates.jl` mirrors the style of `add_global_bounds_constraints!`.
- Called after `add_global_bounds_constraints!` in each template so `calibration_targets` correctly supersedes `global_bounds` (the equality replaces any bounds on the same name).
- Errors clearly when a target name isn't in `traj.global_components`.

## Depends on

[harmoniqs/DirectTrajOpt.jl#82](https://github.com/harmoniqs/DirectTrajOpt.jl/pull/82) — adds the public `fix_global_variable!` this PR depends on. **Do not merge until DTO #82 is merged and a release is cut.**

## Test plan

- [x] New testitem `apply_calibration_targets! pins globals at nominal` (in `_problem_templates.jl`):
  - empty / no-op
  - pin at nominal
  - replace pre-existing GlobalBoundsConstraint
  - error on unknown global
  - multi-target
- [x] Smoke test: SplinePulseProblem with and without `calibration_targets=[:ω]` constructs correctly; solve preserves pinned value to within 1e-12.
- [ ] Full Piccolo test suite (CI-only — local run timed out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)