### PR TITLE
fix(docs): use POSIX [[:space:]] in get_docs_utils.sh for BSD sed

### DIFF
--- a/docs/get_docs_utils.sh
+++ b/docs/get_docs_utils.sh
@@ -18,7 +18,10 @@ else
         exit 1
     fi
 
-    DOC_TEMPLATE_VERSION=$(grep -E '^\s*DOC_TEMPLATE_VERSION:' "$WORKFLOW_FILE" | sed -E 's/.*DOC_TEMPLATE_VERSION:\s*"([^"]+)".*/\1/')
+    # Use POSIX [[:space:]] instead of \s — \s is a GNU extension and is not
+    # honored by BSD grep/sed (macOS), which causes the full matched line
+    # (including any trailing comment) to leak into DOC_TEMPLATE_VERSION.
+    DOC_TEMPLATE_VERSION=$(grep -E '^[[:space:]]*DOC_TEMPLATE_VERSION:' "$WORKFLOW_FILE" | sed -E 's/.*DOC_TEMPLATE_VERSION:[[:space:]]*"([^"]+)".*/\1/')
 fi
 
 if [[ -z "$DOC_TEMPLATE_VERSION" ]]; then


### PR DESCRIPTION
## Summary
- Replace `\s` with POSIX `[[:space:]]` in the `grep -E`/`sed -E` patterns that extract `DOC_TEMPLATE_VERSION` from `.github/workflows/docs.yml`.

## Why
`\s` is a GNU extension and is not honored by macOS BSD `grep`/`sed`. On macOS, running `./docs/get_docs_utils.sh` with no argument leaks the entire matched line — including any trailing comment in `docs.yml` — into `DOC_TEMPLATE_VERSION`, which then crashes the inline `julia -e` invocation with a `ParseError`.

```
$ ./docs/get_docs_utils.sh
Grabbing PiccoloDocsTemplate at version       DOC_TEMPLATE_VERSION: "v0.7.1" # Change this to the specific tag version you want
ERROR: ParseError: # Error @ none:2:113
```

`[[:space:]]` is portable across BSD and GNU. Behavior on Linux CI is unchanged.

## Related
Sibling PRs landing the same one-line fix in our other Julia repos:
- harmoniqs/NamedTrajectories.jl#116
- harmoniqs/DirectTrajOpt.jl#84
- harmoniqs/Piccolissimo.jl#73

## Test plan
- [x] Verified macOS extracts `DOC_TEMPLATE_VERSION` cleanly.
- [ ] CI green on this branch (Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)