### PR TITLE
Release v1.13.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
-version = "1.12.1"
+version = "1.13.0"
 authors = ["Aaron Trowbridge <aaron@harmoniqs.co> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary
- Bump `Piccolo` version from 1.12.1 → 1.13.0

## Highlights since v1.12.0
- feat: thread `calibration_targets` through `SamplingProblem` (#185)
- feat: add `calibration_targets` kwarg to pulse problem templates (#178)
- feat(viz): publication-grade LaTeX labels + tighter leakage example; high-level `plot_pulse` overloads for `AbstractQuantumTrajectory` and `QuantumControlProblem` (#131)
- feat: expose `state_leakage_indices` for ket / density / multiket problems (#170)
- feat: `snap_to_knots=false` by default (#169)
- chore: SciMLBase v3 / OrdinaryDiffEq v7 update + shim interface tests (#168)
- chore(ci): retire CompatHelper, rely on Dependabot for Julia + Actions (#184)
- fix(docs): POSIX `[[:space:]]` in `get_docs_utils.sh` for BSD sed (#183)

## Test plan
- [ ] CI passes on Julia 1.10, 1.11, 1.12
- [ ] Docs build green
- [ ] Trigger JuliaRegistrator after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)