### PR TITLE
Release v1.14.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
-version = "1.13.0"
+version = "1.14.0"
 authors = ["Aaron Trowbridge <aaron@harmoniqs.co> and contributors"]
 
 [deps]
@@ -45,7 +45,7 @@ JLD2 = "0.6"
 LaTeXStrings = "1.4"
 LinearAlgebra = "1.10, 1.11, 1.12"
 Makie = "0.24"
-NamedTrajectories = "0.8"
+NamedTrajectories = "0.8, 0.9"
 OrdinaryDiffEqLinear = "1.10, 2"
 OrdinaryDiffEqTsit5 = "1.9, 2"
 ProgressMeter = "1.11"


### PR DESCRIPTION
## Summary
- Bump `Piccolo` version from 1.13.0 → 1.14.0
- Widen `NamedTrajectories` compat to `"0.8, 0.9"` (NamedTrajectories 0.9.0 is now registered)

## Highlights since v1.13.0
- feat: `save_pulse` / `load_pulse` JLD2-based persistence for `AbstractPulse` + saving/loading guide (#81)
- feat: mathematician-convention Lie algebra generators, physicist convention remains the default (#188)
- fix(trajectories): `default_algorithm` method for `CompositeQuantumSystem` (#176)
- fix: PR101 follow-up corrections (#179)

## Test plan
- [ ] Docs build green
- [ ] Formatter check passes
- [ ] At least one Julia CI job passes (1.10, 1.11, 1.12)
- [ ] After merge: trigger JuliaRegistrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)