### PR TITLE
Validate nonlinear drives with appended global parameters

### DIFF
--- a/src/quantum/systems/drives.jl
+++ b/src/quantum/systems/drives.jl
@@ -698,6 +698,46 @@ end
     @test_throws AssertionError validate_drive_hessian(d_wrong, 2)
 end
 
+@testitem "validate_drive: u_dim extending past n_drives (global params)" begin
+    # Regression: when global_params are appended, callers pass
+    # u_dim = n_drives + length(global_params) so coefficients that read into
+    # the global-parameter slots can be validated without BoundsError.
+    using Piccolo
+    using SparseArrays
+
+    H = sparse([0.0+0im 1.0+0im; 1.0+0im 0.0+0im])
+
+    # Coefficient reads u[3] — i.e. the appended global slot when n_drives = 2
+    # and one global parameter is present.
+    d_auto = NonlinearDrive(H, u -> u[1] * u[2] * u[3])
+    validate_drive_jacobian(d_auto, 3)  # must not BoundsError
+    validate_drive_hessian(d_auto, 3)
+
+    # Explicit jacobian + hessian agreeing with ForwardDiff across the full
+    # u_dim = 3 must pass.
+    d_correct = NonlinearDrive(
+        H,
+        u -> u[1] * u[2] * u[3],
+        (u, j) ->
+            j == 1 ? u[2] * u[3] : j == 2 ? u[1] * u[3] : j == 3 ? u[1] * u[2] : 0.0;
+        coeff_hess = (u, i, j) ->
+            (i == 1 && j == 2) || (i == 2 && j == 1) ? u[3] :
+            (i == 1 && j == 3) || (i == 3 && j == 1) ? u[2] :
+            (i == 2 && j == 3) || (i == 3 && j == 2) ? u[1] : 0.0,
+    )
+    validate_drive_jacobian(d_correct, 3)
+    validate_drive_hessian(d_correct, 3)
+
+    # An explicit jacobian wrong at j = 3 (the global slot) is still caught —
+    # the validator must check the extended range, not just 1:n_drives.
+    d_wrong_global = NonlinearDrive(
+        H,
+        u -> u[1] * u[2] * u[3],
+        (u, j) -> j == 1 ? u[2] * u[3] : j == 2 ? u[1] * u[3] : 0.0,  # wrong at j=3
+    )
+    @test_throws AssertionError validate_drive_jacobian(d_wrong_global, 3)
+end
+
 @testitem "G works on AbstractDrive types" begin
     using Piccolo
     using SparseArrays

--- a/src/quantum/systems/drives.jl
+++ b/src/quantum/systems/drives.jl
@@ -428,7 +428,7 @@ Isomorphisms.G(d::AbstractDrive) = Isomorphisms.G(drive_matrix(d))
 # ----------------------------------------------------------------------------- #
 
 """
-    validate_drive_jacobian(d::NonlinearDrive, n_controls::Int; atol=1e-6, n_samples=3)
+    validate_drive_jacobian(d::NonlinearDrive, u_dim::Int; atol=1e-6, n_samples=3)
 
 Spot-check the Jacobian of a `NonlinearDrive` against ForwardDiff at random control vectors.
 Throws an `AssertionError` if the user-provided Jacobian disagrees with the AD Jacobian.
@@ -438,14 +438,14 @@ terms, catching sign errors or off-by-one bugs early.
 """
 function validate_drive_jacobian(
     d::NonlinearDrive,
-    n_controls::Int;
+    u_dim::Int;
     atol::Float64 = 1e-6,
     n_samples::Int = 3,
 )
     for _ = 1:n_samples
-        u = randn(n_controls)
+        u = randn(u_dim)
         grad_ad = ForwardDiff.gradient(d.coeff, u)
-        for j = 1:n_controls
+        for j = 1:u_dim
             user_val = d.coeff_jac(u, j)
             @assert abs(user_val - grad_ad[j]) < atol (
                 "NonlinearDrive Jacobian mismatch at u=$u, j=$j: " *
@@ -456,21 +456,21 @@ function validate_drive_jacobian(
 end
 
 """
-    validate_drive_hessian(d::NonlinearDrive, n_controls::Int; atol=1e-6, n_samples=3)
+    validate_drive_hessian(d::NonlinearDrive, u_dim::Int; atol=1e-6, n_samples=3)
 
 Spot-check the Hessian of a `NonlinearDrive` against ForwardDiff at random control vectors.
 Throws an `AssertionError` if the user-provided Hessian disagrees with the AD Hessian.
 """
 function validate_drive_hessian(
     d::NonlinearDrive,
-    n_controls::Int;
+    u_dim::Int;
     atol::Float64 = 1e-6,
     n_samples::Int = 3,
 )
     for _ = 1:n_samples
-        u = randn(n_controls)
+        u = randn(u_dim)
         hess_ad = ForwardDiff.hessian(d.coeff, u)
-        for i = 1:n_controls, j = i:n_controls
+        for i = 1:u_dim, j = i:u_dim
             user_val = d.coeff_hess(u, i, j)
             @assert abs(user_val - hess_ad[i, j]) < atol (
                 "NonlinearDrive Hessian mismatch at u=$u, (i,j)=($i,$j): " *

--- a/src/quantum/systems/open_quantum_systems.jl
+++ b/src/quantum/systems/open_quantum_systems.jl
@@ -300,7 +300,7 @@ function OpenQuantumSystem(
     for d in drives
         base = d isa ModulatedDrive ? d.base : d
         if base isa NonlinearDrive
-            validate_drive_jacobian(base, n_drives)
+            validate_drive_jacobian(base, n_drives + length(global_params))
         end
     end
 

--- a/src/quantum/systems/quantum_systems.jl
+++ b/src/quantum/systems/quantum_systems.jl
@@ -407,7 +407,7 @@ function QuantumSystem(
     for d in drives
         base = d isa ModulatedDrive ? d.base : d
         if base isa NonlinearDrive
-            validate_drive_jacobian(base, n_drives)
+            validate_drive_jacobian(base, n_drives + length(global_params))
         end
     end
 
@@ -679,7 +679,7 @@ function QuantumSystem(
     # Validate NonlinearDrive Jacobians
     for d in drives
         if d isa NonlinearDrive
-            validate_drive_jacobian(d, n_drives)
+            validate_drive_jacobian(d, n_drives + length(global_params))
         end
     end
 

--- a/src/quantum/systems/quantum_systems.jl
+++ b/src/quantum/systems/quantum_systems.jl
@@ -962,6 +962,22 @@ end
     @test norm(H_result - H_expected) < 1e-10
 end
 
+@testitem "QuantumSystem: NonlinearDrive reading appended global params" begin
+    # Regression: validator must accept drives whose coefficient reads into
+    # the appended global-parameter slots. The typed-drives constructor passes
+    # n_drives + length(global_params) into validate_drive_jacobian.
+    using Piccolo
+    using SparseArrays
+
+    H = sparse([0.0+0im 1.0+0im; 1.0+0im 0.0+0im])
+    # Coefficient reads u[3] = the single appended global parameter.
+    d = NonlinearDrive(H, u -> u[1] * u[2] * u[3])
+
+    sys = QuantumSystem(H, [d], [(0.0, 1.0), (0.0, 1.0)]; global_params = (g1 = 0.5,))
+    @test sys.n_drives == 2
+    @test length(sys.global_params) == 1
+end
+
 @testitem "QuantumSystem Pair-based modulation constructors" begin
     using Piccolo
     using SparseArrays


### PR DESCRIPTION
## Summary

Fix nonlinear-drive validation for systems that append global parameters to the optimization vector.

`NonlinearDrive` coefficients can depend on the full `u = [controls..., globals...]` vector, but the validation logic in `Piccolo` was only checking the first `n_drives` entries. That causes validation to fail for valid drives that reference appended global parameters.

## Problem

When constructing a `QuantumSystem` or `OpenQuantumSystem` with `global_params`, the effective input to a drive coefficient is longer than the physical control dimension.

Before this change:
- `validate_drive_jacobian` and `validate_drive_hessian` sampled vectors of length `n_drives`
- constructor-side validation passed only `n_drives`
- any `NonlinearDrive` that referenced appended globals could throw bounds errors during validation

This showed up for drives with coefficients like:
- `u[i] * u[j] * u[global_idx]`

where `global_idx > n_drives`.

## Changes

- Rename the validator argument from `n_controls` to `u_dim` to reflect its real meaning
- Update `validate_drive_jacobian` to sample and validate over the full `u_dim`
- Update `validate_drive_hessian` the same way
- Pass `n_drives + length(global_params)` into nonlinear-drive validation from:
  - `QuantumSystem`
  - the typed-drive `QuantumSystem` constructor path
  - `OpenQuantumSystem`


## Notes

This change only affects validation behavior. It does not change the runtime definition of the Hamiltonian or drive coefficients themselves.
