### PR TITLE
Add pulse evolution animations

### DIFF
--- a/docs/literate/guides/visualization.jl
+++ b/docs/literate/guides/visualization.jl
@@ -148,6 +148,47 @@ fig = plot_pulse_IQ(pulse_iq; title = "IQ view (Ω, α)")
 
 fig = plot_pulse_phases(pulse_iq; title = "Polar view (|·|, ∠·)")
 
+# ## Pulse Animations
+#
+# `animate_pulse` shows a pulse drawing itself over time. Use `mode = :record`
+# with a Makie backend that can record frames when you want an `.mp4` or `.gif`
+# for a website or notebook; use `mode = :inline` with GLMakie for a looping
+# interactive preview.
+
+animation_pulse = GaussianPulse([0.8, 0.45], T / 6, T)
+
+fig = animate_pulse(
+    animation_pulse;
+    mode = :inline, # use mode = :record and filename = "pulse_evolution.mp4" to export
+    fps = 24,
+    n_samples = 120,
+    labels = ["Ω_x", "Ω_y"],
+    title = "Gaussian control pulse",
+)
+
+# You can add state or population traces underneath the controls by passing a
+# matrix whose rows are populations and whose columns are time samples. This is
+# useful for showing the control pulse and the quantum response in the same
+# animation.
+
+population_times = collect(range(0, T, length = 120))
+population_trace = vcat(
+    reshape(cos.(π .* population_times ./ (2T)) .^ 2, 1, :),
+    reshape(sin.(π .* population_times ./ (2T)) .^ 2, 1, :),
+)
+
+fig = animate_pulse(
+    animation_pulse;
+    mode = :inline, # use mode = :record and filename = "pulse_with_populations.mp4" to export
+    fps = 24,
+    n_samples = 120,
+    labels = ["Ω_x", "Ω_y"],
+    populations = population_trace,
+    population_times,
+    population_labels = ["|0⟩", "|1⟩"],
+    title = "Pulse with population evolution",
+)
+
 # ## Custom Plotting
 #
 # For full control, extract trajectory data and use Makie directly.

--- a/ext/PiccoloMakieExt.jl
+++ b/ext/PiccoloMakieExt.jl
@@ -106,6 +106,252 @@ function Piccolo.animate_name(
 end
 
 
+"""
+    animate_pulse(
+        pulse::AbstractPulse;
+        fps::Int = 24,
+        mode::Symbol = :inline,
+        filename::String = "pulse_animation.mp4",
+        n_samples::Int = 240,
+        labels = nothing,
+        populations = nothing,
+        population_times = nothing,
+        population_labels = nothing,
+        title::AbstractString = "Pulse evolution"
+    )
+
+Animate a pulse being drawn over time, with optional population/state traces in
+a second panel. The pulse is sampled uniformly so this works with every
+`AbstractPulse` implementation.
+"""
+function Piccolo.animate_pulse(
+    pulse::Piccolo.AbstractPulse;
+    fps::Int = 24,
+    mode::Symbol = :inline,
+    filename::String = "pulse_animation.mp4",
+    n_samples::Int = 240,
+    labels = nothing,
+    populations = nothing,
+    population_times = nothing,
+    population_labels = nothing,
+    title::AbstractString = "Pulse evolution",
+)
+    n_samples >= 2 || throw(ArgumentError("n_samples must be at least 2."))
+
+    pulse_times = collect(range(0.0, Piccolo.duration(pulse), length = n_samples))
+    pulse_values = Piccolo.sample(pulse, pulse_times)
+    n_drive = Piccolo.n_drives(pulse)
+
+    size(pulse_values, 1) == n_drive ||
+        throw(ArgumentError("sample(pulse, times) must return one row per drive."))
+    size(pulse_values, 2) == n_samples ||
+        throw(ArgumentError("sample(pulse, times) must return one column per sample."))
+
+    drive_labels = if isnothing(labels)
+        _pulse_drive_labels(pulse, n_drive)
+    else
+        length(labels) == n_drive ||
+            throw(ArgumentError("labels must contain one entry per pulse drive."))
+        collect(labels)
+    end
+
+    has_populations = !isnothing(populations)
+    population_values = nothing
+    pop_times = nothing
+    pop_labels = nothing
+    n_pop = 0
+
+    if has_populations
+        population_values = Matrix(populations)
+        size(population_values, 2) >= 2 ||
+            throw(ArgumentError("populations must have at least two time samples."))
+
+        n_pop = size(population_values, 1)
+        pop_times =
+            isnothing(population_times) ?
+            collect(
+                range(
+                    pulse_times[1],
+                    pulse_times[end],
+                    length = size(population_values, 2),
+                ),
+            ) : collect(population_times)
+
+        length(pop_times) == size(population_values, 2) || throw(
+            ArgumentError("population_times must match the number of population samples."),
+        )
+
+        pop_labels = if isnothing(population_labels)
+            ["Population $i" for i = 1:n_pop]
+        else
+            length(population_labels) == n_pop || throw(
+                ArgumentError(
+                    "population_labels must contain one entry per population row.",
+                ),
+            )
+            collect(population_labels)
+        end
+    end
+
+    fig = Figure(size = has_populations ? (900, 620) : (900, 380))
+    pulse_axis = Axis(
+        fig[1, 1],
+        xlabel = has_populations ? "" : "Time",
+        xticklabelsvisible = !has_populations,
+        ylabel = "Amplitude",
+        title = title,
+        titlealign = :left,
+    )
+
+    pulse_y_min, pulse_y_max = _padded_extrema(pulse_values)
+    xlims!(pulse_axis, pulse_times[1], pulse_times[end])
+    ylims!(pulse_axis, pulse_y_min, pulse_y_max)
+    hlines!(pulse_axis, [0.0], color = (:gray, 0.45), linestyle = :dash, linewidth = 1)
+
+    colors = Makie.wong_colors()
+    pulse_xs = [Observable(pulse_times[1:1]) for _ = 1:n_drive]
+    pulse_ys = [Observable(vec(pulse_values[i, 1:1])) for i = 1:n_drive]
+    marker_xs = [Observable([pulse_times[1]]) for _ = 1:n_drive]
+    marker_ys = [Observable([pulse_values[i, 1]]) for i = 1:n_drive]
+
+    for i = 1:n_drive
+        color = colors[mod1(i, length(colors))]
+        lines!(
+            pulse_axis,
+            pulse_times,
+            vec(pulse_values[i, :]);
+            color = (color, 0.18),
+            linewidth = 1,
+        )
+        lines!(
+            pulse_axis,
+            pulse_xs[i],
+            pulse_ys[i];
+            color,
+            linewidth = 3,
+            label = string(drive_labels[i]),
+        )
+        scatter!(
+            pulse_axis,
+            marker_xs[i],
+            marker_ys[i];
+            color,
+            markersize = 10,
+            strokewidth = 1,
+            strokecolor = :white,
+        )
+    end
+    axislegend(pulse_axis, position = :rt)
+
+    population_xs = Observable[]
+    population_ys = Observable[]
+    pop_marker_xs = Observable[]
+    pop_marker_ys = Observable[]
+    population_axis = nothing
+
+    if has_populations
+        population_axis = Axis(
+            fig[2, 1],
+            xlabel = "Time",
+            ylabel = "Population",
+            title = "State populations",
+            titlealign = :left,
+        )
+        pop_y_min, pop_y_max = _padded_extrema(population_values)
+        xlims!(population_axis, pop_times[1], pop_times[end])
+        ylims!(population_axis, pop_y_min, pop_y_max)
+
+        population_xs = [Observable(pop_times[1:1]) for _ = 1:n_pop]
+        population_ys = [Observable(vec(population_values[i, 1:1])) for i = 1:n_pop]
+        pop_marker_xs = [Observable([pop_times[1]]) for _ = 1:n_pop]
+        pop_marker_ys = [Observable([population_values[i, 1]]) for i = 1:n_pop]
+
+        for i = 1:n_pop
+            color = colors[mod1(i + n_drive, length(colors))]
+            lines!(
+                population_axis,
+                pop_times,
+                vec(population_values[i, :]);
+                color = (color, 0.18),
+                linewidth = 1,
+            )
+            lines!(
+                population_axis,
+                population_xs[i],
+                population_ys[i];
+                color,
+                linewidth = 3,
+                label = string(pop_labels[i]),
+            )
+            scatter!(
+                population_axis,
+                pop_marker_xs[i],
+                pop_marker_ys[i];
+                color,
+                markersize = 9,
+                strokewidth = 1,
+                strokecolor = :white,
+            )
+        end
+        axislegend(population_axis, position = :rt)
+        rowgap!(fig.layout, 1, Relative(0.06))
+    end
+
+    function update_frame!(i)
+        for drive_i = 1:n_drive
+            pulse_xs[drive_i][] = pulse_times[1:i]
+            pulse_ys[drive_i][] = vec(pulse_values[drive_i, 1:i])
+            marker_xs[drive_i][] = [pulse_times[i]]
+            marker_ys[drive_i][] = [pulse_values[drive_i, i]]
+        end
+
+        if has_populations
+            pop_i = clamp(
+                round(Int, 1 + (i - 1) * (length(pop_times) - 1) / (n_samples - 1)),
+                1,
+                length(pop_times),
+            )
+            for state_i = 1:n_pop
+                population_xs[state_i][] = pop_times[1:pop_i]
+                population_ys[state_i][] = vec(population_values[state_i, 1:pop_i])
+                pop_marker_xs[state_i][] = [pop_times[pop_i]]
+                pop_marker_ys[state_i][] = [population_values[state_i, pop_i]]
+            end
+        end
+    end
+
+    return Piccolo.animate_figure(
+        fig,
+        1:n_samples,
+        update_frame!,
+        mode = mode,
+        fps = fps,
+        filename = filename,
+    )
+end
+
+
+function _padded_extrema(values)
+    lo, hi = extrema(values)
+    if lo == hi
+        pad = max(abs(lo), 1.0) * 0.1
+    else
+        pad = 0.08 * (hi - lo)
+    end
+    return lo - pad, hi + pad
+end
+
+
+function _pulse_drive_labels(pulse, n_drive::Int)
+    base = try
+        string(Piccolo.drive_name(pulse))
+    catch
+        "Drive"
+    end
+    return [base == "Drive" ? "Drive $i" : "$(base)_$i" for i = 1:n_drive]
+end
+
+
 @testitem "Test animate_name for NamedTrajectory" begin
     using QuantumToolbox
     using NamedTrajectories
@@ -118,6 +364,27 @@ end
     traj = NamedTrajectory(comps)
 
     fig = animate_name(traj, :ψ̃, mode = :inline, fps = 10)
+    @test fig isa Figure
+end
+
+
+@testitem "Test animate_pulse for AbstractPulse" begin
+    using CairoMakie
+
+    pulse = GaussianPulse([1.0, 0.5], 0.2, 1.0)
+    populations = [
+        range(1.0, 0.0, length = 12)';
+        range(0.0, 1.0, length = 12)';
+    ]
+
+    fig = animate_pulse(
+        pulse;
+        mode = :inline,
+        fps = 10,
+        n_samples = 12,
+        populations,
+        population_labels = ["|0>", "|1>"],
+    )
     @test fig isa Figure
 end
 

--- a/src/visualizations/animations.jl
+++ b/src/visualizations/animations.jl
@@ -2,9 +2,12 @@ module AnimatedPlots
 
 export animate_figure
 export animate_name
+export animate_pulse
 
 function animate_figure end
 
 function animate_name end
+
+function animate_pulse end
 
 end


### PR DESCRIPTION
Closes #59.

## Summary
- adds `animate_pulse` as a Makie-backed visualization API for all `AbstractPulse` types
- supports optional population/state traces below the pulse animation
- documents pulse-only and pulse-plus-population examples in the visualization guide

## Validation
- `git diff --check`

Note: I could not run the Julia test suite locally because Julia is not installed in this environment. I will follow up on CI results.