### PR TITLE
ci: shard testitem runs across 4 parallel jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - shard ${{ matrix.shard }}/4 - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -28,8 +28,17 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
+        shard:
+          - '1'
+          - '2'
+          - '3'
+          - '4'
     env:
       PYTHON: ""
+      # Distribute @testitem blocks across `shard` parallel CI jobs.
+      # Filter logic lives in test/runtests.jl.
+      TEST_SHARD: ${{ matrix.shard }}
+      TOTAL_SHARDS: '4'
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,16 @@
 using TestItemRunner
 
-@run_package_tests
+# CI matrix shards the testitems across N jobs that run in parallel.
+# Locally / when unset, run everything (TOTAL_SHARDS=1).
+const TEST_SHARD    = parse(Int, get(ENV, "TEST_SHARD",    "1"))
+const TOTAL_SHARDS  = parse(Int, get(ENV, "TOTAL_SHARDS",  "1"))
+
+if TOTAL_SHARDS == 1
+    @run_package_tests
+else
+    # Stable assignment by (filename, name) hash. Same Julia version + same
+    # testitem set ⇒ same shard, so coverage is identical across runs in a
+    # single CI invocation.
+    @run_package_tests filter = ti ->
+        mod(hash((ti.filename, ti.name)), TOTAL_SHARDS) == TEST_SHARD - 1
+end


### PR DESCRIPTION
## Summary

Cuts wallclock CI time by sharding `@run_package_tests` across 4 parallel GitHub matrix jobs. Each job runs ~1/4 of the discovered testitems, selected by a stable hash of `(filename, name)`.

- `test/runtests.jl`: respects `TEST_SHARD` / `TOTAL_SHARDS` env vars. When unset (local `Pkg.test`, REPL, VS Code), behavior is unchanged — runs every testitem.
- `.github/workflows/CI.yml`: adds `shard: ['1','2','3','4']` to the matrix, sets `TOTAL_SHARDS=4`.

Expected impact: ~3x wallclock speedup once Julia precompile (the constant overhead per job) is amortized. The trade-off is more CI minutes total since each shard pays Julia startup separately. We can knock that down later with `julia-actions/cache` hits.

## Context

This is the "phase 1" of the testing parallelism discussion (cf. the Julia community thread on `ReTestItems.jl` / `ParallelTestRunner.jl`):

- **Why not ReTestItems?** It requires test files to contain ONLY `@testitem` / `@testsetup` blocks. Our 335 testitems live inline in `src/**/*.jl` alongside regular code, which fails its discovery (`Test files must only include @testitem and @testsetup calls`). Migrating would mean relocating every testitem out of src/ — a big refactor that's worth doing eventually but not gated on this CI win.
- **Why not ParallelTestRunner?** Parallelizes at the file level (one Julia process per file in `test/`). With our inline pattern there's only one logical "file" (`test/runtests.jl`), so file-level parallelism gives us nothing.
- **What we did instead.** Sharding via `@run_package_tests filter=...` — uses TestItemRunner's existing filter hook to pick the subset for each shard. Zero new dependencies.

## Follow-ups (out of scope)

- [ ] Migrate `@testitem` blocks from `src/` into `test/**/*_test.jl` and adopt ReTestItems for in-process testitem-level parallelism (jar's point in the slack thread: `ntestfiles < ncores < ntestitems` makes this strictly better than file-level).
- [ ] Per-shard coverage merging (codecov should already handle multi-upload).

## Test plan

- [ ] CI runs all 4 shards green on this PR
- [ ] Sum of testitems across shards equals the unsharded count (sanity check before relying on this)
- [ ] Local `Pkg.test("Piccolo")` still runs everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)