### PR TITLE
ci: gate JET correctness analysis to Julia 1.12.x only

### DIFF
--- a/test/jet.jl
+++ b/test/jet.jl
@@ -1,12 +1,14 @@
-# JET integrates tightly with the Julia compiler and is gated to v1.12 only.
+# JET integrates tightly with the Julia compiler and is gated to v1.12.x only.
 # Older Julia ships older JET (0.9.x) which can't analyze the current Piccolo
-# source. Don't relax this gate.
+# source. On 1.13+ (nightly / pre) the compiler shifts faster than JET can
+# track, so findings are noisy and unactionable until JET catches up.
+# Don't widen this gate.
 #
 # Performance analysis (type instabilities / runtime dispatch) — run manually:
 #     julia --project=. -e 'using Piccolo, JET; JET.@report_opt rollout(...)'
 
 @testitem "JET correctness analysis" tags=[:jet] begin
-    if VERSION >= v"1.12"
+    if v"1.12" <= VERSION < v"1.13"
         using JET, Piccolo
         # Remaining finding: `EnsembleSplineIntegrator` is referenced inside
         # `SplinePulseProblem(...)` when `integrator_type = :ensemble`, but no method
@@ -15,7 +17,7 @@
         # ensemble-integrator path is either deleted or reified as an extension.
         JET.test_package(Piccolo; target_modules = (Piccolo,), broken = true)
     else
-        @info "Skipping JET correctness analysis on Julia $VERSION (requires >= 1.12)"
+        @info "Skipping JET correctness analysis on Julia $VERSION (gated to 1.12.x)"
         @test true
     end
 end


### PR DESCRIPTION
## Summary
- JET 0.10+ is tightly coupled to the Julia compiler; on 1.13-pre (nightly) the compiler shifts faster than JET can track, surfacing noisy/unactionable findings.
- Tighten the gate in `test/jet.jl` from `VERSION >= v"1.12"` to `v"1.12" <= VERSION < v"1.13"`, so JET runs on 1.12.x and is muted on 1.13 nightly until JET catches up.
- Updated the rationale comment and skip-info message to reflect the new upper bound.
- The `broken = true` annotation on the remaining `EnsembleSplineIntegrator` finding is preserved.

## Test plan
- [ ] Nightly CI no longer attempts to run JET analysis
- [ ] CI on 1.12 still runs the JET testitem (with the existing `broken = true` finding)

Companion PRs:
- harmoniqs/NamedTrajectories.jl#129
- harmoniqs/DirectTrajOpt.jl#94

🤖 Generated with [Claude Code](https://claude.com/claude-code)