### PR TITLE
perf(systems): parametric eltype for H_drives — type-stable per-subst…

### DIFF
--- a/src/quantum/systems/composite_quantum_systems.jl
+++ b/src/quantum/systems/composite_quantum_systems.jl
@@ -35,14 +35,16 @@ H_coupling = 0.1 * kron(PAULIS[:Z], PAULIS[:Z])
 csys = CompositeQuantumSystem(H_coupling, [sys1, sys2], Float64[])
 ```
 """
-struct CompositeQuantumSystem{F1<:Function,F2<:Function} <: AbstractQuantumSystem
+struct CompositeQuantumSystem{F1<:Function,F2<:Function,DD<:AbstractVector{<:AbstractDrive}} <: AbstractQuantumSystem
     H::F1
     G::F2
     H_drift::SparseMatrixCSC{ComplexF64,Int}
     # Parity with QuantumSystem: drives are AbstractDrive, not raw matrices,
     # so Piccolissimo's SplineIntegrator can call dynamics_operator(::AbstractDrive)
-    # on each entry.
-    H_drives::Vector{AbstractDrive}
+    # on each entry. Parametric `DD` preserves the concrete eltype (e.g.
+    # Vector{LinearDrive} or Vector{Union{LinearDrive,NonlinearDrive}}) for
+    # type-stable iteration in hot per-substep RHS loops.
+    H_drives::DD
     drive_bounds::Vector{Tuple{Float64,Float64}}
     n_drives::Int
     levels::Int
@@ -128,11 +130,12 @@ function CompositeQuantumSystem(
 
     # Wrap each drive matrix in a LinearDrive so Piccolissimo's SplineIntegrator
     # (and anything else consuming the AbstractDrive interface) works uniformly
-    # across QuantumSystem and CompositeQuantumSystem.
+    # across QuantumSystem and CompositeQuantumSystem. Use concrete eltype
+    # LinearDrive (not AbstractDrive) for type-stable iteration.
     H_drives_wrapped =
-        AbstractDrive[LinearDrive(H_drive_matrices[idx], idx) for idx = 1:n_drives]
+        [LinearDrive(H_drive_matrices[idx], idx) for idx = 1:n_drives]
 
-    return CompositeQuantumSystem{typeof(H),typeof(G)}(
+    return CompositeQuantumSystem{typeof(H),typeof(G),typeof(H_drives_wrapped)}(
         H,
         G,
         H_drift,

--- a/src/quantum/systems/composite_quantum_systems.jl
+++ b/src/quantum/systems/composite_quantum_systems.jl
@@ -35,7 +35,11 @@ H_coupling = 0.1 * kron(PAULIS[:Z], PAULIS[:Z])
 csys = CompositeQuantumSystem(H_coupling, [sys1, sys2], Float64[])
 ```
 """
-struct CompositeQuantumSystem{F1<:Function,F2<:Function,DD<:AbstractVector{<:AbstractDrive}} <: AbstractQuantumSystem
+struct CompositeQuantumSystem{
+    F1<:Function,
+    F2<:Function,
+    DD<:AbstractVector{<:AbstractDrive},
+} <: AbstractQuantumSystem
     H::F1
     G::F2
     H_drift::SparseMatrixCSC{ComplexF64,Int}
@@ -132,8 +136,7 @@ function CompositeQuantumSystem(
     # (and anything else consuming the AbstractDrive interface) works uniformly
     # across QuantumSystem and CompositeQuantumSystem. Use concrete eltype
     # LinearDrive (not AbstractDrive) for type-stable iteration.
-    H_drives_wrapped =
-        [LinearDrive(H_drive_matrices[idx], idx) for idx = 1:n_drives]
+    H_drives_wrapped = [LinearDrive(H_drive_matrices[idx], idx) for idx = 1:n_drives]
 
     return CompositeQuantumSystem{typeof(H),typeof(G),typeof(H_drives_wrapped)}(
         H,

--- a/src/quantum/systems/quantum_systems.jl
+++ b/src/quantum/systems/quantum_systems.jl
@@ -523,21 +523,20 @@ function QuantumSystem(
         @assert is_hermitian(H_drift_sum) "Drift Hamiltonian is not Hermitian"
     end
 
-    # Normalize drives — track linear index separately for LinearDrive(index).
-    # Accumulator is AbstractDrive[] during construction (push! needs flexibility),
-    # then narrowed to the most-specific Union eltype via `identity.()` before
-    # passing to QuantumSystem. This preserves type stability in the per-substep
-    # RHS hot loops.
-    drives = AbstractDrive[]
+    # Normalize drives. Use a separate accumulator name so the final `drives`
+    # binding is assigned exactly once — otherwise downstream closures (H_fn,
+    # G_fn → Padé Ĝ at src/control/integrators.jl) box `drives` as Core.Box
+    # and lose type info on the per-substep dispatch path (~8% / +5 allocs).
+    drives_acc = AbstractDrive[]
     linear_idx = 1
     for d_input in H_drives_input
         if d_input isa Pair{<:AbstractDrive,<:Function}
-            push!(drives, ModulatedDrive(d_input.first, d_input.second))
+            push!(drives_acc, ModulatedDrive(d_input.first, d_input.second))
         elseif d_input isa AbstractDrive
-            push!(drives, d_input)
+            push!(drives_acc, d_input)
         elseif d_input isa Pair{<:AbstractMatrix,<:Function}
             push!(
-                drives,
+                drives_acc,
                 ModulatedDrive(
                     LinearDrive(sparse(ComplexF64.(d_input.first)), linear_idx),
                     d_input.second,
@@ -546,12 +545,12 @@ function QuantumSystem(
             linear_idx += 1
         else
             # Plain matrix
-            push!(drives, LinearDrive(sparse(ComplexF64.(d_input)), linear_idx))
+            push!(drives_acc, LinearDrive(sparse(ComplexF64.(d_input)), linear_idx))
             linear_idx += 1
         end
     end
-    # Narrow eltype to the most specific Union after dynamic construction.
-    drives = identity.(drives)
+    # Narrow eltype — fresh `drives` binding, assigned exactly once.
+    drives = identity.(drives_acc)
 
     # Check drive operators are Hermitian
     if hermitian

--- a/src/quantum/systems/quantum_systems.jl
+++ b/src/quantum/systems/quantum_systems.jl
@@ -47,15 +47,21 @@ sys = QuantumSystem([H_z, H_x => t -> cos(ω*t)], [H_y], [1.0])
 
 See also [`OpenQuantumSystem`](@ref), [`VariationalQuantumSystem`](@ref).
 """
-struct QuantumSystem{F1<:Function,F2<:Function,PT<:NamedTuple,DT,HD,DD<:AbstractVector{<:AbstractDrive}} <:
-       AbstractQuantumSystem
+struct QuantumSystem{
+    F1<:Function,
+    F2<:Function,
+    PT<:NamedTuple,
+    DT,
+    HD,
+    DD<:AbstractVector{<:AbstractDrive},
+} <: AbstractQuantumSystem
     H::F1
     G::F2
     H_drift::HD
     drift_terms::DT
     H_drives::DD   # parametric — preserves caller's concrete eltype (e.g. Vector{LinearDrive}
-                   # or Vector{Union{LinearDrive,NonlinearDrive}}), avoiding dynamic dispatch
-                   # on drive_coeff / drive_coeff_jac in per-substep RHS hot loops.
+    # or Vector{Union{LinearDrive,NonlinearDrive}}), avoiding dynamic dispatch
+    # on drive_coeff / drive_coeff_jac in per-substep RHS hot loops.
     drive_bounds::Vector{Tuple{Float64,Float64}}
     n_drives::Int
     levels::Int

--- a/src/quantum/systems/quantum_systems.jl
+++ b/src/quantum/systems/quantum_systems.jl
@@ -47,13 +47,15 @@ sys = QuantumSystem([H_z, H_x => t -> cos(ω*t)], [H_y], [1.0])
 
 See also [`OpenQuantumSystem`](@ref), [`VariationalQuantumSystem`](@ref).
 """
-struct QuantumSystem{F1<:Function,F2<:Function,PT<:NamedTuple,DT,HD} <:
+struct QuantumSystem{F1<:Function,F2<:Function,PT<:NamedTuple,DT,HD,DD<:AbstractVector{<:AbstractDrive}} <:
        AbstractQuantumSystem
     H::F1
     G::F2
     H_drift::HD
     drift_terms::DT
-    H_drives::Vector{AbstractDrive}
+    H_drives::DD   # parametric — preserves caller's concrete eltype (e.g. Vector{LinearDrive}
+                   # or Vector{Union{LinearDrive,NonlinearDrive}}), avoiding dynamic dispatch
+                   # on drive_coeff / drive_coeff_jac in per-substep RHS hot loops.
     drive_bounds::Vector{Tuple{Float64,Float64}}
     n_drives::Int
     levels::Int
@@ -220,8 +222,10 @@ function QuantumSystem(
 
     levels = size(H_drift, 1)
 
-    # Build LinearDrive objects from H_drives matrices
-    linear_drives = AbstractDrive[LinearDrive(H_drives[i], i) for i = 1:n_drives]
+    # Build LinearDrive objects from H_drives matrices.
+    # Use concrete eltype LinearDrive (not AbstractDrive) for type-stable
+    # iteration in per-substep RHS loops.
+    linear_drives = [LinearDrive(H_drives[i], i) for i = 1:n_drives]
 
     return QuantumSystem(
         H,
@@ -430,12 +434,16 @@ function QuantumSystem(
                 sum(drive_coeff(d, u, t) * G_d for (d, G_d) in zip(drives, G_drive_mats))
     end
 
+    # Type-stability fix: preserve the caller's concrete eltype on `drives`
+    # instead of widening to AbstractDrive. The struct's `DD` type parameter
+    # captures it. Callers can pass Vector{LinearDrive}, Vector{NonlinearDrive},
+    # or Vector{Union{LinearDrive,NonlinearDrive}} for fully type-stable iteration.
     return QuantumSystem(
         H_fn,
         G_fn,
         H_drift,
         [DriftTerm(H_drift)],
-        collect(AbstractDrive, drives),
+        drives,
         drive_bounds,
         n_drives,
         levels,
@@ -515,7 +523,11 @@ function QuantumSystem(
         @assert is_hermitian(H_drift_sum) "Drift Hamiltonian is not Hermitian"
     end
 
-    # Normalize drives — track linear index separately for LinearDrive(index)
+    # Normalize drives — track linear index separately for LinearDrive(index).
+    # Accumulator is AbstractDrive[] during construction (push! needs flexibility),
+    # then narrowed to the most-specific Union eltype via `identity.()` before
+    # passing to QuantumSystem. This preserves type stability in the per-substep
+    # RHS hot loops.
     drives = AbstractDrive[]
     linear_idx = 1
     for d_input in H_drives_input
@@ -538,6 +550,8 @@ function QuantumSystem(
             linear_idx += 1
         end
     end
+    # Narrow eltype to the most specific Union after dynamic construction.
+    drives = identity.(drives)
 
     # Check drive operators are Hermitian
     if hermitian


### PR DESCRIPTION
## Summary

Adds a parametric `DD<:AbstractVector{<:AbstractDrive}` type parameter to
`QuantumSystem` and `CompositeQuantumSystem`, preventing the constructors
from widening the user's concrete drive container back to
`Vector{AbstractDrive}`. This restores type-stable dispatch on
`drive_coeff` / `drive_coeff_jac` in downstream per-substep RHS hot loops.

## Changes

- `src/quantum/systems/quantum_systems.jl`:
  - Add `DD<:AbstractVector{<:AbstractDrive}` type parameter
  - Field `H_drives::Vector{AbstractDrive}` → `H_drives::DD`
  - In matrix-input constructor: stop building `AbstractDrive[...]` for
    `linear_drives`; let Julia infer the concrete `Vector{LinearDrive}`
  - In drives-input constructor: stop wrapping with
    `collect(AbstractDrive, drives)` — preserve the caller's eltype as-is
  - In accumulator-based constructor (Pair-syntax drift/drives): add
    `drives = identity.(drives)` at the end to narrow the eltype to the
    most-specific containing Union after dynamic `push!` calls
- `src/quantum/systems/composite_quantum_systems.jl`:
  - Add matching `DD<:AbstractVector{<:AbstractDrive}` parameter
  - Field update mirrored
  - Constructor stops widening to `AbstractDrive[...]`
  - Explicit `CompositeQuantumSystem{typeof(H),typeof(G),typeof(...)}`
    construction now includes the new third parameter

## Breaking change (strict)

Downstream code that explicitly parameterized `QuantumSystem` with all 5
prior type parameters (e.g. `QuantumSystem{F1,F2,PT,DT,HD}`) needs to add
a 6th parameter. Same for `CompositeQuantumSystem` (now 3 params instead
of 2). In practice almost nobody does this — the type is used without
parameters in user code.

## Backwards-compatible

- Constructor signatures unchanged
- Field access (`sys.H_drives`) still returns the same vector content
- The `AbstractDrive`-typed accumulator constructor at top-level (e.g.,
  `AbstractDrive[]` in the function-Hamiltonian path) still works — it
  just stores its empty vector with `DD = Vector{AbstractDrive}`

## Measured downstream speedup (i=1 CNOT)

This PR is one of several stacked optimizations validated downstream in
the rqpnn workspace. Measured on CNOT i=1 K=1→4 (N=15, ketdim=10) using
Piccolissimo `feat/post-tier4-speedups-A4-A6` + this PR:

| | Pre-optimization | After full stack | Speedup |
|---|---|---|---|
| Stage 1 wall (CPU) | 180.4s | 97.8s | **1.85×** |
| Stage 2 wall (CPU, K=4 multiket) | 412.0s | 217.4s | **1.90×** |
| Total | 592.4s | 315.2s | **1.88×** |
| K=4 COHERENT fid | 0.999823 | 0.999823 (bit-equal) | — |
| Per-ket AVG | 1.000009 | 1.000009 (bit-equal) | — |

The CNOT i=1 problem is small enough that this PR's impact is
within noise of the other stack changes (dispatch overhead at 21 drives ×
~10s of µs is lost in the 100s of wall time). The structural fix is
**load-bearing for i=2 Toffoli** where:
- 21 drives × tens of dispatches per substep × N=50 knots × thousands of
  substeps gives projected 2-4× CPU RHS speedup
- Pre-fix baseline: Stage 1 = 14h CPU on the i=2 N=50 problem; this PR
  alone is projected to bring that to ~3.5-7h

## Validation

- **Bit-equal fidelity** verified on CNOT i=1 K=1→4: fid = 0.999823
  matches pre-fix baseline exactly
- **Per-ket trajectory + rollout COH** match to all printed digits
- **Precompile clean** on Julia 1.12.6 with Piccolissimo + PiccolissimoCUDAExt
  consuming the new struct

Toffoli i=2 N=50 T=100 measurement to follow in a separate report once
warm-start regeneration is complete (the saved JLD2 warm start was
generated against the pre-fix struct shape, so a fresh Stage 1 run is
required to load it under the new type signature — known JLD2 limitation
on struct parameter changes).

