### PR TITLE
Add pulse animation helper

### DIFF
--- a/docs/literate/guides/visualization.jl
+++ b/docs/literate/guides/visualization.jl
@@ -87,6 +87,30 @@ optimized_traj = get_trajectory(qcp)
 optimized_pulse = ZeroOrderPulse(optimized_traj)
 fig = plot_pulse(optimized_pulse; title = "Optimized Pulse")
 
+# ### Pulse animation
+#
+# `animate_pulse` turns a vector of pulses into a parameter sweep animation.
+# This is useful when comparing candidate pulses from a scan or showing how a
+# waveform responds to parameter changes. Use `mode = :record` with `CairoMakie`
+# for documentation-friendly `.gif` or `.mp4` output:
+
+amplitudes = collect(range(0.2, 1.0, length = 24))
+pulse_sweep = [
+    GaussianPulse([amp, 0.5 * amp], 1.0, T; center = T / 2)
+    for amp in amplitudes
+]
+
+animate_pulse(
+    pulse_sweep;
+    mode = :record,
+    filename = "pulse_parameter_sweep.gif",
+    fps = 12,
+    parameter_values = amplitudes,
+    parameter_label = "amplitude",
+    title = "Gaussian pulse sweep",
+)
+nothing # hide
+
 # ## Basic Trajectory Plotting
 #
 # The `plot` function from NamedTrajectories.jl plots trajectory components

--- a/docs/literate/guides/visualization.jl
+++ b/docs/literate/guides/visualization.jl
@@ -95,10 +95,8 @@ fig = plot_pulse(optimized_pulse; title = "Optimized Pulse")
 # for documentation-friendly `.gif` or `.mp4` output:
 
 amplitudes = collect(range(0.2, 1.0, length = 24))
-pulse_sweep = [
-    GaussianPulse([amp, 0.5 * amp], 1.0, T; center = T / 2)
-    for amp in amplitudes
-]
+pulse_sweep =
+    [GaussianPulse([amp, 0.5 * amp], 1.0, T; center = T / 2) for amp in amplitudes]
 
 animate_pulse(
     pulse_sweep;

--- a/docs/literate/reference/visualizations.jl
+++ b/docs/literate/reference/visualizations.jl
@@ -175,11 +175,20 @@ save("control_plot.svg", fig1)
 # ## Animating Trajectories
 #
 # Create animations to visualize time evolution.
-# Note: Animation functions like `animate_bloch` and `animate_wigner`
-# are available for specific visualization types.
+# Note: Animation functions like `animate_pulse`, `animate_bloch`, and
+# `animate_wigner` are available for specific visualization types.
 
-## Example: Save an animation of control evolution
-## animate_figure(fig, traj; filename="animation.gif")
+## Animate a simple amplitude sweep
+amps = collect(range(0.2, 1.0, length = 16))
+pulse_sweep = [GaussianPulse([amp, 0.5 * amp], 1.0, T) for amp in amps]
+animate_pulse(
+    pulse_sweep;
+    mode = :record,
+    filename = "pulse_sweep.gif",
+    parameter_values = amps,
+    parameter_label = "amplitude",
+)
+nothing # hide
 
 # # Figure Customization
 #
@@ -260,7 +269,7 @@ fig9
 #
 # - **Basic plotting**: `plot(trajectory, components)` for any trajectory variables
 # - **Quantum plots**: `plot_unitary_populations`, `plot_state_populations`
-# - **Animation**: `animate_figure`, `animate_bloch`, `animate_wigner`
+# - **Animation**: `animate_figure`, `animate_pulse`, `animate_bloch`, `animate_wigner`
 # - **Custom plotting**: Full access to Makie's powerful plotting capabilities
 # - **Multiple backends**: CairoMakie (static), GLMakie (interactive), WGLMakie (web)
 # - **Export options**: PNG, PDF, SVG formats

--- a/ext/PiccoloMakieExt.jl
+++ b/ext/PiccoloMakieExt.jl
@@ -50,6 +50,198 @@ function Piccolo.animate_figure(
 end
 
 
+function _pulse_sample_data(pulse::Piccolo.AbstractPulse, n_samples::Int)
+    controls, times = Piccolo.sample(pulse, n_samples)
+    return Matrix(controls), collect(times)
+end
+
+
+function _pulse_y_limits(values)
+    finite_values = Float64[x for x in vec(values) if isfinite(Float64(x))]
+    if isempty(finite_values)
+        return (-1.0, 1.0)
+    end
+
+    lo, hi = extrema(finite_values)
+    pad = 0.08 * (hi - lo)
+    if pad == 0
+        pad = 0.1 * max(abs(lo), 1.0)
+    end
+    return (lo - pad, hi + pad)
+end
+
+
+function _pulse_drive_labels(pulse::Piccolo.AbstractPulse, labels)
+    nd = Piccolo.n_drives(pulse)
+    if isnothing(labels)
+        return ["Drive $i" for i = 1:nd]
+    end
+
+    @assert length(labels) >= nd "labels must include one label per drive"
+    return collect(labels)
+end
+
+
+const _PULSE_ANIMATION_COLORS = Makie.wong_colors()
+
+
+function _pulse_animation_colors(nd::Int)
+    return [_PULSE_ANIMATION_COLORS[mod1(i, length(_PULSE_ANIMATION_COLORS))] for i = 1:nd]
+end
+
+
+function _animation_neutral()
+    try
+        theme = Makie.current_default_theme()
+        if haskey(theme, :textcolor)
+            return Makie.to_value(theme[:textcolor])
+        end
+    catch
+    end
+    return :black
+end
+
+
+function _frame_label(title::AbstractString, frame_text::AbstractString)
+    return isempty(frame_text) ? title : "$title\n$frame_text"
+end
+
+
+function Piccolo.animate_pulse(
+    pulses::AbstractVector{<:Piccolo.AbstractPulse};
+    fps::Int = 12,
+    mode::Symbol = :inline,
+    filename = "pulse_sweep_animation.mp4",
+    n_samples::Int = 240,
+    layout::Symbol = :stacked,
+    title::AbstractString = "Pulse parameter sweep",
+    labels = nothing,
+    parameter_values = nothing,
+    parameter_label::AbstractString = "Frame",
+)
+    @assert !isempty(pulses) "pulses cannot be empty"
+    @assert n_samples >= 2 "n_samples must be at least 2"
+    @assert layout in (:stacked, :overlay) "layout must be :stacked or :overlay"
+
+    nd = Piccolo.n_drives(first(pulses))
+    @assert all(Piccolo.n_drives(p) == nd for p in pulses) "all pulses must have the same number of drives"
+    if !isnothing(parameter_values)
+        @assert length(parameter_values) == length(pulses) "parameter_values must match the number of pulses"
+    end
+
+    sampled = [_pulse_sample_data(pulse, n_samples) for pulse in pulses]
+    controls_by_frame = [item[1] for item in sampled]
+    times_by_frame = [item[2] for item in sampled]
+    drive_labels = _pulse_drive_labels(first(pulses), labels)
+    colors = _pulse_animation_colors(nd)
+    x_limits = (minimum(first.(times_by_frame)), maximum(last.(times_by_frame)))
+    fig = Figure(size = layout == :stacked ? (800, 120 + 150 * nd) : (850, 460))
+
+    frame_text = isnothing(parameter_values) ? "$parameter_label 1" :
+                 "$parameter_label = $(parameter_values[1])"
+    header = Label(
+        fig[0, 1],
+        _frame_label(title, frame_text);
+        fontsize = 18,
+        font = :bold,
+        tellwidth = false,
+    )
+
+    function drive_values(drive)
+        return vcat([vec(controls[drive, :]) for controls in controls_by_frame]...)
+    end
+
+    y_limits_by_drive = [_pulse_y_limits(drive_values(drive)) for drive = 1:nd]
+    y_limits_overlay = _pulse_y_limits(vcat([vec(controls) for controls in controls_by_frame]...))
+
+    if layout == :stacked
+        axes = Axis[]
+        for drive = 1:nd
+            ax = Axis(
+                fig[drive, 1];
+                xlabel = drive == nd ? "Time" : "",
+                xticklabelsvisible = drive == nd,
+                ylabel = drive_labels[drive],
+                titlealign = :left,
+            )
+            push!(axes, ax)
+        end
+    else
+        ax = Axis(
+            fig[1, 1];
+            xlabel = "Time",
+            ylabel = "Amplitude",
+            titlealign = :left,
+        )
+        Legend(
+            fig[1, 2],
+            [LineElement(; color = colors[i], linewidth = 2) for i = 1:nd],
+            drive_labels;
+            tellheight = false,
+        )
+    end
+
+    function update_frame!(frame)
+        idx = clamp(frame, 1, length(pulses))
+        frame_text = isnothing(parameter_values) ? "$parameter_label $idx" :
+                     "$parameter_label = $(parameter_values[idx])"
+        header.text[] = _frame_label(title, frame_text)
+
+        if layout == :stacked
+            for drive = 1:nd
+                empty!(axes[drive])
+                hlines!(
+                    axes[drive],
+                    [0.0];
+                    color = (_animation_neutral(), 0.35),
+                    linestyle = :dash,
+                    linewidth = 0.5,
+                )
+                Piccolo.plot_pulse!(
+                    axes[drive],
+                    pulses[idx];
+                    drive_indices = [drive],
+                    n_samples = n_samples,
+                    show_knots = false,
+                    colors = [colors[drive]],
+                )
+                xlims!(axes[drive], x_limits...)
+                ylims!(axes[drive], y_limits_by_drive[drive]...)
+            end
+        else
+            empty!(ax)
+            hlines!(
+                ax,
+                [0.0];
+                color = (_animation_neutral(), 0.35),
+                linestyle = :dash,
+                linewidth = 0.5,
+            )
+            Piccolo.plot_pulse!(
+                ax,
+                pulses[idx];
+                n_samples = n_samples,
+                show_knots = false,
+                colors = colors,
+            )
+            xlims!(ax, x_limits...)
+            ylims!(ax, y_limits_overlay...)
+        end
+    end
+
+    update_frame!(1)
+
+    return Piccolo.animate_figure(
+        fig,
+        collect(1:length(pulses)),
+        update_frame!,
+        mode = mode,
+        fps = fps,
+        filename = filename,
+    )
+end
+
+
 function Piccolo.animate_name(
     traj::NamedTrajectory,
     name::Symbol;
@@ -251,6 +443,22 @@ end
 
     @test_throws ArgumentError LivePulsePlotCallback(qtraj, qcp.prob.trajectory; every = 0)
     @test_throws ArgumentError LivePulsePlotCallback(qtraj, qcp.prob.trajectory; every = -1)
+end
+
+@testitem "Test animate_pulse for pulse sweeps" begin
+    using CairoMakie
+    using Piccolo
+
+    pulses = [GaussianPulse([amp, 0.5 * amp], 0.2, 1.0) for amp in range(0.2, 0.6, length = 3)]
+    fig_sweep = animate_pulse(
+        pulses;
+        mode = :inline,
+        fps = 10,
+        n_samples = 8,
+        parameter_values = collect(range(0.2, 0.6, length = 3)),
+        parameter_label = "amplitude",
+    )
+    @test fig_sweep isa Figure
 end
 
 

--- a/ext/PiccoloMakieExt.jl
+++ b/ext/PiccoloMakieExt.jl
@@ -137,8 +137,9 @@ function Piccolo.animate_pulse(
     x_limits = (minimum(first.(times_by_frame)), maximum(last.(times_by_frame)))
     fig = Figure(size = layout == :stacked ? (800, 120 + 150 * nd) : (850, 460))
 
-    frame_text = isnothing(parameter_values) ? "$parameter_label 1" :
-                 "$parameter_label = $(parameter_values[1])"
+    frame_text =
+        isnothing(parameter_values) ? "$parameter_label 1" :
+        "$parameter_label = $(parameter_values[1])"
     header = Label(
         fig[0, 1],
         _frame_label(title, frame_text);
@@ -152,7 +153,8 @@ function Piccolo.animate_pulse(
     end
 
     y_limits_by_drive = [_pulse_y_limits(drive_values(drive)) for drive = 1:nd]
-    y_limits_overlay = _pulse_y_limits(vcat([vec(controls) for controls in controls_by_frame]...))
+    y_limits_overlay =
+        _pulse_y_limits(vcat([vec(controls) for controls in controls_by_frame]...))
 
     if layout == :stacked
         axes = Axis[]
@@ -167,12 +169,7 @@ function Piccolo.animate_pulse(
             push!(axes, ax)
         end
     else
-        ax = Axis(
-            fig[1, 1];
-            xlabel = "Time",
-            ylabel = "Amplitude",
-            titlealign = :left,
-        )
+        ax = Axis(fig[1, 1]; xlabel = "Time", ylabel = "Amplitude", titlealign = :left)
         Legend(
             fig[1, 2],
             [LineElement(; color = colors[i], linewidth = 2) for i = 1:nd],
@@ -183,8 +180,9 @@ function Piccolo.animate_pulse(
 
     function update_frame!(frame)
         idx = clamp(frame, 1, length(pulses))
-        frame_text = isnothing(parameter_values) ? "$parameter_label $idx" :
-                     "$parameter_label = $(parameter_values[idx])"
+        frame_text =
+            isnothing(parameter_values) ? "$parameter_label $idx" :
+            "$parameter_label = $(parameter_values[idx])"
         header.text[] = _frame_label(title, frame_text)
 
         if layout == :stacked
@@ -449,7 +447,8 @@ end
     using CairoMakie
     using Piccolo
 
-    pulses = [GaussianPulse([amp, 0.5 * amp], 0.2, 1.0) for amp in range(0.2, 0.6, length = 3)]
+    pulses =
+        [GaussianPulse([amp, 0.5 * amp], 0.2, 1.0) for amp in range(0.2, 0.6, length = 3)]
     fig_sweep = animate_pulse(
         pulses;
         mode = :inline,

--- a/src/control/display/inspect.jl
+++ b/src/control/display/inspect.jl
@@ -407,8 +407,9 @@ end
 
 _goal_summary(qtraj::UnitaryTrajectory) = _goal_summary_unitary(qtraj.goal)
 _goal_summary(qtraj::KetTrajectory) = "|ψ_init⟩ → |ψ_goal⟩  (dim=$(length(qtraj.goal)))"
-_goal_summary(qtraj::MultiKetTrajectory) =
-    "$(length(qtraj.goals)) state transfers  (dim=$(length(first(qtraj.goals))))"
+_goal_summary(
+    qtraj::MultiKetTrajectory,
+) = "$(length(qtraj.goals)) state transfers  (dim=$(length(first(qtraj.goals))))"
 _goal_summary(qtraj::DensityTrajectory) = "ρ_init → ρ_goal"
 _goal_summary(qtraj::SamplingTrajectory) = "sampled ensemble (n=$(length(qtraj.systems)))"
 _goal_summary(qtraj::AbstractQuantumTrajectory) = string(_typename(qtraj), " goal")

--- a/src/visualizations/animations.jl
+++ b/src/visualizations/animations.jl
@@ -2,6 +2,7 @@ module AnimatedPlots
 
 export animate_figure
 export animate_name
+export animate_pulse
 
 """
     animate_figure(
@@ -117,5 +118,57 @@ See also: `animate_figure`, `animate_bloch`, and
 [`NamedTrajectories.plot`](https://docs.harmoniqs.co/NamedTrajectories/dev/generated/plotting/).
 """
 function animate_name end
+
+"""
+    animate_pulse(
+        pulses::AbstractVector{<:AbstractPulse};
+        fps::Int = 12,
+        mode::Symbol = :inline,
+        filename::String = "pulse_sweep_animation.mp4",
+        n_samples::Int = 240,
+        layout::Symbol = :stacked,
+        title::AbstractString = "Pulse parameter sweep",
+        labels = nothing,
+        parameter_values = nothing,
+        parameter_label::AbstractString = "Frame"
+    ) -> Figure
+
+Animate a sequence of pulses, one pulse per frame, for visualizing parameter sweeps
+or optimization snapshots.
+
+For progressive trajectory/control reveal animations, use `animate_name`.
+
+Defined as a stub here; the implementation is provided by the `PiccoloMakieExt`
+extension and is loaded when a Makie backend is available.
+
+# Arguments
+- `pulses::AbstractVector{<:AbstractPulse}`: Pulses with the same number of drives,
+  sampled and shown as a sweep.
+
+# Keyword Arguments
+- `fps::Int`: Frames per second.
+- `mode::Symbol`: `:inline` or `:record`; see `animate_figure`.
+- `filename::String`: Output path when `mode = :record`.
+- `n_samples::Int`: Number of samples per pulse.
+- `layout::Symbol`: `:stacked` for one axis per drive or `:overlay` for all drives
+  on one axis.
+- `title::AbstractString`: Figure title.
+- `labels`: Optional drive labels.
+- `parameter_values`: Optional values to show for each frame in a pulse sweep.
+- `parameter_label::AbstractString`: Label used with `parameter_values`.
+
+# Examples
+
+```julia
+using GLMakie
+
+amps = range(0.2, 1.0, length=40)
+pulses = [GaussianPulse([amp, 0.5amp], 1.0, 10.0) for amp in amps]
+animate_pulse(pulses; parameter_values=amps, parameter_label="amplitude")
+```
+
+See also: `plot_pulse`, `animate_figure`, and `animate_name`.
+"""
+function animate_pulse end
 
 end


### PR DESCRIPTION
Addresses #59 (parameter-sweep animation; the single-pulse reveal + populations panel land in #240).

## Summary
- Adds `animate_pulse(pulses)` for parameter-sweep / optimization-snapshot pulse animations.
- Renders each frame via the existing `plot_pulse!` API (type-aware) instead of re-deriving sampling/rendering.
- Documents the sweep workflow in the visualization guide and API reference.

## Notes
- Supports `:stacked` and `:overlay` layouts.
- Reuses `animate_figure`, so `:inline` and `:record` modes behave consistently with existing animations.

## Validation
- Maintainer-verified locally (Julia 1.12 + CairoMakie): Gaussian amplitude sweep + ZOH snapshots, both layouts, render correctly. CI green (Formatter, Docs, Julia 1.10/1.11/1.12).