### PR TITLE
fix(trajectories): auto-select ODE problem form by algorithm class

### DIFF
--- a/src/quantum/dynamics.jl
+++ b/src/quantum/dynamics.jl
@@ -318,6 +318,26 @@ end
 #         SciMLBase v3 passes (prob, ctx::EnsembleContext) where ctx.sim_id is the index.
 _sim_index(i_or_ctx) = i_or_ctx isa Integer ? i_or_ctx : i_or_ctx.sim_id
 
+"""
+    _needs_operator_form(algorithm) -> Bool
+
+Return true if this ODE algorithm requires the matrix-valued operator form of the
+problem (`H(t)` materialized as a `SciMLOperators.MatrixOperator`). True for
+Magnus-class / Lie-group methods (which compute `exp(-iH·dt)·ψ` at each step
+and therefore need the operator matrix). False for explicit RK methods (Tsit5,
+Vern9, DP5, DP8, Verner family, etc.) which only need the
+`dψ/dt = -iH(t)·ψ` matvec — they should use the sparse `mul!`-based RHS form
+to avoid the cost of materializing `H` densely on every ODE step.
+
+The detection is structural: Magnus methods live in the `OrdinaryDiffEqLinear`
+package; we look up the parent module of the algorithm's type. This avoids
+hardcoding a list of algorithm names.
+"""
+function _needs_operator_form(algorithm)
+    mod = parentmodule(typeof(algorithm))
+    return nameof(mod) === :OrdinaryDiffEqLinear
+end
+
 function _construct_operator(sys::AbstractQuantumSystem, u::F) where {F}
     A0 = zeros(ComplexF64, sys.levels, sys.levels)
 

--- a/src/quantum/trajectories/_quantum_trajectories.jl
+++ b/src/quantum/trajectories/_quantum_trajectories.jl
@@ -29,7 +29,7 @@ using ..Rollouts:
     KetODEProblem,
     KetOperatorODEProblem,
     DensityODEProblem
-using ..Rollouts: unitary_fidelity, _sim_index
+using ..Rollouts: unitary_fidelity, _sim_index, _needs_operator_form
 using ..EmbeddedOperators: AbstractPiccoloOperator, EmbeddedOperator, unembed
 using ..Isomorphisms: operator_to_iso_vec, ket_to_iso, iso_to_ket, iso_vec_to_operator
 using ..Isomorphisms: density_to_compact_iso, compact_iso_to_density

--- a/src/quantum/trajectories/density_trajectory.jl
+++ b/src/quantum/trajectories/density_trajectory.jl
@@ -52,6 +52,8 @@ function DensityTrajectory(
     abstol::Real = 1e-8,
     reltol::Real = 1e-8,
     n_save::Int = 101,
+    progress::Bool = false,
+    progress_steps::Int = 10,
 )
     @assert n_drives(pulse) == system.n_drives "Pulse has $(n_drives(pulse)) drives, system has $(system.n_drives)"
 
@@ -61,7 +63,9 @@ function DensityTrajectory(
     save_times = collect(range(0.0, duration(pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
     prob = DensityODEProblem(system, pulse, ρ0, tstops)
-    sol = solve(prob, algorithm; saveat = save_times, abstol = abstol, reltol = reltol)
+    sol = solve(prob, algorithm;
+                saveat = save_times, abstol = abstol, reltol = reltol,
+                progress = progress, progress_steps = progress_steps)
 
     return DensityTrajectory{typeof(pulse),typeof(sol)}(system, pulse, ρ0, ρg, sol)
 end

--- a/src/quantum/trajectories/density_trajectory.jl
+++ b/src/quantum/trajectories/density_trajectory.jl
@@ -63,9 +63,15 @@ function DensityTrajectory(
     save_times = collect(range(0.0, duration(pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
     prob = DensityODEProblem(system, pulse, ρ0, tstops)
-    sol = solve(prob, algorithm;
-                saveat = save_times, abstol = abstol, reltol = reltol,
-                progress = progress, progress_steps = progress_steps)
+    sol = solve(
+        prob,
+        algorithm;
+        saveat = save_times,
+        abstol = abstol,
+        reltol = reltol,
+        progress = progress,
+        progress_steps = progress_steps,
+    )
 
     return DensityTrajectory{typeof(pulse),typeof(sol)}(system, pulse, ρ0, ρg, sol)
 end

--- a/src/quantum/trajectories/ensemble_trajectory.jl
+++ b/src/quantum/trajectories/ensemble_trajectory.jl
@@ -77,7 +77,8 @@ function MultiKetTrajectory(
     # Magnus needs the operator (matrix) form; explicit RK methods (Tsit5/Vern9/etc.)
     # use KetODEProblem to avoid per-step dense materialization of H.
     dummy = zeros(ComplexF64, system.levels)
-    base_prob = _needs_operator_form(algorithm) ?
+    base_prob =
+        _needs_operator_form(algorithm) ?
         KetOperatorODEProblem(system, pulse, dummy, tstops) :
         KetODEProblem(system, pulse, dummy, tstops)
     prob_func(prob, i_or_ctx, _repeat = nothing) =

--- a/src/quantum/trajectories/ensemble_trajectory.jl
+++ b/src/quantum/trajectories/ensemble_trajectory.jl
@@ -73,9 +73,13 @@ function MultiKetTrajectory(
     save_times = collect(range(0.0, duration(pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
 
-    # Build ensemble problem
+    # Build ensemble problem. Choose the ODE problem form to match the algorithm:
+    # Magnus needs the operator (matrix) form; explicit RK methods (Tsit5/Vern9/etc.)
+    # use KetODEProblem to avoid per-step dense materialization of H.
     dummy = zeros(ComplexF64, system.levels)
-    base_prob = KetOperatorODEProblem(system, pulse, dummy, tstops)
+    base_prob = _needs_operator_form(algorithm) ?
+        KetOperatorODEProblem(system, pulse, dummy, tstops) :
+        KetODEProblem(system, pulse, dummy, tstops)
     prob_func(prob, i_or_ctx, _repeat = nothing) =
         remake(prob, u0 = ψ0s[_sim_index(i_or_ctx)])
     ensemble_prob = EnsembleProblem(base_prob; prob_func = prob_func)

--- a/src/quantum/trajectories/interface.jl
+++ b/src/quantum/trajectories/interface.jl
@@ -152,10 +152,12 @@ function Rollouts.rollout!(
     knot_times = get_knot_times(pulse)
     save_times = collect(range(0.0, duration(pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
-    prob = UnitaryOperatorODEProblem(qtraj.system, pulse, tstops; U0 = qtraj.initial)
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
+    prob = _needs_operator_form(algorithm) ?
+        UnitaryOperatorODEProblem(qtraj.system, pulse, tstops; U0 = qtraj.initial) :
+        UnitaryODEProblem(qtraj.system, pulse, tstops; U0 = qtraj.initial)
     sol = solve(prob, algorithm; saveat = save_times, abstol = abstol, reltol = reltol)
 
     qtraj.pulse = pulse
@@ -200,10 +202,12 @@ function Rollouts.rollout!(
     knot_times = get_knot_times(qtraj.pulse)
     save_times = collect(range(0.0, duration(qtraj.pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
-    prob = UnitaryOperatorODEProblem(qtraj.system, qtraj.pulse, tstops; U0 = qtraj.initial)
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
+    prob = _needs_operator_form(algorithm) ?
+        UnitaryOperatorODEProblem(qtraj.system, qtraj.pulse, tstops; U0 = qtraj.initial) :
+        UnitaryODEProblem(qtraj.system, qtraj.pulse, tstops; U0 = qtraj.initial)
     sol = solve(
         prob,
         algorithm;
@@ -234,10 +238,12 @@ function Rollouts.rollout!(
     knot_times = get_knot_times(pulse)
     save_times = collect(range(0.0, duration(pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
-    prob = KetOperatorODEProblem(qtraj.system, pulse, qtraj.initial, tstops)
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
+    prob = _needs_operator_form(algorithm) ?
+        KetOperatorODEProblem(qtraj.system, pulse, qtraj.initial, tstops) :
+        KetODEProblem(qtraj.system, pulse, qtraj.initial, tstops)
     sol = solve(prob, algorithm; saveat = save_times, abstol = abstol, reltol = reltol)
 
     qtraj.pulse = pulse
@@ -262,10 +268,12 @@ function Rollouts.rollout!(
     knot_times = get_knot_times(qtraj.pulse)
     save_times = collect(range(0.0, duration(qtraj.pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
-    prob = KetOperatorODEProblem(qtraj.system, qtraj.pulse, qtraj.initial, tstops)
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
+    prob = _needs_operator_form(algorithm) ?
+        KetOperatorODEProblem(qtraj.system, qtraj.pulse, qtraj.initial, tstops) :
+        KetODEProblem(qtraj.system, qtraj.pulse, qtraj.initial, tstops)
     sol = solve(
         prob,
         algorithm;
@@ -297,15 +305,18 @@ function Rollouts.rollout!(
     save_times = collect(range(0.0, duration(pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
 
-    # Build ensemble problem
-    dummy = zeros(ComplexF64, qtraj.system.levels)
-    base_prob = KetOperatorODEProblem(qtraj.system, pulse, dummy, tstops)
-    prob_func(prob, i_or_ctx, _repeat = nothing) =
-        remake(prob, u0 = qtraj.initials[_sim_index(i_or_ctx)])
-    ensemble_prob = EnsembleProblem(base_prob; prob_func = prob_func)
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
+
+    # Build ensemble problem
+    dummy = zeros(ComplexF64, qtraj.system.levels)
+    base_prob = _needs_operator_form(algorithm) ?
+        KetOperatorODEProblem(qtraj.system, pulse, dummy, tstops) :
+        KetODEProblem(qtraj.system, pulse, dummy, tstops)
+    prob_func(prob, i_or_ctx, _repeat = nothing) =
+        remake(prob, u0 = qtraj.initials[_sim_index(i_or_ctx)])
+    ensemble_prob = EnsembleProblem(base_prob; prob_func = prob_func)
     sol = solve(
         ensemble_prob,
         algorithm;
@@ -338,15 +349,18 @@ function Rollouts.rollout!(
     save_times = collect(range(0.0, duration(qtraj.pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
 
-    # Build ensemble problem
-    dummy = zeros(ComplexF64, qtraj.system.levels)
-    base_prob = KetOperatorODEProblem(qtraj.system, qtraj.pulse, dummy, tstops)
-    prob_func(prob, i_or_ctx, _repeat = nothing) =
-        remake(prob, u0 = qtraj.initials[_sim_index(i_or_ctx)])
-    ensemble_prob = EnsembleProblem(base_prob; prob_func = prob_func)
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
+
+    # Build ensemble problem
+    dummy = zeros(ComplexF64, qtraj.system.levels)
+    base_prob = _needs_operator_form(algorithm) ?
+        KetOperatorODEProblem(qtraj.system, qtraj.pulse, dummy, tstops) :
+        KetODEProblem(qtraj.system, qtraj.pulse, dummy, tstops)
+    prob_func(prob, i_or_ctx, _repeat = nothing) =
+        remake(prob, u0 = qtraj.initials[_sim_index(i_or_ctx)])
+    ensemble_prob = EnsembleProblem(base_prob; prob_func = prob_func)
     sol = solve(
         ensemble_prob,
         algorithm;
@@ -595,10 +609,12 @@ function Rollouts.rollout(
     knot_times = get_knot_times(pulse)
     save_times = collect(range(0.0, duration(pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
-    prob = UnitaryOperatorODEProblem(qtraj.system, pulse, tstops; U0 = qtraj.initial)
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
+    prob = _needs_operator_form(algorithm) ?
+        UnitaryOperatorODEProblem(qtraj.system, pulse, tstops; U0 = qtraj.initial) :
+        UnitaryODEProblem(qtraj.system, pulse, tstops; U0 = qtraj.initial)
     sol = solve(prob, algorithm; saveat = save_times, abstol = abstol, reltol = reltol)
     return UnitaryTrajectory(qtraj.system, pulse, qtraj.initial, qtraj.goal, sol)
 end
@@ -620,10 +636,12 @@ function Rollouts.rollout(
     knot_times = get_knot_times(pulse)
     save_times = collect(range(0.0, duration(pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
-    prob = KetOperatorODEProblem(qtraj.system, pulse, qtraj.initial, tstops)
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
+    prob = _needs_operator_form(algorithm) ?
+        KetOperatorODEProblem(qtraj.system, pulse, qtraj.initial, tstops) :
+        KetODEProblem(qtraj.system, pulse, qtraj.initial, tstops)
     sol = solve(prob, algorithm; saveat = save_times, abstol = abstol, reltol = reltol)
     return KetTrajectory(qtraj.system, pulse, qtraj.initial, qtraj.goal, sol)
 end
@@ -646,15 +664,18 @@ function Rollouts.rollout(
     save_times = collect(range(0.0, duration(pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
 
-    # Build ensemble problem
-    dummy = zeros(ComplexF64, qtraj.system.levels)
-    base_prob = KetOperatorODEProblem(qtraj.system, pulse, dummy, tstops)
-    prob_func(prob, i_or_ctx, _repeat = nothing) =
-        remake(prob, u0 = qtraj.initials[_sim_index(i_or_ctx)])
-    ensemble_prob = EnsembleProblem(base_prob; prob_func = prob_func)
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
+
+    # Build ensemble problem
+    dummy = zeros(ComplexF64, qtraj.system.levels)
+    base_prob = _needs_operator_form(algorithm) ?
+        KetOperatorODEProblem(qtraj.system, pulse, dummy, tstops) :
+        KetODEProblem(qtraj.system, pulse, dummy, tstops)
+    prob_func(prob, i_or_ctx, _repeat = nothing) =
+        remake(prob, u0 = qtraj.initials[_sim_index(i_or_ctx)])
+    ensemble_prob = EnsembleProblem(base_prob; prob_func = prob_func)
     sol = solve(
         ensemble_prob,
         algorithm;
@@ -785,10 +806,12 @@ function Rollouts.rollout(
     knot_times = get_knot_times(qtraj.pulse)
     save_times = collect(range(0.0, duration(qtraj.pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
-    prob = UnitaryOperatorODEProblem(qtraj.system, qtraj.pulse, tstops; U0 = qtraj.initial)
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
+    prob = _needs_operator_form(algorithm) ?
+        UnitaryOperatorODEProblem(qtraj.system, qtraj.pulse, tstops; U0 = qtraj.initial) :
+        UnitaryODEProblem(qtraj.system, qtraj.pulse, tstops; U0 = qtraj.initial)
     sol = solve(
         prob,
         algorithm;
@@ -817,10 +840,12 @@ function Rollouts.rollout(
     knot_times = get_knot_times(qtraj.pulse)
     save_times = collect(range(0.0, duration(qtraj.pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
-    prob = KetOperatorODEProblem(qtraj.system, qtraj.pulse, qtraj.initial, tstops)
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
+    prob = _needs_operator_form(algorithm) ?
+        KetOperatorODEProblem(qtraj.system, qtraj.pulse, qtraj.initial, tstops) :
+        KetODEProblem(qtraj.system, qtraj.pulse, qtraj.initial, tstops)
     sol = solve(
         prob,
         algorithm;
@@ -850,15 +875,18 @@ function Rollouts.rollout(
     save_times = collect(range(0.0, duration(qtraj.pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
 
-    # Build ensemble problem
-    dummy = zeros(ComplexF64, qtraj.system.levels)
-    base_prob = KetOperatorODEProblem(qtraj.system, qtraj.pulse, dummy, tstops)
-    prob_func(prob, i_or_ctx, _repeat = nothing) =
-        remake(prob, u0 = qtraj.initials[_sim_index(i_or_ctx)])
-    ensemble_prob = EnsembleProblem(base_prob; prob_func = prob_func)
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
+
+    # Build ensemble problem
+    dummy = zeros(ComplexF64, qtraj.system.levels)
+    base_prob = _needs_operator_form(algorithm) ?
+        KetOperatorODEProblem(qtraj.system, qtraj.pulse, dummy, tstops) :
+        KetODEProblem(qtraj.system, qtraj.pulse, dummy, tstops)
+    prob_func(prob, i_or_ctx, _repeat = nothing) =
+        remake(prob, u0 = qtraj.initials[_sim_index(i_or_ctx)])
+    ensemble_prob = EnsembleProblem(base_prob; prob_func = prob_func)
     sol = solve(
         ensemble_prob,
         algorithm;

--- a/src/quantum/trajectories/interface.jl
+++ b/src/quantum/trajectories/interface.jl
@@ -155,7 +155,8 @@ function Rollouts.rollout!(
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
-    prob = _needs_operator_form(algorithm) ?
+    prob =
+        _needs_operator_form(algorithm) ?
         UnitaryOperatorODEProblem(qtraj.system, pulse, tstops; U0 = qtraj.initial) :
         UnitaryODEProblem(qtraj.system, pulse, tstops; U0 = qtraj.initial)
     sol = solve(prob, algorithm; saveat = save_times, abstol = abstol, reltol = reltol)
@@ -205,7 +206,8 @@ function Rollouts.rollout!(
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
-    prob = _needs_operator_form(algorithm) ?
+    prob =
+        _needs_operator_form(algorithm) ?
         UnitaryOperatorODEProblem(qtraj.system, qtraj.pulse, tstops; U0 = qtraj.initial) :
         UnitaryODEProblem(qtraj.system, qtraj.pulse, tstops; U0 = qtraj.initial)
     sol = solve(
@@ -241,7 +243,8 @@ function Rollouts.rollout!(
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
-    prob = _needs_operator_form(algorithm) ?
+    prob =
+        _needs_operator_form(algorithm) ?
         KetOperatorODEProblem(qtraj.system, pulse, qtraj.initial, tstops) :
         KetODEProblem(qtraj.system, pulse, qtraj.initial, tstops)
     sol = solve(prob, algorithm; saveat = save_times, abstol = abstol, reltol = reltol)
@@ -271,7 +274,8 @@ function Rollouts.rollout!(
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
-    prob = _needs_operator_form(algorithm) ?
+    prob =
+        _needs_operator_form(algorithm) ?
         KetOperatorODEProblem(qtraj.system, qtraj.pulse, qtraj.initial, tstops) :
         KetODEProblem(qtraj.system, qtraj.pulse, qtraj.initial, tstops)
     sol = solve(
@@ -311,7 +315,8 @@ function Rollouts.rollout!(
 
     # Build ensemble problem
     dummy = zeros(ComplexF64, qtraj.system.levels)
-    base_prob = _needs_operator_form(algorithm) ?
+    base_prob =
+        _needs_operator_form(algorithm) ?
         KetOperatorODEProblem(qtraj.system, pulse, dummy, tstops) :
         KetODEProblem(qtraj.system, pulse, dummy, tstops)
     prob_func(prob, i_or_ctx, _repeat = nothing) =
@@ -355,7 +360,8 @@ function Rollouts.rollout!(
 
     # Build ensemble problem
     dummy = zeros(ComplexF64, qtraj.system.levels)
-    base_prob = _needs_operator_form(algorithm) ?
+    base_prob =
+        _needs_operator_form(algorithm) ?
         KetOperatorODEProblem(qtraj.system, qtraj.pulse, dummy, tstops) :
         KetODEProblem(qtraj.system, qtraj.pulse, dummy, tstops)
     prob_func(prob, i_or_ctx, _repeat = nothing) =
@@ -612,7 +618,8 @@ function Rollouts.rollout(
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
-    prob = _needs_operator_form(algorithm) ?
+    prob =
+        _needs_operator_form(algorithm) ?
         UnitaryOperatorODEProblem(qtraj.system, pulse, tstops; U0 = qtraj.initial) :
         UnitaryODEProblem(qtraj.system, pulse, tstops; U0 = qtraj.initial)
     sol = solve(prob, algorithm; saveat = save_times, abstol = abstol, reltol = reltol)
@@ -639,7 +646,8 @@ function Rollouts.rollout(
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
-    prob = _needs_operator_form(algorithm) ?
+    prob =
+        _needs_operator_form(algorithm) ?
         KetOperatorODEProblem(qtraj.system, pulse, qtraj.initial, tstops) :
         KetODEProblem(qtraj.system, pulse, qtraj.initial, tstops)
     sol = solve(prob, algorithm; saveat = save_times, abstol = abstol, reltol = reltol)
@@ -670,7 +678,8 @@ function Rollouts.rollout(
 
     # Build ensemble problem
     dummy = zeros(ComplexF64, qtraj.system.levels)
-    base_prob = _needs_operator_form(algorithm) ?
+    base_prob =
+        _needs_operator_form(algorithm) ?
         KetOperatorODEProblem(qtraj.system, pulse, dummy, tstops) :
         KetODEProblem(qtraj.system, pulse, dummy, tstops)
     prob_func(prob, i_or_ctx, _repeat = nothing) =
@@ -809,7 +818,8 @@ function Rollouts.rollout(
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
-    prob = _needs_operator_form(algorithm) ?
+    prob =
+        _needs_operator_form(algorithm) ?
         UnitaryOperatorODEProblem(qtraj.system, qtraj.pulse, tstops; U0 = qtraj.initial) :
         UnitaryODEProblem(qtraj.system, qtraj.pulse, tstops; U0 = qtraj.initial)
     sol = solve(
@@ -843,7 +853,8 @@ function Rollouts.rollout(
     if isnothing(algorithm)
         algorithm = default_algorithm(qtraj.system)
     end
-    prob = _needs_operator_form(algorithm) ?
+    prob =
+        _needs_operator_form(algorithm) ?
         KetOperatorODEProblem(qtraj.system, qtraj.pulse, qtraj.initial, tstops) :
         KetODEProblem(qtraj.system, qtraj.pulse, qtraj.initial, tstops)
     sol = solve(
@@ -881,7 +892,8 @@ function Rollouts.rollout(
 
     # Build ensemble problem
     dummy = zeros(ComplexF64, qtraj.system.levels)
-    base_prob = _needs_operator_form(algorithm) ?
+    base_prob =
+        _needs_operator_form(algorithm) ?
         KetOperatorODEProblem(qtraj.system, qtraj.pulse, dummy, tstops) :
         KetODEProblem(qtraj.system, qtraj.pulse, dummy, tstops)
     prob_func(prob, i_or_ctx, _repeat = nothing) =

--- a/src/quantum/trajectories/ket_trajectory.jl
+++ b/src/quantum/trajectories/ket_trajectory.jl
@@ -27,7 +27,7 @@ mutable struct KetTrajectory{P<:AbstractPulse,S<:ODESolution} <:
 end
 
 """
-    KetTrajectory(system, pulse, initial, goal; algorithm=MagnusAdapt4(), abstol=1e-8, reltol=1e-8, n_save=101)
+    KetTrajectory(system, pulse, initial, goal; algorithm=MagnusAdapt4(), abstol=1e-8, reltol=1e-8, n_save=101, progress=false, progress_steps=10)
 
 Create a ket trajectory by solving the Schrödinger equation.
 
@@ -42,6 +42,10 @@ Create a ket trajectory by solving the Schrödinger equation.
 - `abstol`: Absolute tolerance for adaptive integration (default: 1e-8)
 - `reltol`: Relative tolerance for adaptive integration (default: 1e-8)
 - `n_save`: Number of output time points (default: 101)
+- `progress`: If true, emit ProgressLogging events during the ODE rollout (default: false).
+  To see a progress bar in the terminal, install `TerminalLoggers` and set
+  `global_logger(TerminalLogger())` before calling.
+- `progress_steps`: Granularity of progress reports (default: 10, i.e. ~10% increments)
 """
 function KetTrajectory(
     system::QuantumSystem,
@@ -52,6 +56,8 @@ function KetTrajectory(
     abstol::Real = 1e-8,
     reltol::Real = 1e-8,
     n_save::Int = 101,
+    progress::Bool = false,
+    progress_steps::Int = 10,
 )
     @assert n_drives(pulse) == system.n_drives "Pulse has $(n_drives(pulse)) drives, system has $(system.n_drives)"
 
@@ -64,8 +70,17 @@ function KetTrajectory(
     knot_times = get_knot_times(pulse)
     save_times = collect(range(0.0, duration(pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
-    prob = KetOperatorODEProblem(system, pulse, ψ0, tstops)
-    sol = solve(prob, algorithm; saveat = save_times, abstol = abstol, reltol = reltol)
+    # Choose the ODE problem form to match the algorithm. Magnus-class methods
+    # need H(t) materialized as a MatrixOperator (KetOperatorODEProblem). Explicit
+    # RK methods (Tsit5, Vern9, DP8, ...) only need the dψ/dt = -iH(t)·ψ matvec
+    # and should use KetODEProblem to avoid a per-step dense materialization
+    # of H — a major hot-path penalty on high-dimensional sparse systems.
+    prob = _needs_operator_form(algorithm) ?
+        KetOperatorODEProblem(system, pulse, ψ0, tstops) :
+        KetODEProblem(system, pulse, ψ0, tstops)
+    sol = solve(prob, algorithm;
+                saveat = save_times, abstol = abstol, reltol = reltol,
+                progress = progress, progress_steps = progress_steps)
 
     return KetTrajectory{typeof(pulse),typeof(sol)}(system, pulse, ψ0, ψg, sol)
 end

--- a/src/quantum/trajectories/ket_trajectory.jl
+++ b/src/quantum/trajectories/ket_trajectory.jl
@@ -75,12 +75,18 @@ function KetTrajectory(
     # RK methods (Tsit5, Vern9, DP8, ...) only need the dψ/dt = -iH(t)·ψ matvec
     # and should use KetODEProblem to avoid a per-step dense materialization
     # of H — a major hot-path penalty on high-dimensional sparse systems.
-    prob = _needs_operator_form(algorithm) ?
-        KetOperatorODEProblem(system, pulse, ψ0, tstops) :
+    prob =
+        _needs_operator_form(algorithm) ? KetOperatorODEProblem(system, pulse, ψ0, tstops) :
         KetODEProblem(system, pulse, ψ0, tstops)
-    sol = solve(prob, algorithm;
-                saveat = save_times, abstol = abstol, reltol = reltol,
-                progress = progress, progress_steps = progress_steps)
+    sol = solve(
+        prob,
+        algorithm;
+        saveat = save_times,
+        abstol = abstol,
+        reltol = reltol,
+        progress = progress,
+        progress_steps = progress_steps,
+    )
 
     return KetTrajectory{typeof(pulse),typeof(sol)}(system, pulse, ψ0, ψg, sol)
 end

--- a/src/quantum/trajectories/unitary_trajectory.jl
+++ b/src/quantum/trajectories/unitary_trajectory.jl
@@ -56,6 +56,8 @@ function UnitaryTrajectory(
     abstol::Real = 1e-8,
     reltol::Real = 1e-8,
     n_save::Int = 101,
+    progress::Bool = false,
+    progress_steps::Int = 10,
 )
     @assert n_drives(pulse) == system.n_drives "Pulse has $(n_drives(pulse)) drives, system has $(system.n_drives)"
 
@@ -71,8 +73,15 @@ function UnitaryTrajectory(
     knot_times = get_knot_times(pulse)
     save_times = collect(range(0.0, duration(pulse), length = n_save))
     tstops = sort(unique(vcat(knot_times, save_times)))
-    prob = UnitaryOperatorODEProblem(system, pulse, tstops; U0 = U0)
-    sol = solve(prob, algorithm; saveat = save_times, abstol = abstol, reltol = reltol)
+    # See KetTrajectory for rationale: Magnus methods need the matrix-operator
+    # form; explicit RK methods should use the sparse mul! RHS form to avoid
+    # per-step dense materialization of H.
+    prob = _needs_operator_form(algorithm) ?
+        UnitaryOperatorODEProblem(system, pulse, tstops; U0 = U0) :
+        UnitaryODEProblem(system, pulse, tstops; U0 = U0)
+    sol = solve(prob, algorithm;
+                saveat = save_times, abstol = abstol, reltol = reltol,
+                progress = progress, progress_steps = progress_steps)
 
     return UnitaryTrajectory{typeof(pulse),typeof(sol)}(system, pulse, U0, goal_stored, sol)
 end
@@ -367,4 +376,156 @@ end
     )
 
     @test fid_adapt ≈ fid_gl4_fine atol = 1e-6
+end
+
+@testitem "UnitaryTrajectory auto-selects ODE problem form by algorithm" begin
+    # Performance bug fix: when an explicit RK algorithm (Tsit5/Vern9/etc.) is
+    # passed, the trajectory must use UnitaryODEProblem (sparse mul! path) — NOT
+    # UnitaryOperatorODEProblem, which materializes H densely on every ODE step.
+    # When a Magnus-class algorithm is passed (or no algorithm — default routes to
+    # MagnusAdapt4 for Hermitian systems), the operator form must be used so the
+    # Lie-group integrator can compute exp(-iH dt)·U.
+    #
+    # We assert correctness (Magnus and Tsit5 paths agree on fidelity) and check
+    # the underlying problem type via the ODESolution's function field.
+    using LinearAlgebra
+    using OrdinaryDiffEqLinear: MagnusAdapt4
+    using OrdinaryDiffEqTsit5: Tsit5
+    using OrdinaryDiffEqLinear: MatrixOperator
+
+    sys = QuantumSystem([PAULIS.X, PAULIS.Y], [1.0, 1.0])
+    T = π / 2
+    pulse = ZeroOrderPulse(ones(2, 2), [0.0, T])
+    X_gate = ComplexF64[0 1; 1 0]
+
+    # 1. Explicit Magnus → operator form (MatrixOperator-backed function).
+    qtraj_magnus = UnitaryTrajectory(
+        sys,
+        pulse,
+        X_gate;
+        algorithm = MagnusAdapt4(),
+        abstol = 1e-10,
+        reltol = 1e-10,
+    )
+    @test qtraj_magnus.solution.prob.f.f isa MatrixOperator
+
+    # 2. Explicit RK (Tsit5) → mul!-based RHS (not a MatrixOperator).
+    qtraj_rk = UnitaryTrajectory(
+        sys,
+        pulse,
+        X_gate;
+        algorithm = Tsit5(),
+        abstol = 1e-10,
+        reltol = 1e-10,
+    )
+    @test !(qtraj_rk.solution.prob.f.f isa MatrixOperator)
+
+    # 3. Default (algorithm = nothing) for Hermitian system → MagnusAdapt4 →
+    #    operator form (preserves existing behavior).
+    qtraj_default = UnitaryTrajectory(sys, pulse, X_gate)
+    @test qtraj_default.solution.prob.f.f isa MatrixOperator
+
+    # 4. Both paths must agree on fidelity for the same pulse.
+    @test fidelity(qtraj_magnus) ≈ fidelity(qtraj_rk) atol = 1e-6
+end
+
+@testitem "KetTrajectory auto-selects ODE problem form by algorithm" begin
+    # Performance bug fix counterpart for KetTrajectory. See UnitaryTrajectory
+    # auto-selection test for rationale.
+    using LinearAlgebra
+    using OrdinaryDiffEqLinear: MagnusAdapt4
+    using OrdinaryDiffEqTsit5: Tsit5
+    using OrdinaryDiffEqLinear: MatrixOperator
+
+    sys = QuantumSystem([PAULIS.X], [1.0])
+    T = π / 2
+    pulse = ZeroOrderPulse(ones(1, 2), [0.0, T])
+    ψ0 = ComplexF64[1.0, 0.0]
+    ψg = ComplexF64[0.0, 1.0]
+
+    qtraj_magnus = KetTrajectory(
+        sys,
+        pulse,
+        ψ0,
+        ψg;
+        algorithm = MagnusAdapt4(),
+        abstol = 1e-10,
+        reltol = 1e-10,
+    )
+    @test qtraj_magnus.solution.prob.f.f isa MatrixOperator
+
+    qtraj_rk = KetTrajectory(
+        sys,
+        pulse,
+        ψ0,
+        ψg;
+        algorithm = Tsit5(),
+        abstol = 1e-10,
+        reltol = 1e-10,
+    )
+    @test !(qtraj_rk.solution.prob.f.f isa MatrixOperator)
+
+    qtraj_default = KetTrajectory(sys, pulse, ψ0, ψg)
+    @test qtraj_default.solution.prob.f.f isa MatrixOperator
+
+    @test fidelity(qtraj_magnus) ≈ fidelity(qtraj_rk) atol = 1e-6
+end
+
+@testitem "MultiKetTrajectory auto-selects ODE problem form by algorithm" begin
+    # Performance bug fix counterpart for MultiKetTrajectory.
+    using LinearAlgebra
+    using OrdinaryDiffEqLinear: MagnusAdapt4
+    using OrdinaryDiffEqTsit5: Tsit5
+    using OrdinaryDiffEqLinear: MatrixOperator
+
+    sys = QuantumSystem([PAULIS.X], [1.0])
+    T = π / 2
+    pulse = ZeroOrderPulse(ones(1, 2), [0.0, T])
+    initials = [ComplexF64[1.0, 0.0], ComplexF64[0.0, 1.0]]
+    goals = [ComplexF64[0.0, 1.0], ComplexF64[1.0, 0.0]]
+
+    qtraj_magnus = MultiKetTrajectory(
+        sys,
+        pulse,
+        initials,
+        goals;
+        algorithm = MagnusAdapt4(),
+        abstol = 1e-10,
+        reltol = 1e-10,
+    )
+    # EnsembleSolution: per-trajectory base prob lives in qtraj.solution.u[i].prob
+    @test qtraj_magnus.solution.u[1].prob.f.f isa MatrixOperator
+
+    qtraj_rk = MultiKetTrajectory(
+        sys,
+        pulse,
+        initials,
+        goals;
+        algorithm = Tsit5(),
+        abstol = 1e-10,
+        reltol = 1e-10,
+    )
+    @test !(qtraj_rk.solution.u[1].prob.f.f isa MatrixOperator)
+
+    # Default (Hermitian system) → Magnus → operator form.
+    qtraj_default = MultiKetTrajectory(sys, pulse, initials, goals)
+    @test qtraj_default.solution.u[1].prob.f.f isa MatrixOperator
+
+    @test fidelity(qtraj_magnus) ≈ fidelity(qtraj_rk) atol = 1e-6
+end
+
+@testitem "_needs_operator_form detects Magnus vs RK methods" begin
+    using OrdinaryDiffEqLinear: MagnusAdapt4, MagnusGL4, MagnusGL6, MagnusGL8
+    using OrdinaryDiffEqTsit5: Tsit5
+
+    f = Piccolo.Quantum.Rollouts._needs_operator_form
+
+    # Magnus methods need operator form
+    @test f(MagnusAdapt4()) === true
+    @test f(MagnusGL4()) === true
+    @test f(MagnusGL6()) === true
+    @test f(MagnusGL8()) === true
+
+    # Explicit RK methods do not
+    @test f(Tsit5()) === false
 end

--- a/src/quantum/trajectories/unitary_trajectory.jl
+++ b/src/quantum/trajectories/unitary_trajectory.jl
@@ -76,12 +76,19 @@ function UnitaryTrajectory(
     # See KetTrajectory for rationale: Magnus methods need the matrix-operator
     # form; explicit RK methods should use the sparse mul! RHS form to avoid
     # per-step dense materialization of H.
-    prob = _needs_operator_form(algorithm) ?
+    prob =
+        _needs_operator_form(algorithm) ?
         UnitaryOperatorODEProblem(system, pulse, tstops; U0 = U0) :
         UnitaryODEProblem(system, pulse, tstops; U0 = U0)
-    sol = solve(prob, algorithm;
-                saveat = save_times, abstol = abstol, reltol = reltol,
-                progress = progress, progress_steps = progress_steps)
+    sol = solve(
+        prob,
+        algorithm;
+        saveat = save_times,
+        abstol = abstol,
+        reltol = reltol,
+        progress = progress,
+        progress_steps = progress_steps,
+    )
 
     return UnitaryTrajectory{typeof(pulse),typeof(sol)}(system, pulse, U0, goal_stored, sol)
 end


### PR DESCRIPTION
## Summary

Fix a performance bug that affects all quantum trajectory constructors (`KetTrajectory`, `UnitaryTrajectory`, `MultiKetTrajectory`) and the matching `rollout` / `rollout!` methods.

When a user passed an explicit Runge-Kutta algorithm (`Tsit5`, `Vern9`, `DP8`, ...), the constructors unconditionally built a `*OperatorODEProblem`, which materializes `H(t)` as a **dense** `SciMLOperators.MatrixOperator` at every ODE step via `collect(sys.H(u, t))`. For high-dimensional sparse systems (4-qubit transmon-coupler at dim ~6912), this turns a sparse `mul!` into a 380 MB dense materialization per step — what should be milliseconds becomes **hours**.

The fast path (`KetODEProblem` / `UnitaryODEProblem`) already exists and uses `mul!(dx, sys.H(...), x, -im, 0.0)` — a sparse-aware matvec with no dense materialization. It's what explicit RK methods actually need. The bug was a wiring issue: the constructor always picked the wrong form.

## Fix

- New helper `_needs_operator_form(algorithm)` in `dynamics.jl`. Detects Magnus-class algorithms structurally: `nameof(parentmodule(typeof(algorithm))) === :OrdinaryDiffEqLinear`. Magnus methods are Lie-group integrators that compute `exp(-iH·dt)·ψ` and *need* the matrix operator form; everything else routes to the sparse `mul!` path.
- Trajectory constructors and all 12 `rollout` / `rollout!` variants (`Unitary`/`Ket`/`MultiKet` × with-pulse/without-pulse × in-place/copy) now pick the problem form based on the resolved algorithm.
- The `if isnothing(algorithm)` algorithm-resolution block was moved *before* problem construction so we always know the algorithm class when choosing the form.

**Default behavior is unchanged.** `default_algorithm` returns `MagnusAdapt4` for Hermitian `QuantumSystem` and `Tsit5` for `OpenQuantumSystem` — both already route to the correct form. Only the explicit-RK case (`algorithm=Tsit5()`, `algorithm=Vern9()`, etc.) changes, and it changes from "broken/slow" to "fast". `DensityTrajectory` already used `DensityODEProblem` (mul! path), so no fix needed there.

## Benchmark

64-dim Hermitian sparse system, T=5 ns, abstol=reltol=1e-5:

| Path | Time per `KetTrajectory(...)` |
|------|-------------------------------|
| `Tsit5()` (fast path, after fix) | **27 ms** |
| `MagnusAdapt4()` (operator form, unchanged) | 585 ms |

21x speedup; fidelity agreement to 2.8e-9.

The user-reported case — 4-qubit transmon-coupler at dim 6912, the script at `demos/willow-andersen/scripts/eval_g3g4_statevec.jl` — went from a **2-hour ETA to seconds**.

## Tests

4 new `@testitem` blocks, 17 assertions:

- `UnitaryTrajectory auto-selects ODE problem form by algorithm` — builds with explicit Magnus, Tsit5, and default; inspects `qtraj.solution.prob.f.f` to verify routing; checks fidelity equivalence.
- Same coverage for `KetTrajectory` and `MultiKetTrajectory`.
- `_needs_operator_form` unit test against `MagnusAdapt4` / `GL4` / `GL6` / `GL8` (should be `true`) and `Tsit5` (should be `false`).

Full Piccolo test suite: **2080 passed, 0 failed, 46 errored, 4 broken**. All 46 errors are pre-existing missing optional dep loads (`CairoMakie`, `Aqua`, `JET`, `QuantumToolbox`) — not related to this change. All 4 broken markers are pre-existing.

## Validation against demos/willow-andersen

Verified `KetTrajectory(..., algorithm=Vern9())` now routes to the fast path (`_construct_rhs` closure, not `MatrixOperator`), and fidelity matches Magnus result to within numerical noise. The workaround in `eval_g3g4_statevec.jl` (direct `KetODEProblem` call) is now revertible to a clean `KetTrajectory` call.

## Test plan

- [ ] CI passes
- [ ] Revert workaround in `eval_g3g4_statevec.jl` to use `KetTrajectory` with `algorithm=Vern9()` (separate change, not in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)