### PR TITLE
fix(drives): isolate NonlinearDrive validator from global RNG

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
-version = "1.16.0"
+version = "1.16.1"
 authors = ["Aaron Trowbridge <aaron@harmoniqs.co> and contributors"]
 
 [deps]

--- a/src/quantum/systems/_quantum_systems.jl
+++ b/src/quantum/systems/_quantum_systems.jl
@@ -32,6 +32,7 @@ using ..QuantumObjectUtils
 using ..LiftedOperators
 
 using LinearAlgebra
+using Random
 using SparseArrays
 using TestItems
 using ForwardDiff

--- a/src/quantum/systems/drives.jl
+++ b/src/quantum/systems/drives.jl
@@ -442,8 +442,11 @@ function validate_drive_jacobian(
     atol::Float64 = 1e-6,
     n_samples::Int = 3,
 )
+    # Local RNG so QuantumSystem construction does not advance the caller's
+    # global RNG stream.
+    rng = MersenneTwister(0)
     for _ = 1:n_samples
-        u = randn(u_dim)
+        u = randn(rng, u_dim)
         grad_ad = ForwardDiff.gradient(d.coeff, u)
         for j = 1:u_dim
             user_val = d.coeff_jac(u, j)
@@ -467,8 +470,9 @@ function validate_drive_hessian(
     atol::Float64 = 1e-6,
     n_samples::Int = 3,
 )
+    rng = MersenneTwister(0)
     for _ = 1:n_samples
-        u = randn(u_dim)
+        u = randn(rng, u_dim)
         hess_ad = ForwardDiff.hessian(d.coeff, u)
         for i = 1:u_dim, j = i:u_dim
             user_val = d.coeff_hess(u, i, j)

--- a/src/quantum/systems/drives.jl
+++ b/src/quantum/systems/drives.jl
@@ -742,6 +742,53 @@ end
     @test_throws AssertionError validate_drive_jacobian(d_wrong_global, 3)
 end
 
+@testitem "QuantumSystem construction does not advance the global RNG" begin
+    # Regression: validators previously sampled with `randn(u_dim)` on the
+    # global stream during `QuantumSystem` construction, silently shifting
+    # downstream `rand`/`randn` results in user scripts that seed once at
+    # the top.
+
+    using Piccolo
+    using Random
+    using SparseArrays
+
+    H_drift = sparse(ComplexF64[1.0 0.0; 0.0 -1.0])
+    H1 = sparse(ComplexF64[0.0 1.0; 1.0 0.0])
+    H2 = sparse(ComplexF64[0.0 -1.0im; 1.0im 0.0])
+
+    # 1. Direct validator entry points.
+    d_simple = NonlinearDrive(H1, u -> u[1] * u[2] * u[3])
+    Random.seed!(42)
+    baseline = rand(5)
+    Random.seed!(42)
+    validate_drive_jacobian(d_simple, 3)
+    validate_drive_hessian(d_simple, 3)
+    @test rand(5) == baseline
+
+    # 2. Full QuantumSystem path with NonlinearDrives + globals — this is
+    #    the surface that hit the user. Multiple nonlinear drives × a
+    #    larger u_dim is the worst case for randn consumption.
+    drives = AbstractDrive[
+        LinearDrive(H1, 1),
+        NonlinearDrive(H2, u -> u[1]^2 + u[2] * u[3]),
+        NonlinearDrive(H1, u -> u[2] * u[3]),
+    ]
+    bounds = [(-1.0, 1.0), (-1.0, 1.0), (-1.0, 1.0)]
+    Random.seed!(42)
+    baseline2 = rand(5)
+    Random.seed!(42)
+    QuantumSystem(H_drift, drives, bounds; global_params = (g1 = 0.5,))
+    @test rand(5) == baseline2
+
+    # 3. Same again but with no globals — verifies the no-globals path is
+    #    also RNG-clean.
+    Random.seed!(42)
+    baseline3 = rand(5)
+    Random.seed!(42)
+    QuantumSystem(H_drift, drives, bounds)
+    @test rand(5) == baseline3
+end
+
 @testitem "G works on AbstractDrive types" begin
     using Piccolo
     using SparseArrays


### PR DESCRIPTION
## Summary

PR #194 added `validate_drive_jacobian` / `validate_drive_hessian` that
run automatically during `QuantumSystem` construction, sampling random
control vectors via `randn(u_dim)` on the **global** RNG. As a side
effect, constructing a `QuantumSystem` (especially with
`global_params`, which raises `u_dim`) advances the caller's RNG stream
by tens of draws.

Any user script that does:

```julia
Random.seed!(42)
sys = QuantumSystem(...; global_params = ...)
pulse_init = rand(...)              # silently shifted
```

now sees a different `pulse_init` than before PR #194. Downstream the
optimizer lands in a different basin from the same `seed!` — for
deliberately under-tracked / multi-basin problems (e.g. K=1→K=4
curricula), that can collapse Stage 2 coherent fidelity from ~1.0 to
~0.02 with no visible signal that anything moved.

Reproducer (REPL):

```julia
Random.seed!(42); a = rand(5)
Random.seed!(42); QuantumSystem(H_drift, drives, control_bounds;
    time_dependent=true, global_params=g); b = rand(5)
@assert a == b           # fails on main, passes after this fix
```

## Fix

Use a local `MersenneTwister(0)` inside both validators so construction
never touches the caller's stream. The validators remain deterministic
across runs (same samples, same assertions).

```julia
function validate_drive_jacobian(d, u_dim; atol=1e-6, n_samples=3)
    rng = MersenneTwister(0)
    for _ = 1:n_samples
        u = randn(rng, u_dim)
        # ...
    end
end
```

`using Random` added in `_quantum_systems.jl` alongside the other stdlib
imports.

## Verification

- REPL test confirms `seed!(42) → rand(5)` is identical with and
  without a preceding `QuantumSystem(...; global_params=...)` call.
- Bumped patch version 1.16.0 → 1.16.1.

## Notes

This is a determinism bug, not a solver bug. The optimizer and
dynamics are unchanged; only construction-time RNG behavior is fixed.
Scripts that don't rely on `Random.seed!` for control initialization
are unaffected.