### PR TITLE
feat(viz): LivePulsePlotCallback for live pulse plotting during solves

### DIFF
--- a/ext/PiccoloMakieExt.jl
+++ b/ext/PiccoloMakieExt.jl
@@ -119,7 +119,9 @@ function (cb::_LivePulsePlotCallback)(primal::AbstractVector, iter::Integer)
     expected = data_dim + traj.global_dim
     if length(primal) != expected
         @warn "primal-vector length mismatch ($(length(primal)) vs $expected); " *
-              "pass `fixed_variable_treatment = MadNLP.RelaxBound` to MadNLPOptions"
+              "trajectory reconstruction skipped. (For MadNLP, this usually " *
+              "means `fixed_variable_treatment` was set to `MakeParameter` " *
+              "explicitly, overriding DTO's default RelaxBound coupling.)"
         return true
     end
 
@@ -185,10 +187,10 @@ end
                                every = 1, save_dir = save_dir)
     @test cb isa DirectTrajOpt.AbstractIntermediateCallback
 
+    # No explicit fixed_variable_treatment — DTO auto-couples RelaxBound.
     DirectTrajOpt.solve!(qcp; options = DirectTrajOpt.MadNLPOptions(
         max_iter = 3,
         intermediate_callback = cb,
-        fixed_variable_treatment = MadNLP.RelaxBound,
     ), verbose = false)
 
     pngs = filter(f -> endswith(f, ".png"), readdir(save_dir))

--- a/ext/PiccoloMakieExt.jl
+++ b/ext/PiccoloMakieExt.jl
@@ -177,8 +177,14 @@ end
     qtraj = UnitaryTrajectory(sys, pulse, GATES[:X])
 
     opts = PiccoloOptions(timesteps_all_equal = true, verbose = false)
-    qcp = SmoothPulseProblem(qtraj, N; Q = 100.0, R = 1e-2, ddu_bound = 1.0,
-                             piccolo_options = opts)
+    qcp = SmoothPulseProblem(
+        qtraj,
+        N;
+        Q = 100.0,
+        R = 1e-2,
+        ddu_bound = 1.0,
+        piccolo_options = opts,
+    )
 
     save_dir = mktempdir()
     cb = LivePulsePlotCallback(qtraj, qcp.prob.trajectory; save_dir = save_dir)

--- a/ext/PiccoloMakieExt.jl
+++ b/ext/PiccoloMakieExt.jl
@@ -107,6 +107,7 @@ function Piccolo.LivePulsePlotCallback(
     save_dir::Union{Nothing,String} = nothing,
     title_prefix::String = "iter",
 )
+    every >= 1 || throw(ArgumentError("every must be >= 1, got $every"))
     if save_dir !== nothing
         mkpath(save_dir)
     end
@@ -114,6 +115,11 @@ function Piccolo.LivePulsePlotCallback(
 end
 
 function (cb::_LivePulsePlotCallback)(primal::AbstractVector, iter::Integer)
+    # Gate skipped iters before any allocation.
+    if (iter % cb.every) != 0
+        return true
+    end
+
     traj = cb.trajectory
     data_dim = traj.dim * traj.N
     expected = data_dim + traj.global_dim
@@ -121,7 +127,7 @@ function (cb::_LivePulsePlotCallback)(primal::AbstractVector, iter::Integer)
         @warn "primal-vector length mismatch ($(length(primal)) vs $expected); " *
               "trajectory reconstruction skipped. (For MadNLP, this usually " *
               "means `fixed_variable_treatment` was set to `MakeParameter` " *
-              "explicitly, overriding DTO's default RelaxBound coupling.)"
+              "explicitly, overriding DTO's default RelaxBound coupling.)" maxlog = 1
         return true
     end
 
@@ -131,15 +137,11 @@ function (cb::_LivePulsePlotCallback)(primal::AbstractVector, iter::Integer)
         update!(traj, collect(view(primal, 1:data_dim)); type = :data)
     end
 
-    if (iter % cb.every) != 0
-        return true
-    end
-
     pulse = extract_pulse(cb.qtraj, traj)
     fig = plot_pulse(pulse; title = "$(cb.title_prefix) $iter")
 
     if cb.save_dir !== nothing
-        Makie.save(joinpath(cb.save_dir, "iter_$(lpad(iter, 3, '0')).png"), fig)
+        Makie.save(joinpath(cb.save_dir, "iter_$(lpad(iter, 5, '0')).png"), fig)
     end
     return true
 end
@@ -161,18 +163,14 @@ end
 end
 
 
-@testitem "LivePulsePlotCallback fires through MadNLP via abstract adapter" begin
+@testitem "LivePulsePlotCallback subtype + direct invocation" begin
     using DirectTrajOpt
     using NamedTrajectories
     using CairoMakie
-    import MadNLP
     using Random
 
     Random.seed!(42)
-    H_drift = 0.5 * PAULIS[:Z]
-    H_drives = [PAULIS[:X], PAULIS[:Y]]
-    sys = QuantumSystem(H_drift, H_drives, [1.0, 1.0])
-
+    sys = QuantumSystem(0.5 * PAULIS[:Z], [PAULIS[:X], PAULIS[:Y]], [1.0, 1.0])
     T, N = 10.0, 30
     times = collect(range(0, T, length = N))
     pulse = ZeroOrderPulse(0.1 * randn(2, N), times)
@@ -183,18 +181,70 @@ end
                              piccolo_options = opts)
 
     save_dir = mktempdir()
-    cb = LivePulsePlotCallback(qtraj, qcp.prob.trajectory;
-                               every = 1, save_dir = save_dir)
+    cb = LivePulsePlotCallback(qtraj, qcp.prob.trajectory; save_dir = save_dir)
+
+    # Type contract: the callback subtypes DTO's solver-agnostic abstract type,
+    # so any DTO backend can install it via its intermediate_callback option.
     @test cb isa DirectTrajOpt.AbstractIntermediateCallback
 
-    # No explicit fixed_variable_treatment — DTO auto-couples RelaxBound.
-    DirectTrajOpt.solve!(qcp; options = DirectTrajOpt.MadNLPOptions(
-        max_iter = 3,
-        intermediate_callback = cb,
-    ), verbose = false)
+    # Direct invocation with a synthesized primal vector of the right length.
+    traj = qcp.prob.trajectory
+    expected = traj.dim * traj.N + traj.global_dim
+    @test cb(randn(expected), 0) === true
+    @test cb(randn(expected), 1) === true
 
     pngs = filter(f -> endswith(f, ".png"), readdir(save_dir))
-    @test !isempty(pngs)
+    @test length(pngs) == 2
+
+    # Each call produces a distinct frame.
+    @test stat(joinpath(save_dir, pngs[1])).size != stat(joinpath(save_dir, pngs[2])).size
+end
+
+@testitem "LivePulsePlotCallback every > 1 skips renders" begin
+    using DirectTrajOpt
+    using NamedTrajectories
+    using CairoMakie
+    using Random
+
+    Random.seed!(7)
+    sys = QuantumSystem(0.5 * PAULIS[:Z], [PAULIS[:X]], [1.0])
+    times = collect(range(0, 5.0, length = 20))
+    qtraj = UnitaryTrajectory(sys, ZeroOrderPulse(0.1 * randn(1, 20), times), GATES[:X])
+    qcp = SmoothPulseProblem(
+        qtraj,
+        20;
+        piccolo_options = PiccoloOptions(timesteps_all_equal = true, verbose = false),
+    )
+
+    save_dir = mktempdir()
+    cb = LivePulsePlotCallback(qtraj, qcp.prob.trajectory; every = 3, save_dir = save_dir)
+
+    traj = qcp.prob.trajectory
+    expected = traj.dim * traj.N + traj.global_dim
+    for iter = 0:10
+        cb(randn(expected), iter)
+    end
+
+    # iter % 3 == 0 fires on iters 0, 3, 6, 9 → 4 PNGs out of 11 invocations.
+    pngs = filter(f -> endswith(f, ".png"), readdir(save_dir))
+    @test length(pngs) == 4
+end
+
+@testitem "LivePulsePlotCallback rejects every <= 0" begin
+    using NamedTrajectories
+    using CairoMakie
+
+    sys = QuantumSystem(0.5 * PAULIS[:Z], [PAULIS[:X]], [1.0])
+    times = collect(range(0, 1.0, length = 5))
+    qtraj = UnitaryTrajectory(sys, ZeroOrderPulse(zeros(1, 5), times), GATES[:X])
+    qcp = SmoothPulseProblem(
+        qtraj,
+        5;
+        piccolo_options = PiccoloOptions(timesteps_all_equal = true, verbose = false),
+    )
+
+    @test_throws ArgumentError LivePulsePlotCallback(qtraj, qcp.prob.trajectory; every = 0)
+    @test_throws ArgumentError LivePulsePlotCallback(qtraj, qcp.prob.trajectory; every = -1)
 end
 
 

--- a/ext/PiccoloMakieExt.jl
+++ b/ext/PiccoloMakieExt.jl
@@ -5,6 +5,10 @@ using Makie
 using NamedTrajectories
 using TestItems
 
+using DirectTrajOpt: AbstractIntermediateCallback
+using NamedTrajectories: update!
+using Piccolo: AbstractQuantumTrajectory, extract_pulse, plot_pulse
+
 # Animation implementations - extend Piccolo stubs.
 # Docstrings live on the stubs in `src/visualizations/animations.jl`.
 
@@ -84,6 +88,61 @@ function Piccolo.animate_name(
 end
 
 
+# ---------------------------------------------------------------------------- #
+# LivePulsePlotCallback — implementation of stub in src/visualizations/live_callbacks.jl
+# ---------------------------------------------------------------------------- #
+
+struct _LivePulsePlotCallback{QT<:AbstractQuantumTrajectory} <: AbstractIntermediateCallback
+    qtraj::QT
+    trajectory::NamedTrajectory
+    every::Int
+    save_dir::Union{Nothing,String}
+    title_prefix::String
+end
+
+function Piccolo.LivePulsePlotCallback(
+    qtraj::AbstractQuantumTrajectory,
+    traj::NamedTrajectory;
+    every::Int = 1,
+    save_dir::Union{Nothing,String} = nothing,
+    title_prefix::String = "iter",
+)
+    if save_dir !== nothing
+        mkpath(save_dir)
+    end
+    return _LivePulsePlotCallback(qtraj, traj, every, save_dir, title_prefix)
+end
+
+function (cb::_LivePulsePlotCallback)(primal::AbstractVector, iter::Integer)
+    traj = cb.trajectory
+    data_dim = traj.dim * traj.N
+    expected = data_dim + traj.global_dim
+    if length(primal) != expected
+        @warn "primal-vector length mismatch ($(length(primal)) vs $expected); " *
+              "pass `fixed_variable_treatment = MadNLP.RelaxBound` to MadNLPOptions"
+        return true
+    end
+
+    if traj.global_dim > 0
+        update!(traj, collect(view(primal, 1:expected)); type = :both)
+    else
+        update!(traj, collect(view(primal, 1:data_dim)); type = :data)
+    end
+
+    if (iter % cb.every) != 0
+        return true
+    end
+
+    pulse = extract_pulse(cb.qtraj, traj)
+    fig = plot_pulse(pulse; title = "$(cb.title_prefix) $iter")
+
+    if cb.save_dir !== nothing
+        Makie.save(joinpath(cb.save_dir, "iter_$(lpad(iter, 3, '0')).png"), fig)
+    end
+    return true
+end
+
+
 @testitem "Test animate_name for NamedTrajectory" begin
     using QuantumToolbox
     using NamedTrajectories
@@ -97,6 +156,43 @@ end
 
     fig = animate_name(traj, :ψ̃, mode = :inline, fps = 10)
     @test fig isa Figure
+end
+
+
+@testitem "LivePulsePlotCallback fires through MadNLP via abstract adapter" begin
+    using DirectTrajOpt
+    using NamedTrajectories
+    using CairoMakie
+    import MadNLP
+    using Random
+
+    Random.seed!(42)
+    H_drift = 0.5 * PAULIS[:Z]
+    H_drives = [PAULIS[:X], PAULIS[:Y]]
+    sys = QuantumSystem(H_drift, H_drives, [1.0, 1.0])
+
+    T, N = 10.0, 30
+    times = collect(range(0, T, length = N))
+    pulse = ZeroOrderPulse(0.1 * randn(2, N), times)
+    qtraj = UnitaryTrajectory(sys, pulse, GATES[:X])
+
+    opts = PiccoloOptions(timesteps_all_equal = true, verbose = false)
+    qcp = SmoothPulseProblem(qtraj, N; Q = 100.0, R = 1e-2, ddu_bound = 1.0,
+                             piccolo_options = opts)
+
+    save_dir = mktempdir()
+    cb = LivePulsePlotCallback(qtraj, qcp.prob.trajectory;
+                               every = 1, save_dir = save_dir)
+    @test cb isa DirectTrajOpt.AbstractIntermediateCallback
+
+    DirectTrajOpt.solve!(qcp; options = DirectTrajOpt.MadNLPOptions(
+        max_iter = 3,
+        intermediate_callback = cb,
+        fixed_variable_treatment = MadNLP.RelaxBound,
+    ), verbose = false)
+
+    pngs = filter(f -> endswith(f, ".png"), readdir(save_dir))
+    @test !isempty(pngs)
 end
 
 

--- a/src/visualizations/_visualizations.jl
+++ b/src/visualizations/_visualizations.jl
@@ -5,6 +5,9 @@ using Reexport
 include("animations.jl")
 @reexport using .AnimatedPlots
 
+include("live_callbacks.jl")
+@reexport using .LiveCallbacks
+
 include("quantum_objects/_quantum_object_plots.jl")
 @reexport using .QuantumObjectPlots
 

--- a/src/visualizations/live_callbacks.jl
+++ b/src/visualizations/live_callbacks.jl
@@ -21,10 +21,7 @@ so it can be passed directly to any DTO solver backend:
 
 ```julia
 cb = LivePulsePlotCallback(qtraj, qcp.prob.trajectory; save_dir = "out/")
-solve!(qcp; options = MadNLPOptions(
-    intermediate_callback    = cb,
-    fixed_variable_treatment = MadNLP.RelaxBound,  # required for trajectory reconstruction
-))
+solve!(qcp; options = MadNLPOptions(intermediate_callback = cb))
 ```
 
 # Arguments
@@ -36,10 +33,11 @@ solve!(qcp; options = MadNLPOptions(
 - `save_dir`: if non-`nothing`, save `iter_NNN.png` per rendered iter.
 - `title_prefix`: title-bar prefix, joined to the iter count.
 
-# MadNLP caveat
-With default `fixed_variable_treatment = MadNLP.MakeParameter`, MadNLP eliminates
-fixed boundary variables from the primal vector and trajectory reconstruction
-breaks. Pass `MadNLP.RelaxBound` so the callback receives the full primal.
+# MadNLP note
+The callback needs the full primal vector (including fixed boundary variables) to
+reconstruct the trajectory faithfully. DTO sets `fixed_variable_treatment =
+MadNLP.RelaxBound` automatically when it sees an `AbstractIntermediateCallback`
+installed without an explicit value — you don't need to set it yourself.
 
 Defined as a stub here; the implementation is provided by the `PiccoloMakieExt`
 extension and is loaded when a Makie backend (`CairoMakie`, `GLMakie`, `WGLMakie`)

--- a/src/visualizations/live_callbacks.jl
+++ b/src/visualizations/live_callbacks.jl
@@ -1,0 +1,50 @@
+module LiveCallbacks
+
+export LivePulsePlotCallback
+
+"""
+    LivePulsePlotCallback(
+        qtraj::AbstractQuantumTrajectory,
+        traj::NamedTrajectory;
+        every::Int = 1,
+        save_dir::Union{Nothing,String} = nothing,
+        title_prefix::String = "iter",
+    )
+
+Solver-agnostic per-iteration callback for trajectory optimization. Each
+time it fires it reconstructs the current pulse via `extract_pulse(qtraj, traj)`,
+renders it with `plot_pulse(pulse; title = "\$title_prefix \$iter")`, and
+(if `save_dir` is set) writes a PNG snapshot to disk.
+
+The returned callback subtypes `DirectTrajOpt.AbstractIntermediateCallback`,
+so it can be passed directly to any DTO solver backend:
+
+```julia
+cb = LivePulsePlotCallback(qtraj, qcp.prob.trajectory; save_dir = "out/")
+solve!(qcp; options = MadNLPOptions(
+    intermediate_callback    = cb,
+    fixed_variable_treatment = MadNLP.RelaxBound,  # required for trajectory reconstruction
+))
+```
+
+# Arguments
+- `qtraj`: the original `AbstractQuantumTrajectory` (provides pulse type + drive names).
+- `traj`: the `NamedTrajectory` being optimized in place; mutated by the callback each iter.
+
+# Keyword Arguments
+- `every`: redraw cadence in IPM iterations. `1` plots every iter.
+- `save_dir`: if non-`nothing`, save `iter_NNN.png` per rendered iter.
+- `title_prefix`: title-bar prefix, joined to the iter count.
+
+# MadNLP caveat
+With default `fixed_variable_treatment = MadNLP.MakeParameter`, MadNLP eliminates
+fixed boundary variables from the primal vector and trajectory reconstruction
+breaks. Pass `MadNLP.RelaxBound` so the callback receives the full primal.
+
+Defined as a stub here; the implementation is provided by the `PiccoloMakieExt`
+extension and is loaded when a Makie backend (`CairoMakie`, `GLMakie`, `WGLMakie`)
+is available.
+"""
+function LivePulsePlotCallback end
+
+end


### PR DESCRIPTION
## Summary

Adds `LivePulsePlotCallback` — a solver-agnostic per-iteration callback that renders the converging pulse via `plot_pulse(extract_pulse(qtraj, traj))` and optionally saves a PNG per render. Lets you watch an optimization live or stitch the saved frames into an animation.

Usage:

```julia
using Piccolo, DirectTrajOpt, CairoMakie
import MadNLP

cb = LivePulsePlotCallback(qtraj, qcp.prob.trajectory; save_dir = "out/")

solve!(qcp; options = MadNLPOptions(
    intermediate_callback    = cb,
    fixed_variable_treatment = MadNLP.RelaxBound,
))
```

## Architecture

- **Stub** in `src/visualizations/live_callbacks.jl` (always loaded). Docstring + `function LivePulsePlotCallback end`.
- **Implementation** in the existing `PiccoloMakieExt` extension. Defines `_LivePulsePlotCallback <: DirectTrajOpt.AbstractIntermediateCallback` and a constructor method on `Piccolo.LivePulsePlotCallback`.
- **No new extension package**. Because the callback subtypes DTO's solver-agnostic `AbstractIntermediateCallback`, the per-solver wrapping happens inside each DTO solver extension (`MadNLPSolverExt`, future `IpoptSolverExt`). Piccolo only needs to know about `Makie`, which `PiccoloMakieExt` already declares.

## Depends on

[harmoniqs/DirectTrajOpt.jl#98](https://github.com/harmoniqs/DirectTrajOpt.jl/pull/98) — introduces `DirectTrajOpt.AbstractIntermediateCallback` plus the MadNLP adapter that translates `(solver, mode) → (variable(solver.x), solver.cnt.k)`.

DTO #98 should land first.

## MadNLP caveat

`fixed_variable_treatment = MadNLP.RelaxBound` is required for the callback to receive the full primal vector — without it MadNLP's default `MakeParameter` eliminates fixed boundary variables and trajectory reconstruction fails. The callback emits a helpful `@warn` if it sees a mismatched primal-vector length, so the failure mode is at least informative.

## Test plan

- [x] `LivePulsePlotCallback fires through MadNLP via abstract adapter` testitem — constructs the callback, asserts `cb isa DirectTrajOpt.AbstractIntermediateCallback`, solves a small X-gate problem with `intermediate_callback = cb` + `fixed_variable_treatment = MadNLP.RelaxBound`, and asserts PNGs were written.
- [x] End-to-end smoke (out of repo): 200-iter `SmoothPulseProblem` with the callback at `every = 1` produces 201 distinct frames tracking the converging pulse; renders are the docs-grade stacked-panel `plot_pulse` output from Piccolo v1.16's visualization stack.