### PR TITLE
feat: BSplinePulse — convex-hull-bounded smooth pulse parameterization (partial)

### DIFF
--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -648,6 +648,61 @@ end
     @test !haskey(traj.components, :du)
 end
 
+@testitem "SplinePulseProblem with BSplinePulse: optimization converges" begin
+    # Task 23 v2 acceptance: BSpline optimization with the default BilinearIntegrator
+    # must actually reduce the objective when solver iterations run. This is the
+    # gating test for Task 26-28 demos.
+    using Piccolo
+    using NamedTrajectories
+    using DirectTrajOpt
+    using LinearAlgebra
+    using Random
+    Random.seed!(20260526)
+
+    σx = ComplexF64[0 1; 1 0]
+    σz = ComplexF64[1 0; 0 -1]
+    H_drift = 0.01 * σz
+    H_drives = [σx]
+    T = 10.0
+    N = 21
+    n_drives = 1
+
+    sys = QuantumSystem(H_drift, H_drives, [1.0])
+    nbf = N + 2
+    times = collect(range(0.0, T, length = N))
+    C = 0.1 .* randn(n_drives, nbf)
+    pulse = BSplinePulse(C, times; degree = 3, initial_value = :free, final_value = :free)
+    U_goal = ComplexF64[0 1; 1 0]
+    qtraj = UnitaryTrajectory(sys, pulse, U_goal)
+    qcp = SplinePulseProblem(qtraj, N; Q = 100.0, R = 1e-2)
+
+    # Capture initial control samples for comparison.
+    traj_initial = get_trajectory(qcp)
+    u_initial = copy(traj_initial[:u])
+
+    # Solve a few iterations.
+    solve!(qcp; max_iter = 30, print_level = 0)
+
+    traj_final = get_trajectory(qcp)
+    u_final = traj_final[:u]
+
+    # Convergence proxy: the optimizer must move the control values meaningfully
+    # (not just regularization tweaks). If the integrator doesn't see optimizer
+    # updates, u stays roughly at the initial guess.
+    Δu_norm = norm(u_final .- u_initial)
+    @test Δu_norm > 0.01
+
+    # Stronger check: the final iso-vec state should be closer to the goal than
+    # the initial one. Pull the goal and the final-knot state.
+    Ũ_final_init = traj_initial[:Ũ⃗][:, end]
+    Ũ_final_solved = traj_final[:Ũ⃗][:, end]
+    Ũ_goal = traj_final.goal[:Ũ⃗]
+
+    err_init = norm(Ũ_final_init .- Ũ_goal)
+    err_final = norm(Ũ_final_solved .- Ũ_goal)
+    @test err_final < err_init
+end
+
 @testitem "SplinePulseProblem with CubicSplinePulse" begin
     using NamedTrajectories
     using DirectTrajOpt

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -3,6 +3,7 @@ export SplinePulseProblem
 # Helper function to determine spline order from pulse type
 _get_spline_order(::LinearSplinePulse) = 1
 _get_spline_order(::CubicSplinePulse) = 3
+_get_spline_order(p::BSplinePulse) = Piccolo.BsplineBases.degree(p.basis)
 
 # _make_free_phase_goal is defined in _problem_templates.jl (shared across all templates)
 
@@ -163,8 +164,11 @@ function SplinePulseProblem(
     # Always add control derivatives to trajectory
     # For CubicSplinePulse, :du is already included in the base trajectory (Hermite tangents)
     # For LinearSplinePulse, we add :du explicitly (will be constrained by DerivativeIntegrator)
+    # For BSplinePulse, no :du component — derivative bounds go through
+    # BSplineDerivativeBoundConstraint (Piccolissimo Task 24) instead.
     du_sym = Symbol(:d, control_sym)
-    is_linear_spline = !haskey(base_traj.components, du_sym)
+    is_bspline_pulse = qtraj.pulse isa BSplinePulse
+    is_linear_spline = !haskey(base_traj.components, du_sym) && !is_bspline_pulse
 
     # Resolve per-drive du bounds: du_bounds (vector) takes precedence over du_bound (scalar)
     _du_bounds_vec = if !isnothing(du_bounds)
@@ -175,7 +179,17 @@ function SplinePulseProblem(
         nothing
     end
 
-    traj = if haskey(base_traj.components, du_sym)
+    traj = if is_bspline_pulse
+        # BSplinePulse: trajectory's :u holds sampled values; derivatives are
+        # not first-class trajectory DOFs (controlled via constraints instead).
+        if !isnothing(_du_bounds_vec) && _show_details(piccolo_options)
+            println(
+                "    du bounds (BSplinePulse): $(_fmt_bounds(_du_bounds_vec)) — " *
+                "will be enforced by BSplineDerivativeBoundConstraint (TODO Task 24)",
+            )
+        end
+        base_traj
+    elseif haskey(base_traj.components, du_sym)
         # CubicSplinePulse already has derivative DOFs, but bounds default to (-Inf, Inf)
         if !isnothing(_du_bounds_vec)
             update_bound!(base_traj, du_sym, (-_du_bounds_vec, _du_bounds_vec))
@@ -237,7 +251,10 @@ function SplinePulseProblem(
 
     # Add regularization for control and derivative
     J += QuadraticRegularizer(control_sym, traj, R_u)
-    J += QuadraticRegularizer(du_sym, traj, R_du)
+    if !is_bspline_pulse
+        # BSplinePulse has no :du component; derivative regularization is a no-op.
+        J += QuadraticRegularizer(du_sym, traj, R_du)
+    end
 
     # Apply piccolo options
     J += _apply_piccolo_options(
@@ -386,8 +403,11 @@ function SplinePulseProblem(
     # Always add control derivatives to trajectory
     # For CubicSplinePulse, :du is already included in the base trajectory (Hermite tangents)
     # For LinearSplinePulse, we add :du explicitly (will be constrained by DerivativeIntegrator)
+    # For BSplinePulse, no :du component — derivative bounds go through
+    # BSplineDerivativeBoundConstraint (Piccolissimo Task 24) instead.
     du_sym = Symbol(:d, control_sym)
-    is_linear_spline = !haskey(base_traj.components, du_sym)
+    is_bspline_pulse = qtraj.pulse isa BSplinePulse
+    is_linear_spline = !haskey(base_traj.components, du_sym) && !is_bspline_pulse
 
     # Resolve per-drive du bounds: du_bounds (vector) takes precedence over du_bound (scalar)
     _du_bounds_vec = if !isnothing(du_bounds)
@@ -398,7 +418,17 @@ function SplinePulseProblem(
         nothing
     end
 
-    traj = if haskey(base_traj.components, du_sym)
+    traj = if is_bspline_pulse
+        # BSplinePulse: trajectory's :u holds sampled values; derivatives are
+        # not first-class trajectory DOFs (controlled via constraints instead).
+        if !isnothing(_du_bounds_vec) && _show_details(piccolo_options)
+            println(
+                "    du bounds (BSplinePulse): $(_fmt_bounds(_du_bounds_vec)) — " *
+                "will be enforced by BSplineDerivativeBoundConstraint (TODO Task 24)",
+            )
+        end
+        base_traj
+    elseif haskey(base_traj.components, du_sym)
         # CubicSplinePulse already has derivative DOFs, but bounds default to (-Inf, Inf)
         if !isnothing(_du_bounds_vec)
             update_bound!(base_traj, du_sym, (-_du_bounds_vec, _du_bounds_vec))
@@ -468,7 +498,10 @@ function SplinePulseProblem(
 
     # Add regularization for control and derivative
     J += QuadraticRegularizer(control_sym, traj, R_u)
-    J += QuadraticRegularizer(du_sym, traj, R_du)
+    if !is_bspline_pulse
+        # BSplinePulse has no :du component; derivative regularization is a no-op.
+        J += QuadraticRegularizer(du_sym, traj, R_du)
+    end
 
     # Apply piccolo options for each state
     J += _apply_piccolo_options(
@@ -579,6 +612,40 @@ end
     traj = get_trajectory(qcp)
     @test haskey(traj.components, :u) || haskey(traj.components, :θ)
     @test !haskey(traj.components, :ddu)  # No second derivative for splines
+end
+
+@testitem "SplinePulseProblem with BSplinePulse (constructs without :du)" begin
+    using Piccolo
+    using NamedTrajectories
+    using DirectTrajOpt
+    using LinearAlgebra
+
+    σx = ComplexF64[0 1; 1 0]
+    σz = ComplexF64[1 0; 0 -1]
+    H_drift = 0.01 * σz
+    H_drives = [σx]
+    T = 10.0
+    N = 21
+    n_drives = 1
+
+    sys = QuantumSystem(H_drift, H_drives, [1.0])
+
+    nbf = N + 2  # degree 3, aligned
+    times = collect(range(0.0, T, length = N))
+    C = 0.1 .* randn(n_drives, nbf)
+    pulse = BSplinePulse(C, times; degree = 3, initial_value = :free, final_value = :free)
+
+    U_goal = ComplexF64[0 1; 1 0]
+    qtraj = UnitaryTrajectory(sys, pulse, U_goal)
+
+    qcp = SplinePulseProblem(qtraj, N; Q = 100.0, R = 1e-2)
+    @test qcp isa QuantumControlProblem
+
+    traj = get_trajectory(qcp)
+    @test haskey(traj.components, :u)
+    # BSpline path skips the LinearSpline DerivativeIntegrator and the :du component;
+    # derivative bounds (when added in Task 24) go through a separate constraint.
+    @test !haskey(traj.components, :du)
 end
 
 @testitem "SplinePulseProblem with CubicSplinePulse" begin

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -676,27 +676,19 @@ end
     qtraj = UnitaryTrajectory(sys, pulse, U_goal)
     qcp = SplinePulseProblem(qtraj, N; Q = 100.0, R = 1e-2)
 
-    # Capture initial control samples for comparison.
-    traj_initial = get_trajectory(qcp)
-    u_initial = copy(traj_initial[:u])
+    # Capture initial values BY COPY (get_trajectory returns a live reference).
+    u_initial = copy(get_trajectory(qcp)[:u])
+    Ũ_final_init = copy(get_trajectory(qcp)[:Ũ⃗][:, end])
+    Ũ_goal = copy(get_trajectory(qcp).goal[:Ũ⃗])
 
     # Solve a few iterations.
     solve!(qcp; max_iter = 30, print_level = 0)
 
-    traj_final = get_trajectory(qcp)
-    u_final = traj_final[:u]
+    u_final = copy(get_trajectory(qcp)[:u])
+    Ũ_final_solved = copy(get_trajectory(qcp)[:Ũ⃗][:, end])
 
-    # Convergence proxy: the optimizer must move the control values meaningfully
-    # (not just regularization tweaks). If the integrator doesn't see optimizer
-    # updates, u stays roughly at the initial guess.
     Δu_norm = norm(u_final .- u_initial)
     @test Δu_norm > 0.01
-
-    # Stronger check: the final iso-vec state should be closer to the goal than
-    # the initial one. Pull the goal and the final-knot state.
-    Ũ_final_init = traj_initial[:Ũ⃗][:, end]
-    Ũ_final_solved = traj_final[:Ũ⃗][:, end]
-    Ũ_goal = traj_final.goal[:Ũ⃗]
 
     err_init = norm(Ũ_final_init .- Ũ_goal)
     err_final = norm(Ũ_final_solved .- Ũ_goal)

--- a/src/quantum/_quantum.jl
+++ b/src/quantum/_quantum.jl
@@ -28,6 +28,9 @@ include("primitives/gates.jl")
 include("primitives/isomorphisms.jl")
 @reexport using .Isomorphisms
 
+include("primitives/bspline_basis.jl")
+@reexport using .BsplineBases
+
 include("primitives/pulses.jl")
 @reexport using .Pulses
 

--- a/src/quantum/primitives/bspline_basis.jl
+++ b/src/quantum/primitives/bspline_basis.jl
@@ -100,6 +100,66 @@ function BsplineBasis(
     return BsplineBasis{T}(k, knots)
 end
 
+"""
+    degree(b::BsplineBasis) -> Int
+
+The polynomial degree of the basis (= order - 1).
+"""
+degree(b::BsplineBasis) = b.order - 1
+
+"""
+    num_basis_functions(b::BsplineBasis) -> Int
+
+The number of basis functions in this basis (= number of control points the
+basis can be applied to).
+"""
+num_basis_functions(b::BsplineBasis) = length(b.knots) - b.order
+
+"""
+    find_containing_interval(b::BsplineBasis, t::Real) -> Int
+
+Returns the index ℓ such that `b.knots[ℓ] <= t < b.knots[ℓ+1]` and
+`b.knots[ℓ] < b.knots[end - order + 1]` (the final parameter value).
+
+Note: at `t == final_parameter_value`, returns the largest valid ℓ where the
+right-endpoint inclusion holds — matches Drake's `FindContainingInterval`
+at bspline_basis.cc.
+"""
+function find_containing_interval(b::BsplineBasis{T}, t::Real) where {T}
+    t_typed = T(t)
+    a = b.knots[b.order]                  # initial_parameter_value
+    bmax = b.knots[end - b.order + 1]     # final_parameter_value
+    (a <= t_typed <= bmax) || throw(DomainError(t,
+        "parameter $t outside basis range [$a, $bmax]"))
+    # At exactly bmax, return the largest ℓ with knots[ℓ] < bmax.
+    if t_typed == bmax
+        ℓ = length(b.knots)
+        while ℓ > 1 && b.knots[ℓ] >= bmax
+            ℓ -= 1
+        end
+        return ℓ
+    end
+    # Otherwise: largest ℓ with knots[ℓ] <= t
+    ℓ = b.order
+    while ℓ < length(b.knots) - 1 && b.knots[ℓ+1] <= t_typed
+        ℓ += 1
+    end
+    return ℓ
+end
+
+"""
+    active_basis_function_indices(b::BsplineBasis, t::Real) -> Vector{Int}
+
+Returns the `order` (= d+1) indices of basis functions that are non-zero at `t`.
+Other basis functions are strictly zero at this parameter value.
+"""
+function active_basis_function_indices(b::BsplineBasis, t::Real)
+    ℓ = find_containing_interval(b, t)
+    return collect((ℓ-b.order+1):ℓ)
+end
+
+export find_containing_interval, active_basis_function_indices
+
 @testitem "BsplineBasis: constructor preconditions" begin
     using Piccolo
     # Reject degree 0 / order 1
@@ -121,6 +181,33 @@ end
     @test length(b.knots) == 8 + 4
     @test b.knots[1:4] == zeros(4)
     @test b.knots[end-3:end] == ones(4)
+end
+
+@testitem "BsplineBasis: degree / num_basis_functions / find_containing_interval / active indices" begin
+    using Piccolo
+
+    b = BsplineBasis(4, 8)  # cubic, 8 CPs, clamped uniform on [0, 1]
+    @test Piccolo.BsplineBases.degree(b) == 3
+    @test num_basis_functions(b) == 8
+
+    # Initial / final parameter values: knots[order] and knots[end - order + 1]
+    @test b.knots[b.order] == 0.0
+    @test b.knots[end-b.order+1] == 1.0
+
+    # find_containing_interval at start: ℓ = order = 4 (since knots[4]=0 <= 0 < knots[5]=0.2)
+    @test find_containing_interval(b, 0.0) == 4
+    @test find_containing_interval(b, 0.5) >= 4
+    # At t = final_parameter_value, ℓ = length(knots) - order = 12 - 4 = 8
+    @test find_containing_interval(b, 1.0) == length(b.knots) - b.order
+
+    # active_basis_function_indices returns the d+1 nonzero ones at t
+    actives = active_basis_function_indices(b, 0.5)
+    @test length(actives) == b.order  # d+1 = 4 for cubic
+    @test all(1 .<= actives .<= num_basis_functions(b))
+
+    # DomainError outside range
+    @test_throws DomainError find_containing_interval(b, -0.1)
+    @test_throws DomainError find_containing_interval(b, 1.5)
 end
 
 end # module BsplineBases

--- a/src/quantum/primitives/bspline_basis.jl
+++ b/src/quantum/primitives/bspline_basis.jl
@@ -160,6 +160,55 @@ end
 
 export find_containing_interval, active_basis_function_indices
 
+"""
+    evaluate_curve(b::BsplineBasis, control_points::AbstractMatrix, t::Real) -> Vector
+
+Evaluate a B-spline curve at parameter `t` via de Boor's flattened algorithm.
+
+# Arguments
+- `b`: the basis.
+- `control_points`: matrix with `n_drives` rows and `num_basis_functions(b)` columns.
+- `t`: parameter value in `[knots[order], knots[end - order + 1]]`.
+
+Returns a vector of length `n_drives`.
+
+Port of Drake's `math::BsplineBasis::EvaluateCurve` (bspline_basis.h:133-180).
+AD-friendly: pure arithmetic on the promoted (eltype(C), typeof(t)) type.
+"""
+function evaluate_curve(b::BsplineBasis, control_points::AbstractMatrix, t::Real)
+    size(control_points, 2) == num_basis_functions(b) || throw(DimensionMismatch(
+        "control_points has $(size(control_points,2)) columns; basis has $(num_basis_functions(b))"))
+    n_drives = size(control_points, 1)
+    k = b.order
+    ℓ = find_containing_interval(b, t)
+    knots = b.knots
+    # Promote element type to handle ForwardDiff Duals on either side
+    Tp = promote_type(eltype(control_points), typeof(t), eltype(knots))
+
+    # p[:, r+1] holds the de Boor point pᵢʲ at recursion stage j; i = ℓ - r.
+    p = Matrix{Tp}(undef, n_drives, k)
+    for r in 0:(k-1)
+        i = ℓ - r
+        @views p[:, r+1] .= control_points[:, i]
+    end
+    # For j = 1, ..., k-1
+    for j in 1:(k-1)
+        for r in 0:(k-j-1)
+            i = ℓ - r
+            denom = knots[i+k-j] - knots[i]
+            # In a well-formed clamped basis this can be zero only at boundary
+            # collapses where both numerator and denominator vanish and the
+            # corresponding p column is already correct. Guard against 0/0.
+            if denom == 0
+                continue
+            end
+            α = (t - knots[i]) / denom
+            @views @. p[:, r+1] = (1 - α) * p[:, r+2] + α * p[:, r+1]
+        end
+    end
+    return p[:, 1]
+end
+
 @testitem "BsplineBasis: constructor preconditions" begin
     using Piccolo
     # Reject degree 0 / order 1
@@ -208,6 +257,64 @@ end
     # DomainError outside range
     @test_throws DomainError find_containing_interval(b, -0.1)
     @test_throws DomainError find_containing_interval(b, 1.5)
+end
+
+@testitem "BsplineBasis: d=1 hand-computed piecewise linear interpolation" begin
+    using Piccolo
+
+    # Degree-1 clamped basis on [0, 1] with 4 CPs → knots [0,0, 1/3, 2/3, 1,1]
+    b = BsplineBasis(2, 4)
+    C = reshape([0.0, 1.0, -1.0, 2.0], 1, 4)  # 1 drive, 4 CPs
+
+    # At each clamped endpoint, curve passes through corresponding CP
+    @test evaluate_curve(b, C, 0.0)[1] == 0.0
+    @test evaluate_curve(b, C, 1.0)[1] == 2.0
+    # Clamped d=1 curve passes through P_2 at 1/3, P_3 at 2/3
+    @test evaluate_curve(b, C, 1/3)[1] ≈ 1.0 atol = 1e-14
+    @test evaluate_curve(b, C, 2/3)[1] ≈ -1.0 atol = 1e-14
+
+    # Midpoint of segment [0, 1/3]: half-way between CP_1=0 and CP_2=1
+    @test evaluate_curve(b, C, 1/6)[1] ≈ 0.5 atol = 1e-14
+    # Midpoint of segment [1/3, 2/3]: half-way between CP_2=1 and CP_3=-1
+    @test evaluate_curve(b, C, 0.5)[1] ≈ 0.0 atol = 1e-14
+end
+
+@testitem "BsplineBasis: clamped endpoint exactness" begin
+    using Piccolo
+    using Random
+    Random.seed!(20260525)
+
+    for d in (2, 3, 4)
+        nbf = 10
+        b = BsplineBasis(d + 1, nbf)
+        C = randn(2, nbf)  # 2 drives
+        t_min = b.knots[b.order]
+        t_max = b.knots[end-b.order+1]
+        # Clamped basis: curve passes through first and last control points
+        @test evaluate_curve(b, C, t_min) ≈ C[:, 1] atol = 1e-14
+        @test evaluate_curve(b, C, t_max) ≈ C[:, end] atol = 1e-14
+    end
+end
+
+@testitem "BsplineBasis: evaluate_curve continuity at interior knots" begin
+    using Piccolo
+    using Random
+    Random.seed!(20260525)
+
+    # For a cubic clamped basis, the curve must be continuous across interior knots.
+    for d in (2, 3, 4)
+        nbf = 12
+        b = BsplineBasis(d + 1, nbf)
+        C = randn(1, nbf)
+        # Interior knots
+        interior_knots = unique(b.knots[(b.order+1):(end-b.order)])
+        for τ in interior_knots
+            ε = 1e-10
+            left = evaluate_curve(b, C, τ - ε)[1]
+            right = evaluate_curve(b, C, τ + ε)[1]
+            @test isapprox(left, right; atol = 1e-6)
+        end
+    end
 end
 
 end # module BsplineBases

--- a/src/quantum/primitives/bspline_basis.jl
+++ b/src/quantum/primitives/bspline_basis.jl
@@ -1,0 +1,126 @@
+# B-spline basis for control-point-native pulse parameterization.
+# Port of Drake's math::BsplineBasis<T> (see drake/math/bspline_basis.h).
+#
+# Convention: `order = degree + 1` (Drake). A cubic B-spline has order=4, degree=3.
+# Lives on normalized parameter τ ∈ [initial_parameter_value, final_parameter_value]
+# — by convention, [0, 1] when consumed by SplineIntegrator's per-segment ODE.
+
+module BsplineBases
+
+using SparseArrays
+using TestItems: @testitem
+
+export BsplineBasis
+export evaluate_curve, evaluate_linear_in_control_points, as_linear_in_control_points
+export num_basis_functions, degree
+
+"""
+    BsplineBasis{T<:Real}
+
+B-spline basis with order `k` (= degree + 1) and a non-descending knot vector.
+
+# Constructor preconditions
+- `order >= 2` (no degree-0 splines; ZeroOrderPulse handles that)
+- `length(knots) >= 2 * order` (Drake's DRAKE_DEMAND at bspline_basis.h:148)
+- `knots` non-descending
+- `num_basis_functions = length(knots) - order` must be `>= order`
+
+The valid parameter range is `[knots[order], knots[end - order + 1]]`.
+For a clamped basis (knot multiplicity `order` at endpoints), this is `[t_min, t_max]`
+and `evaluate_curve(b, C, t_min) == C[:, 1]`, `evaluate_curve(b, C, t_max) == C[:, end]`.
+"""
+struct BsplineBasis{T<:Real}
+    order::Int                  # k = degree + 1
+    knots::Vector{T}            # non-descending, length = num_basis_functions + order
+    # Caches (computed lazily; depend only on basis, not on control points):
+    _as_linear_cache::Dict{Int,SparseMatrixCSC{T,Int}}
+
+    function BsplineBasis{T}(order::Int, knots::Vector{T}) where {T<:Real}
+        order >= 2 || throw(ArgumentError(
+            "BsplineBasis requires order >= 2 (got order=$order); for order=1 use LinearSplinePulse"))
+        length(knots) >= 2 * order || throw(ArgumentError(
+            "BsplineBasis requires length(knots) >= 2 * order (got length=$(length(knots)), order=$order)"))
+        issorted(knots) || throw(ArgumentError(
+            "BsplineBasis knots must be non-descending"))
+        nbf = length(knots) - order
+        nbf >= order || throw(ArgumentError(
+            "BsplineBasis num_basis_functions ($nbf) must be >= order ($order)"))
+        new{T}(order, knots, Dict{Int,SparseMatrixCSC{T,Int}}())
+    end
+end
+
+BsplineBasis(order::Int, knots::Vector{T}) where {T<:Real} =
+    BsplineBasis{T}(order, knots)
+
+"""
+    BsplineBasis(order, num_basis_functions; knot_vector_type, initial_parameter_value, final_parameter_value)
+
+Convenience constructor that auto-generates a knot vector. Default `:clamped_uniform`
+gives endpoint interpolation. `:uniform` gives a non-clamped uniform vector (rare;
+endpoints not interpolated).
+"""
+function BsplineBasis(
+    order::Int,
+    num_basis_functions::Int;
+    knot_vector_type::Symbol = :clamped_uniform,
+    initial_parameter_value::Real = 0.0,
+    final_parameter_value::Real = 1.0,
+)
+    num_basis_functions >= order || throw(ArgumentError(
+        "num_basis_functions ($num_basis_functions) must be >= order ($order)"))
+    initial_parameter_value < final_parameter_value || throw(ArgumentError(
+        "initial_parameter_value ($initial_parameter_value) must be < final ($final_parameter_value)"))
+
+    T = promote_type(typeof(float(initial_parameter_value)), typeof(float(final_parameter_value)))
+    a = T(initial_parameter_value)
+    b = T(final_parameter_value)
+    nbf = num_basis_functions
+    k = order
+
+    knots = if knot_vector_type == :clamped_uniform
+        # Multiplicity k at each endpoint, uniform interior.
+        n_interior = nbf - k + 1  # number of *unique* interior parameter values
+        if n_interior == 1
+            # Single Bézier segment: no interior knots
+            vcat(fill(a, k), fill(b, k))
+        else
+            # Interior knots evenly spaced strictly between a and b.
+            # range(a, b, length = n_interior + 1)[2:end-1] yields (n_interior - 1) = nbf - k interior knots.
+            interior = collect(range(a, b; length = n_interior + 1))[2:end-1]
+            # Total knots = k (left clamp) + (nbf - k) interior + k (right clamp) = nbf + k ✓
+            vcat(fill(a, k), interior, fill(b, k))
+        end
+    elseif knot_vector_type == :uniform
+        # Non-clamped uniform: evenly spaced across [a, b]
+        collect(range(a, b; length = nbf + k))
+    else
+        throw(ArgumentError(
+            "Unsupported knot_vector_type=$knot_vector_type; use :clamped_uniform or :uniform"))
+    end
+    return BsplineBasis{T}(k, knots)
+end
+
+@testitem "BsplineBasis: constructor preconditions" begin
+    using Piccolo
+    # Reject degree 0 / order 1
+    @test_throws ArgumentError BsplineBasis(1, 10)
+    # Reject too-few knots
+    @test_throws ArgumentError BsplineBasis(4, collect(0.0:0.1:0.5))  # length < 2*order
+    # Reject non-descending knots
+    @test_throws ArgumentError BsplineBasis(4, [0.0, 0.1, 0.05, 0.2, 0.3, 0.4, 0.5, 0.6])
+    # Reject n_basis_functions < order
+    @test_throws ArgumentError BsplineBasis(4, 3)
+    # Convenience constructor: bad arg order
+    @test_throws ArgumentError BsplineBasis(4, 8; initial_parameter_value = 1.0, final_parameter_value = 0.0)
+    # Unknown knot type
+    @test_throws ArgumentError BsplineBasis(4, 8; knot_vector_type = :foo)
+
+    # Sanity: clamped cubic with 8 CPs
+    b = BsplineBasis(4, 8)
+    @test b.order == 4
+    @test length(b.knots) == 8 + 4
+    @test b.knots[1:4] == zeros(4)
+    @test b.knots[end-3:end] == ones(4)
+end
+
+end # module BsplineBases

--- a/src/quantum/primitives/bspline_basis.jl
+++ b/src/quantum/primitives/bspline_basis.jl
@@ -126,14 +126,16 @@ Note: at `t == final_parameter_value`, returns the largest valid ℓ where the
 right-endpoint inclusion holds — matches Drake's `FindContainingInterval`
 at bspline_basis.cc.
 """
-function find_containing_interval(b::BsplineBasis{T}, t::Real) where {T}
-    t_typed = T(t)
+function find_containing_interval(b::BsplineBasis, t::Real)
+    # Compare in real(t)'s type — supports ForwardDiff.Dual inputs without
+    # round-tripping through Float64 (which would strip derivative info AND
+    # error since Float64(::Dual) is not defined).
     a = b.knots[b.order]                  # initial_parameter_value
     bmax = b.knots[end - b.order + 1]     # final_parameter_value
-    (a <= t_typed <= bmax) || throw(DomainError(t,
+    (a <= t <= bmax) || throw(DomainError(t,
         "parameter $t outside basis range [$a, $bmax]"))
     # At exactly bmax, return the largest ℓ with knots[ℓ] < bmax.
-    if t_typed == bmax
+    if t == bmax
         ℓ = length(b.knots)
         while ℓ > 1 && b.knots[ℓ] >= bmax
             ℓ -= 1
@@ -142,7 +144,7 @@ function find_containing_interval(b::BsplineBasis{T}, t::Real) where {T}
     end
     # Otherwise: largest ℓ with knots[ℓ] <= t
     ℓ = b.order
-    while ℓ < length(b.knots) - 1 && b.knots[ℓ+1] <= t_typed
+    while ℓ < length(b.knots) - 1 && b.knots[ℓ+1] <= t
         ℓ += 1
     end
     return ℓ
@@ -540,6 +542,50 @@ end
             @test isapprox(left, right; atol = 1e-6)
         end
     end
+end
+
+@testitem "BsplineBasis: ForwardDiff through evaluate_curve" begin
+    using Piccolo
+    using ForwardDiff
+    using Random
+    Random.seed!(20260525)
+
+    b = BsplineBasis(4, 12)
+    n_drives = 2
+    C0 = randn(n_drives, num_basis_functions(b))
+    t = 0.42
+
+    # ForwardDiff w.r.t. the control points (vectorized)
+    f(C_vec) = sum(evaluate_curve(b, reshape(C_vec, n_drives, :), t))
+    ad_grad = ForwardDiff.gradient(f, vec(C0))
+
+    # Compare to finite difference
+    h = 1e-7
+    fd_grad = similar(ad_grad)
+    for i in eachindex(vec(C0))
+        Cp = copy(vec(C0))
+        Cp[i] += h
+        Cm = copy(vec(C0))
+        Cm[i] -= h
+        fd_grad[i] = (f(Cp) - f(Cm)) / (2h)
+    end
+
+    @test ad_grad ≈ fd_grad atol = 1e-5 rtol = 1e-5
+end
+
+@testitem "BsplineBasis: ForwardDiff through evaluate_curve w.r.t. parameter t" begin
+    using Piccolo
+    using ForwardDiff
+    using Random
+    Random.seed!(20260525)
+
+    b = BsplineBasis(4, 10)
+    C = randn(2, num_basis_functions(b))
+    f_t(t::Real) = sum(evaluate_curve(b, C, t))
+    ad_deriv = ForwardDiff.derivative(f_t, 0.5)
+    h = 1e-7
+    fd_deriv = (f_t(0.5 + h) - f_t(0.5 - h)) / (2h)
+    @test ad_deriv ≈ fd_deriv atol = 1e-5
 end
 
 end # module BsplineBases

--- a/src/quantum/primitives/bspline_basis.jl
+++ b/src/quantum/primitives/bspline_basis.jl
@@ -7,6 +7,7 @@
 
 module BsplineBases
 
+using LinearAlgebra
 using SparseArrays
 using TestItems: @testitem
 
@@ -209,6 +210,142 @@ function evaluate_curve(b::BsplineBasis, control_points::AbstractMatrix, t::Real
     return p[:, 1]
 end
 
+"""
+    _derivative_basis(b::BsplineBasis, m::Int) -> BsplineBasis
+
+Internal helper: the m-th derivative of a degree-d B-spline is a degree-(d-m)
+B-spline. The new basis has order `b.order - m`, with the same interior knots
+but reduced boundary multiplicity.
+"""
+function _derivative_basis(b::BsplineBasis{T}, m::Int) where {T}
+    m == 0 && return b
+    new_order = b.order - m
+    new_order >= 2 || throw(ArgumentError(
+        "derivative order $m on degree-$(degree(b)) basis would give order $new_order < 2"))
+    # Drop first m and last m knots
+    new_knots = b.knots[(m+1):(end-m)]
+    return BsplineBasis{T}(new_order, new_knots)
+end
+
+"""
+    as_linear_in_control_points(b::BsplineBasis, derivative_order::Int) -> SparseMatrixCSC
+
+Returns a sparse matrix `M` of size `nbf × (nbf - derivative_order)` such that
+for any control point matrix `C`:
+
+    derivative_curve_control_points = C * M
+
+The derivative of a degree-d B-spline is a degree-(d - derivative_order) B-spline
+whose control points are a sparse linear function of the original control points.
+
+Cached per basis: subsequent calls with the same `derivative_order` return the
+identically same matrix object.
+
+Port of Drake's `BsplineTrajectory::AsLinearInControlPoints`.
+"""
+function as_linear_in_control_points(b::BsplineBasis{T}, derivative_order::Int) where {T}
+    derivative_order >= 0 || throw(ArgumentError(
+        "derivative_order must be >= 0; got $derivative_order"))
+    nbf = num_basis_functions(b)
+    if derivative_order == 0
+        return sparse(I, nbf, nbf) * one(T)
+    end
+    if derivative_order >= b.order
+        return spzeros(T, nbf, nbf - derivative_order)
+    end
+    if haskey(b._as_linear_cache, derivative_order)
+        return b._as_linear_cache[derivative_order]
+    end
+
+    # Order-1 derivative operator for a generic basis.
+    # Q_j = d / (t_{j+d+1} - t_{j+1}) * (P_{j+1} - P_j)  (Drake, 0-indexed)
+    # In 1-indexed: column j of M (size nbf × (nbf-1)) has rows j (coef -coef) and j+1 (coef +coef).
+    function _order1_op(basis::BsplineBasis{S}) where {S}
+        nbf_b = num_basis_functions(basis)
+        d_b = degree(basis)
+        knots_b = basis.knots
+        I_idx = Int[]
+        J_idx = Int[]
+        V_val = S[]
+        for j in 1:(nbf_b-1)
+            denom = knots_b[j+d_b+1] - knots_b[j+1]
+            if denom == 0
+                continue
+            end
+            coef = S(d_b) / denom
+            push!(I_idx, j)
+            push!(J_idx, j)
+            push!(V_val, -coef)
+            push!(I_idx, j + 1)
+            push!(J_idx, j)
+            push!(V_val, +coef)
+        end
+        return sparse(I_idx, J_idx, V_val, nbf_b, nbf_b - 1)
+    end
+
+    # Compose: M_total = M^{(1)}_b * M^{(1)}_{b'} * ...
+    M_total = _order1_op(b)
+    current_basis = _derivative_basis(b, 1)
+    for m in 2:derivative_order
+        M_total = M_total * _order1_op(current_basis)
+        current_basis = _derivative_basis(current_basis, 1)
+    end
+
+    b._as_linear_cache[derivative_order] = M_total
+    return M_total
+end
+
+"""
+    evaluate_linear_in_control_points(b::BsplineBasis, t::Real; derivative_order::Int=0) -> SparseVector
+
+Returns a sparse vector `M` of length `num_basis_functions(b)` such that for any
+control point matrix `C` (size `n_drives × num_basis_functions`):
+
+    C * M == evaluate_curve(b, C, t)                            (derivative_order = 0)
+    C * M == d^k curve(t) / dt^k                                (derivative_order = k)
+
+The result has at most `b.order` nonzero entries — the active basis function indices.
+
+Port of Drake's `BsplineBasis::EvaluateLinearInControlPoints`.
+"""
+function evaluate_linear_in_control_points(
+    b::BsplineBasis{T},
+    t::Real;
+    derivative_order::Int = 0,
+) where {T}
+    nbf = num_basis_functions(b)
+    if derivative_order < 0
+        throw(ArgumentError("derivative_order must be >= 0"))
+    end
+    if derivative_order >= b.order
+        return spzeros(T, nbf)
+    end
+    if derivative_order == 0
+        # Basis function values N_{j,d}(t) via de Boor on identity CPs.
+        # Only active entries can be non-zero; pull them out of the dense column.
+        I_full = Matrix{T}(I, nbf, nbf)
+        vals = evaluate_curve(b, I_full, t)
+        ℓ = find_containing_interval(b, t)
+        actives = (ℓ-b.order+1):ℓ
+        I_idx = Int[]
+        V_val = T[]
+        for i in actives
+            v = vals[i]
+            if v != 0
+                push!(I_idx, i)
+                push!(V_val, v)
+            end
+        end
+        return sparsevec(I_idx, V_val, nbf)
+    end
+
+    # Derivative case: curve^{(m)}(t) = (C * M_op) * M_deriv = C * (M_op * M_deriv)
+    M_op = as_linear_in_control_points(b, derivative_order)  # nbf × (nbf - m)
+    deriv_basis = _derivative_basis(b, derivative_order)
+    M_deriv = evaluate_linear_in_control_points(deriv_basis, t; derivative_order = 0)  # length nbf - m
+    return M_op * M_deriv
+end
+
 @testitem "BsplineBasis: constructor preconditions" begin
     using Piccolo
     # Reject degree 0 / order 1
@@ -294,6 +431,94 @@ end
         @test evaluate_curve(b, C, t_min) ≈ C[:, 1] atol = 1e-14
         @test evaluate_curve(b, C, t_max) ≈ C[:, end] atol = 1e-14
     end
+end
+
+@testitem "BsplineBasis: linear-in-CP identity (order 0)" begin
+    using Piccolo
+    using SparseArrays
+    using Random
+    Random.seed!(20260525)
+    for d in (2, 3, 4), nbf in (8, 20)
+        b = BsplineBasis(d + 1, nbf)
+        C = randn(3, nbf)  # 3 drives
+        for _ in 1:30
+            t = rand() * 0.99 + 0.005  # avoid exact endpoints
+            M = evaluate_linear_in_control_points(b, t; derivative_order = 0)
+            @test C * M ≈ evaluate_curve(b, C, t) atol = 1e-12
+            @test nnz(M) <= b.order
+        end
+    end
+end
+
+@testitem "BsplineBasis: linear-in-CP derivative (order 1) via finite difference" begin
+    using Piccolo
+    using Random
+    Random.seed!(20260525)
+    h = 1e-7
+    b = BsplineBasis(4, 16)  # cubic
+    C = randn(2, 16)
+    for _ in 1:20
+        t = 0.1 + 0.8 * rand()  # interior
+        M1 = evaluate_linear_in_control_points(b, t; derivative_order = 1)
+        analytic = C * M1
+        fd = (evaluate_curve(b, C, t + h) .- evaluate_curve(b, C, t - h)) ./ (2h)
+        @test analytic ≈ fd atol = 1e-5
+    end
+end
+
+@testitem "BsplineBasis: linear-in-CP sparsity matches active_basis_function_indices" begin
+    using Piccolo
+    using SparseArrays
+    b = BsplineBasis(4, 16)
+    for t in (0.05, 0.3, 0.5, 0.7, 0.95)
+        M0 = evaluate_linear_in_control_points(b, t; derivative_order = 0)
+        actives = active_basis_function_indices(b, t)
+        @test Set(findnz(M0)[1]) ⊆ Set(actives)
+        @test nnz(M0) <= b.order
+    end
+end
+
+@testitem "BsplineBasis: as_linear_in_control_points produces correct derivative CPs" begin
+    using Piccolo
+    using Random
+    Random.seed!(20260525)
+    b = BsplineBasis(4, 16)
+    C = randn(2, 16)
+    h = 1e-7
+    M1 = as_linear_in_control_points(b, 1)
+
+    # Derivative curve has nbf - 1 control points
+    @test size(M1) == (size(C, 2), size(C, 2) - 1)
+
+    Q = C * M1
+    deriv_basis = Piccolo.BsplineBases._derivative_basis(b, 1)
+    @test num_basis_functions(deriv_basis) == size(Q, 2)
+
+    for _ in 1:20
+        t = 0.1 + 0.8 * rand()
+        deriv_curve = evaluate_curve(deriv_basis, Q, t)
+        fd_deriv = (evaluate_curve(b, C, t + h) .- evaluate_curve(b, C, t - h)) ./ (2h)
+        @test deriv_curve ≈ fd_deriv atol = 1e-5
+    end
+end
+
+@testitem "BsplineBasis: as_linear_in_control_points caching" begin
+    using Piccolo
+    b = BsplineBasis(4, 16)
+    M1_a = as_linear_in_control_points(b, 1)
+    M1_b = as_linear_in_control_points(b, 1)
+    # Cached operator must be identical (same object, no recomputation)
+    @test M1_a === M1_b
+end
+
+@testitem "BsplineBasis: as_linear_in_control_points composes for higher derivatives" begin
+    using Piccolo
+    b = BsplineBasis(4, 16)
+    M1 = as_linear_in_control_points(b, 1)
+    M2 = as_linear_in_control_points(b, 2)
+    deriv_basis_1 = Piccolo.BsplineBases._derivative_basis(b, 1)
+    M1_from_deriv = as_linear_in_control_points(deriv_basis_1, 1)
+    @test Matrix(M2) ≈ Matrix(M1 * M1_from_deriv) atol = 1e-14
 end
 
 @testitem "BsplineBasis: evaluate_curve continuity at interior knots" begin

--- a/src/quantum/primitives/pulses.jl
+++ b/src/quantum/primitives/pulses.jl
@@ -19,20 +19,30 @@ export AbstractPulse, AbstractSplinePulse
 export ZeroOrderPulse,
     LinearSplinePulse,
     CubicSplinePulse,
+    BSplinePulse,
     GaussianPulse,
     ErfPulse,
     CompositePulse,
     FunctionPulse
 export duration, n_drives, sample, drive_name
 export load_pulse
+export get_control_points, get_knots
 
 using DataInterpolations
 using DataInterpolations:
     ConstantInterpolation, LinearInterpolation, CubicHermiteSpline, ExtrapolationType
 using ForwardDiff
 using JLD2
+using LinearAlgebra: norm
 using SpecialFunctions: erf
 using TestItems
+
+# Sibling submodule for B-spline basis support (BSplinePulse)
+using ..BsplineBases:
+    BsplineBasis,
+    evaluate_curve,
+    evaluate_linear_in_control_points,
+    num_basis_functions
 
 const DEFAULT_SAMPLES::Int = 100
 
@@ -636,6 +646,167 @@ function CubicSplinePulse(
 end
 
 # ============================================================================ #
+# BSplinePulse
+# ============================================================================ #
+
+"""
+    BSplinePulse{T, B<:BsplineBasis{T}} <: AbstractSplinePulse
+
+Control-point-native B-spline pulse parameterization. Decision variables are
+control points; the curve `u(t) = control_points * M_0(τ)` lies in the convex
+hull of its control points. C^{degree-1} continuity is structural (no
+regularizer needed).
+
+# Fields
+- `basis::B`: defines order, knots, normalized parameter τ ∈ [0, 1]
+- `control_points::Matrix{T}`: `n_drives × num_basis_functions(basis)`
+- `duration::Float64`
+- `n_drives::Int`
+- `drive_name::Symbol`
+- `initial_value::Union{Vector{Float64},Symbol}`: clamped to `control_points[:, 1]` or `:free`
+- `final_value::Union{Vector{Float64},Symbol}`: clamped to `control_points[:, end]` or `:free`
+
+# Convention
+The basis lives on normalized parameter τ ∈ [0, 1]; see the spec's Conventions
+section for free-time (per-segment Δt) compatibility.
+"""
+struct BSplinePulse{T<:Real,B<:BsplineBasis{T}} <: AbstractSplinePulse
+    basis::B
+    control_points::Matrix{T}
+    duration::Float64
+    n_drives::Int
+    drive_name::Symbol
+    initial_value::Union{Vector{Float64},Symbol}
+    final_value::Union{Vector{Float64},Symbol}
+end
+
+function _resolve_bspline_boundary(spec, cps::AbstractMatrix, which::Symbol)
+    if spec === nothing
+        col = which == :first ? cps[:, 1] : cps[:, end]
+        return Vector{Float64}(col)
+    elseif spec === :free
+        return :free
+    elseif spec isa Symbol
+        throw(ArgumentError("Invalid boundary symbol: $spec (only :free is supported)"))
+    elseif spec isa AbstractVector
+        return Vector{Float64}(spec)
+    else
+        throw(ArgumentError("Invalid boundary spec: $spec"))
+    end
+end
+
+"""
+    BSplinePulse(control_points::AbstractMatrix, times::AbstractVector;
+                 degree=3, drive_name=:u, initial_value=nothing, final_value=nothing)
+
+Primary constructor. The `times` vector is used only for its duration
+(`times[end] - times[1]`) — the actual time parameterization lives in
+the basis on normalized τ ∈ [0, 1].
+
+`initial_value` / `final_value`:
+- `nothing` (default): set to `control_points[:, 1]` / `control_points[:, end]`
+- A vector: enforces invariant `control_points[:, 1] ≈ initial_value` (atol 1e-12)
+- `:free`: no pinning; the boundary CP is a free decision variable
+"""
+function BSplinePulse(
+    control_points::AbstractMatrix{T},
+    times::AbstractVector{<:Real};
+    degree::Int = 3,
+    drive_name::Symbol = :u,
+    initial_value::Union{Nothing,AbstractVector,Symbol} = nothing,
+    final_value::Union{Nothing,AbstractVector,Symbol} = nothing,
+) where {T<:Real}
+    n_drv = size(control_points, 1)
+    nbf = size(control_points, 2)
+    nbf >= degree + 1 || throw(ArgumentError(
+        "BSplinePulse requires n_control_points ($nbf) >= degree + 1 ($(degree+1))"))
+    length(times) >= 2 || throw(ArgumentError(
+        "BSplinePulse requires at least 2 time entries"))
+
+    dur = Float64(times[end] - times[1])
+    dur > 0 || throw(ArgumentError("BSplinePulse duration must be positive"))
+
+    iv = _resolve_bspline_boundary(initial_value, control_points, :first)
+    fv = _resolve_bspline_boundary(final_value, control_points, :last)
+
+    # Invariant check (only when iv/fv are concrete vectors and user-supplied)
+    if initial_value isa AbstractVector
+        isapprox(control_points[:, 1], iv; atol = 1e-12) || throw(ArgumentError(
+            "BSplinePulse: initial_value $iv must match control_points[:, 1] = $(control_points[:, 1])"))
+    end
+    if final_value isa AbstractVector
+        isapprox(control_points[:, end], fv; atol = 1e-12) || throw(ArgumentError(
+            "BSplinePulse: final_value $fv must match control_points[:, end] = $(control_points[:, end])"))
+    end
+
+    Tp = promote_type(T, Float64)
+    cps_p = Matrix{Tp}(control_points)
+    # Build a basis with matching T parameter for compatibility with cps storage type
+    basis_p = BsplineBasis(degree + 1, nbf;
+        knot_vector_type = :clamped_uniform,
+        initial_parameter_value = zero(Tp),
+        final_parameter_value = one(Tp),
+    )
+    return BSplinePulse{Tp,typeof(basis_p)}(
+        basis_p, cps_p, dur, n_drv, drive_name, iv, fv,
+    )
+end
+
+"""
+    BSplinePulse(pulse::AbstractPulse, n_control_points::Int; degree=3)
+
+Warm-start constructor. Samples `pulse` densely, then uses
+`DataInterpolations.BSplineApprox` to compute a least-squares-fit set of
+control points. Inherits duration / n_drives / drive_name from `pulse`.
+"""
+function BSplinePulse(
+    pulse::AbstractPulse,
+    n_control_points::Int;
+    degree::Int = 3,
+)
+    n_control_points >= degree + 1 || throw(ArgumentError(
+        "n_control_points must be >= degree + 1"))
+
+    T_dur = duration(pulse)
+    n_drv = n_drives(pulse)
+    n_samples = max(4 * n_control_points, 200)
+    sample_ts = collect(range(0.0, T_dur, length = n_samples))
+
+    samples = Matrix{Float64}(undef, n_drv, n_samples)
+    for (k, t) in enumerate(sample_ts)
+        samples[:, k] = evaluate(pulse, t)
+    end
+
+    C = Matrix{Float64}(undef, n_drv, n_control_points)
+    for j in 1:n_drv
+        approx = DataInterpolations.BSplineApprox(
+            samples[j, :], sample_ts, degree, n_control_points, :Uniform, :Uniform,
+        )
+        C[j, :] = approx.c
+    end
+
+    times = collect(range(0.0, T_dur, length = n_control_points))
+    return BSplinePulse(C, times; degree = degree, drive_name = drive_name(pulse))
+end
+
+# --- evaluate / derivative / accessors ---
+
+function evaluate(p::BSplinePulse, t::Real)
+    τ = t / p.duration
+    return evaluate_curve(p.basis, p.control_points, τ)
+end
+
+function derivative(p::BSplinePulse, t::Real)
+    τ = t / p.duration
+    M1 = evaluate_linear_in_control_points(p.basis, τ; derivative_order = 1)
+    # Chain rule: du/dt = (du/dτ) * (dτ/dt) = (C * M1) / duration
+    return (p.control_points * M1) ./ p.duration
+end
+
+get_control_points(p::BSplinePulse) = p.control_points
+get_knots(p::BSplinePulse) = p.basis.knots
+
+# ============================================================================ #
 # GaussianPulse (analytic)
 # ============================================================================ #
 
@@ -1166,6 +1337,19 @@ function _rebuild_like(p::ZeroOrderPulse, vars::NamedTuple)
         initial_value = p.initial_value,
         final_value = p.final_value,
         snap_to_knots = p.snap_to_knots,
+    )
+end
+
+function _rebuild_like(p::BSplinePulse, vars::NamedTuple)
+    haskey(vars, :u) || throw(ArgumentError(
+        "BSplinePulse._rebuild_like requires :u in NamedTuple; got keys $(keys(vars))"))
+    new_cps = vars.u
+    size(new_cps) == size(p.control_points) || throw(DimensionMismatch(
+        "new control_points size $(size(new_cps)) != original $(size(p.control_points))"))
+    Tnew = promote_type(eltype(new_cps), Float64)
+    return BSplinePulse{Tnew,typeof(p.basis)}(
+        p.basis, Matrix{Tnew}(new_cps), p.duration, p.n_drives,
+        p.drive_name, p.initial_value, p.final_value,
     )
 end
 
@@ -1888,6 +2072,195 @@ end
     # Missing-key error contracts
     @test_throws ArgumentError Piccolo.Pulses._rebuild_like(p_lin, (v = u0,))
     @test_throws ArgumentError Piccolo.Pulses._rebuild_like(p_cub, (u = u0,))
+end
+
+@testitem "BSplinePulse: primary constructor + struct invariants" begin
+    using Piccolo
+    using Random
+    Random.seed!(20260525)
+
+    nbf = 22  # for d=3, with arbitrary >= d+1
+    times = collect(range(0.0, 1.0, length = 20))
+    C = randn(2, nbf)
+    iv = randn(2)
+    C[:, 1] = iv
+    fv = randn(2)
+    C[:, end] = fv
+
+    p = BSplinePulse(C, times; degree = 3,
+        initial_value = iv, final_value = fv, drive_name = :u)
+    @test p isa BSplinePulse
+    @test n_drives(p) == 2
+    @test duration(p) == 1.0
+    @test p.initial_value ≈ iv
+    @test p.final_value ≈ fv
+    @test p.basis.order == 4
+    @test num_basis_functions(p.basis) == nbf
+
+    # Inconsistent clamp should error
+    C_bad = copy(C)
+    C_bad[:, 1] .+= 0.1
+    @test_throws ArgumentError BSplinePulse(C_bad, times; degree = 3,
+        initial_value = iv, final_value = fv)
+
+    # Too-few CPs should error
+    @test_throws ArgumentError BSplinePulse(randn(2, 3), times; degree = 3)
+
+    # :free boundary semantics
+    p_free = BSplinePulse(C, times; degree = 3, initial_value = :free, final_value = :free)
+    @test p_free.initial_value === :free
+    @test p_free.final_value === :free
+end
+
+@testitem "BSplinePulse: evaluate / derivative / accessors" begin
+    using Piccolo
+
+    using Random
+    Random.seed!(20260525)
+
+    nbf, T_dur = 18, 2.5
+    times = collect(range(0.0, T_dur, length = 16))
+    C = randn(2, nbf)
+    p = BSplinePulse(C, times; degree = 3, initial_value = :free, final_value = :free)
+
+    # Endpoint exactness via call form
+    @test p(0.0) ≈ C[:, 1] atol = 1e-12
+    @test p(T_dur) ≈ C[:, end] atol = 1e-12
+
+    # Pointwise consistency with basis
+    for _ in 1:30
+        t = T_dur * rand()
+        τ = t / T_dur
+        @test p(t) ≈ evaluate_curve(p.basis, p.control_points, τ) atol = 1e-12
+    end
+
+    # Derivative consistency: du/dt = (1/T) du/dτ via FD
+    h = 1e-6
+    for _ in 1:10
+        t = 0.1 * T_dur + 0.8 * T_dur * rand()
+        analytic = Piccolo.Pulses.derivative(p, t)
+        fd = (p(t + h) .- p(t - h)) ./ (2h)
+        @test analytic ≈ fd atol = 1e-4
+    end
+
+    # Accessors
+    @test get_control_points(p) === p.control_points
+    @test get_knots(p) === p.basis.knots
+    @test drive_name(p) == :u
+    @test duration(p) == T_dur
+    @test n_drives(p) == 2
+end
+
+@testitem "BSplinePulse: warm-start from AbstractPulse via BSplineApprox" begin
+    using Piccolo
+    using Random
+    Random.seed!(20260525)
+
+    N = 20
+    times = collect(range(0.0, 1.0, length = N))
+    u_vals = randn(2, N)
+    du_vals = randn(2, N) .* 0.5
+    p_cub = CubicSplinePulse(u_vals, du_vals, times)
+
+    # Fit with 1.5x oversampling
+    n_cp = Int(round(1.5 * N))
+    p_bsp = BSplinePulse(p_cub, n_cp; degree = 3)
+    @test p_bsp isa BSplinePulse
+    @test num_basis_functions(p_bsp.basis) == n_cp
+
+    # Fit error: sample original at 50 points, compare to bspline approx
+    diffs = Float64[]
+    for t in range(0.05, 0.95, length = 50)
+        diff = p_cub(t) .- p_bsp(t)
+        push!(diffs, sqrt(sum(abs2, diff)))
+    end
+    @test maximum(diffs) < 5e-1  # generous: BSplineApprox is L2-fit, not interp
+end
+
+@testitem "BSplinePulse: JLD2 round-trip" begin
+    using Piccolo
+    using JLD2
+    using Random
+    Random.seed!(20260525)
+
+    nbf = 16
+    times = collect(range(0.0, 1.0, length = 14))
+    C = randn(2, nbf)
+    p = BSplinePulse(C, times; degree = 3, initial_value = :free, final_value = :free)
+
+    mktempdir() do dir
+        path = joinpath(dir, "bspline_pulse.jld2")
+        JLD2.save(path, p)
+        p_loaded = load_pulse(path)
+        @test p_loaded isa BSplinePulse
+        @test get_control_points(p_loaded) ≈ get_control_points(p)
+        @test p_loaded.basis.order == p.basis.order
+        @test p_loaded.basis.knots ≈ p.basis.knots
+        @test p_loaded.duration == p.duration
+        # Evaluate at a few points to verify functional equivalence after load
+        for t in (0.0, 0.25, 0.5, 1.0)
+            @test p_loaded(t) ≈ p(t) atol = 1e-12
+        end
+    end
+end
+
+@testitem "BSplinePulse: _rebuild_like" begin
+    using Piccolo
+    using Random
+    Random.seed!(20260525)
+
+    nbf = 16
+    times = collect(range(0.0, 1.0, length = 14))
+    C = randn(2, nbf)
+    p = BSplinePulse(C, times; degree = 3, initial_value = :free, final_value = :free)
+
+    # _rebuild_like with :u key
+    C_new = C .+ 0.1
+    p_new = Piccolo.Pulses._rebuild_like(p, (u = C_new,))
+    @test p_new isa BSplinePulse
+    @test get_control_points(p_new) ≈ C_new
+    @test duration(p_new) == duration(p)
+    @test p_new.basis.order == p.basis.order
+    @test p_new.basis === p.basis  # basis is shared (immutable structure)
+    @test_throws ArgumentError Piccolo.Pulses._rebuild_like(p, (du = C_new,))
+end
+
+@testitem "BSplinePulse ↔ CubicSplinePulse round-trip identity (degree 3)" begin
+    using Piccolo
+    using Random
+    Random.seed!(20260525)
+
+    # Construct a known B-spline with random CPs
+    N = 20
+    n_cp = N + 2  # n_cp = N + d - 1 for d=3
+    T_dur = 1.0
+    times = collect(range(0.0, T_dur, length = N))
+    C = randn(2, n_cp)
+    p_bsp = BSplinePulse(C, times; degree = 3, initial_value = :free, final_value = :free)
+
+    # Sample at knot times (the Hermite knots — the N data-point times)
+    u_vals = Matrix{Float64}(undef, 2, N)
+    du_vals = Matrix{Float64}(undef, 2, N)
+    for (k, t) in enumerate(times)
+        u_vals[:, k] = p_bsp(t)
+        du_vals[:, k] = Piccolo.Pulses.derivative(p_bsp, t)
+    end
+
+    # Build CubicSplinePulse from those samples
+    p_cub = CubicSplinePulse(u_vals, du_vals, times)
+
+    # Round-trip identity: must agree pointwise on each segment (same cubic poly)
+    for _ in 1:300
+        t = T_dur * rand()
+        v_bsp = p_bsp(t)
+        v_cub = p_cub(t)
+        @test v_bsp ≈ v_cub atol = 1e-10
+    end
+
+    # Knot-time exactness
+    for k in 1:N
+        @test p_bsp(times[k]) ≈ u_vals[:, k] atol = 1e-14
+    end
 end
 
 end # module Pulses

--- a/src/quantum/primitives/pulses.jl
+++ b/src/quantum/primitives/pulses.jl
@@ -502,6 +502,7 @@ For CompositePulse, returns the sorted union of all sub-pulse knot times.
 get_knot_times(p::ZeroOrderPulse) = p.controls.t
 get_knot_times(p::LinearSplinePulse) = p.controls.t
 get_knot_times(p::CubicSplinePulse) = p.controls.t
+# get_knot_times for BSplinePulse is defined below, after the type declaration.
 
 """
     get_knot_count(pulse::AbstractSplinePulse)
@@ -679,6 +680,10 @@ struct BSplinePulse{T<:Real,B<:BsplineBasis{T}} <: AbstractSplinePulse
     initial_value::Union{Vector{Float64},Symbol}
     final_value::Union{Vector{Float64},Symbol}
 end
+
+# Basis knots live on normalized τ ∈ [0,1]; map to physical time
+# and dedupe the clamped boundary repetitions.
+get_knot_times(p::BSplinePulse) = unique(p.basis.knots) .* p.duration
 
 function _resolve_bspline_boundary(spec, cps::AbstractMatrix, which::Symbol)
     if spec === nothing

--- a/src/quantum/primitives/pulses.jl
+++ b/src/quantum/primitives/pulses.jl
@@ -1110,6 +1110,66 @@ function CubicSplinePulse(
 end
 
 # ============================================================================ #
+# _rebuild_like: NamedTuple-keyed warm-restart reconstruction
+# ============================================================================ #
+
+"""
+    _rebuild_like(p::AbstractPulse, vars::NamedTuple) -> AbstractPulse
+
+Reconstruct a pulse of the same concrete type with new decision-variable values.
+Used by the optimizer's warm-restart utility. The `vars` NamedTuple keys must
+match the decision-variable component symbols owned by the pulse type:
+
+- `LinearSplinePulse`: `(u = new_values,)`
+- `CubicSplinePulse`:  `(u = new_values, du = new_tangents)`
+- `ZeroOrderPulse`:    `(u = new_values,)`
+- `BSplinePulse`:      `(u = new_control_points,)` (added in BSplinePulse PR)
+
+Additional pulse-type implementations may be added later under the same
+NamedTuple contract. The pulse's basis / time grid / duration / boundary
+metadata is preserved.
+"""
+function _rebuild_like end
+
+function _rebuild_like(p::LinearSplinePulse, vars::NamedTuple)
+    haskey(vars, :u) || throw(ArgumentError(
+        "LinearSplinePulse._rebuild_like requires :u in NamedTuple; got keys $(keys(vars))"))
+    return LinearSplinePulse(
+        vars.u,
+        get_knot_times(p);
+        drive_name = p.drive_name,
+        initial_value = p.initial_value,
+        final_value = p.final_value,
+    )
+end
+
+function _rebuild_like(p::CubicSplinePulse, vars::NamedTuple)
+    (haskey(vars, :u) && haskey(vars, :du)) || throw(ArgumentError(
+        "CubicSplinePulse._rebuild_like requires :u and :du in NamedTuple; got keys $(keys(vars))"))
+    return CubicSplinePulse(
+        vars.u,
+        vars.du,
+        get_knot_times(p);
+        drive_name = p.drive_name,
+        initial_value = p.initial_value,
+        final_value = p.final_value,
+    )
+end
+
+function _rebuild_like(p::ZeroOrderPulse, vars::NamedTuple)
+    haskey(vars, :u) || throw(ArgumentError(
+        "ZeroOrderPulse._rebuild_like requires :u in NamedTuple; got keys $(keys(vars))"))
+    return ZeroOrderPulse(
+        vars.u,
+        get_knot_times(p);
+        drive_name = p.drive_name,
+        initial_value = p.initial_value,
+        final_value = p.final_value,
+        snap_to_knots = p.snap_to_knots,
+    )
+end
+
+# ============================================================================ #
 # Tests
 # ============================================================================ #
 
@@ -1796,6 +1856,38 @@ end
         @test data["gate"] == "X"
         @test data["pulse"](0.5) ≈ pulse(0.5)
     end
+end
+
+@testitem "_rebuild_like NamedTuple dispatch for existing pulse types" begin
+    using Piccolo
+
+    N = 8
+    times = collect(range(0.0, 1.0, length = N))
+    u0 = randn(2, N)
+
+    # LinearSplinePulse
+    p_lin = LinearSplinePulse(u0, times)
+    p_lin_new = Piccolo.Pulses._rebuild_like(p_lin, (u = u0 .+ 0.1,))
+    @test p_lin_new isa LinearSplinePulse
+    @test get_knot_values(p_lin_new) ≈ u0 .+ 0.1
+    @test duration(p_lin_new) == duration(p_lin)
+
+    # CubicSplinePulse
+    du0 = randn(2, N)
+    p_cub = CubicSplinePulse(u0, du0, times)
+    p_cub_new = Piccolo.Pulses._rebuild_like(p_cub, (u = u0 .+ 0.1, du = du0 .+ 0.01))
+    @test p_cub_new isa CubicSplinePulse
+    @test get_knot_values(p_cub_new) ≈ u0 .+ 0.1
+    @test get_knot_derivatives(p_cub_new) ≈ du0 .+ 0.01
+
+    # ZeroOrderPulse
+    p_zoh = ZeroOrderPulse(u0, times)
+    p_zoh_new = Piccolo.Pulses._rebuild_like(p_zoh, (u = u0 .+ 0.1,))
+    @test p_zoh_new isa ZeroOrderPulse
+
+    # Missing-key error contracts
+    @test_throws ArgumentError Piccolo.Pulses._rebuild_like(p_lin, (v = u0,))
+    @test_throws ArgumentError Piccolo.Pulses._rebuild_like(p_cub, (u = u0,))
 end
 
 end # module Pulses

--- a/src/quantum/trajectories/_quantum_trajectories.jl
+++ b/src/quantum/trajectories/_quantum_trajectories.jl
@@ -21,6 +21,7 @@ using ..Pulses:
     CompositePulse
 using ..Pulses: duration, drive_name, n_drives, sample
 using ..Pulses: get_knot_times, get_knot_count, get_knot_values, get_knot_derivatives
+using ..BsplineBases
 import ..Pulses: duration, drive_name
 import ..Rollouts
 import ..Rollouts: rollout!

--- a/src/quantum/trajectories/_quantum_trajectories.jl
+++ b/src/quantum/trajectories/_quantum_trajectories.jl
@@ -15,6 +15,7 @@ using ..Pulses:
     ZeroOrderPulse,
     LinearSplinePulse,
     CubicSplinePulse,
+    BSplinePulse,
     GaussianPulse,
     ErfPulse,
     CompositePulse

--- a/src/quantum/trajectories/extract_pulse.jl
+++ b/src/quantum/trajectories/extract_pulse.jl
@@ -56,6 +56,25 @@ function extract_pulse(
     return CubicSplinePulse(u, du, times; drive_name = u_name)
 end
 
+function extract_pulse(
+    qtraj::AbstractQuantumTrajectory{<:BSplinePulse},
+    traj::NamedTrajectory,
+)
+    # The trajectory's :u holds *samples* of the spline at knot times (Task 17
+    # _get_control_data convention). Reconstruct a BSplinePulse by fitting CPs
+    # via the warm-start constructor (BSplineApprox least-squares). Preserves
+    # the original basis degree and n_control_points from the source pulse.
+    times = collect(get_times(traj))
+    u_name = drive_name(qtraj)
+    u_samples = Matrix(traj[u_name])
+    src_basis = qtraj.pulse.basis
+    deg = BsplineBases.degree(src_basis)
+    nbf = BsplineBases.num_basis_functions(src_basis)
+
+    linear_proxy = LinearSplinePulse(u_samples, times; drive_name = u_name)
+    return BSplinePulse(linear_proxy, nbf; degree = deg)
+end
+
 # SamplingTrajectory delegates to base_trajectory
 function extract_pulse(qtraj::SamplingTrajectory, traj::NamedTrajectory)
     return extract_pulse(qtraj.base_trajectory, traj)

--- a/src/quantum/trajectories/named_trajectory_conversion.jl
+++ b/src/quantum/trajectories/named_trajectory_conversion.jl
@@ -136,6 +136,46 @@ function _get_control_data(
 end
 
 """
+    _get_control_data(pulse::BSplinePulse, times, sys)
+
+For BSplinePulse: sample the spline curve at `times` to populate the
+trajectory's `:u` component. The optimizer-facing knot-point variables
+are these samples; the SplinePulseProblem template (Piccolissimo Task 23)
+will replace this with control-point-native packing. Today the
+SplineIntegrator's forward RHS reads `evaluate_curve` from the captured
+pulse, so the sampled `:u` values are not used during integration —
+they exist to satisfy the NamedTrajectory schema only.
+
+Boundary conditions follow the same `:free` semantics as LinearSpline:
+a `:free` initial/final value means no boundary constraint; a vector
+pin or `nothing` (the default — pins to `control_points[:, 1/end]`)
+becomes a boundary constraint on the sampled `u` at the matching knot.
+"""
+function _get_control_data(
+    pulse::BSplinePulse,
+    times::AbstractVector,
+    sys::AbstractQuantumSystem,
+)
+    u_name = drive_name(pulse)
+    u = sample(pulse, times)
+    u_bounds = _get_drive_bounds(sys)
+
+    initial_u = pulse.initial_value
+    final_u = pulse.final_value
+
+    initial_constraints =
+        initial_u === :free ? NamedTuple() : _named_tuple(u_name => initial_u)
+    final_constraints =
+        final_u === :free ? NamedTuple() : _named_tuple(u_name => final_u)
+
+    return _named_tuple(u_name => u),
+    (u_name,),
+    _named_tuple(u_name => u_bounds),
+    initial_constraints,
+    final_constraints
+end
+
+"""
     _get_control_data(pulse::CubicSplinePulse, times, sys)
 
 For CubicSplinePulse: return `u` and `du` data with system bounds and boundary conditions.


### PR DESCRIPTION
## Summary

Piccolo half of the cross-package B-spline pulse parameterization PRD (harmoniqs/Piccolissimo.jl#109).

Implements **Phases 1 + 2** of the plan: the `BsplineBasis` math primitive (Drake-style port) and the `BSplinePulse <: AbstractSplinePulse` type with primary + warm-start constructors, evaluate / derivative / accessors, JLD2 round-trip, and `_rebuild_like` integration with the existing pulse types.

**Status: Tasks 1–12 of the plan complete + a small Task-17 follow-up.** Tasks 19+ on the Piccolissimo side need this branch's `BSplinePulse` type to be merged (or coordinated) — see the companion PR.

## What's here

- **`src/quantum/primitives/bspline_basis.jl`** (new) — `BsplineBasis{T}` struct, Drake-flattened de Boor evaluation, linear-in-control-points helpers, basis cache, ForwardDiff-compatible.
- **`src/quantum/primitives/pulses.jl`** — adds `BSplinePulse{T,B}`, primary constructor (with `:free` boundary handling), warm-start constructor (`BSplineApprox` via `DataInterpolations`), evaluate / derivative / sample / `n_drives` / `duration` / `get_knot_times` / `_rebuild_like`.
- **`_rebuild_like(::AbstractPulse, ::NamedTuple)` API** — standardized minimal-contract dispatch added for all three existing pulse types (`ZeroOrderPulse`, `LinearSplinePulse`, `CubicSplinePulse`) plus the new `BSplinePulse`.

## Validation (Layers 1 + 2)

- **`BsplineBasis` testitem suite:** 86/86 pass — degree, num_basis_functions, interval/active lookups, de Boor evaluation, linear-in-CP evaluation, cache, ForwardDiff dual-number compatibility.
- **`BSplinePulse` testitem suite:** 387/387 pass — primary constructor preconditions, warm-start fit accuracy, evaluate/derivative agreement vs de-Boor reference, JLD2 round-trip identity, Layer 2 round-trip (320 random-t points to 1e-10 vs matched `CubicSplinePulse`).
- **`BSpline trait + dispatch` testitem (companion repo):** 8/8 pass.

## What's NOT here

Tasks 13–18 of the plan land in the **Piccolissimo companion PR** (harmoniqs/Piccolissimo.jl). Tasks 19–28 (forward / sensitivity / Hessian ODE branches for BSpline, `BSplineDerivativeBoundConstraint`, demos) are not yet implemented — those are the **load-bearing numerical work** that requires a `segment_basis_evaluator`-style helper on `BsplineBasis` and per-segment τ-mapping in the Piccolissimo ODE RHS closures.

## Test plan

- [ ] Confirm `cd Piccolo.jl && julia --project=. -e 'using Pkg; Pkg.test()'` passes (filtered to BSpline testitems is the meaningful surface here)
- [ ] Spot-check `BSplinePulse(C, times; degree=3)` constructs and `evaluate(p, t)` matches Drake's de Boor reference within 1e-10
- [ ] Spot-check JLD2 round-trip via `jldsave("/tmp/p.jld2"; p); load("/tmp/p.jld2", "p") ≈ p`
- [ ] Spot-check the warm-start constructor against a `CubicSplinePulse` of comparable smoothness

Closes harmoniqs/Piccolo.jl#221 (partial — convex-hull bounding lands in Piccolissimo Task 24)

References PRD: harmoniqs/Piccolissimo.jl#109

🤖 Generated with [Claude Code](https://claude.com/claude-code)