### PR TITLE
chore: bump version to 1.17.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
-version = "1.16.1"
+version = "1.17.0"
 authors = ["Aaron Trowbridge <aaron@harmoniqs.co> and contributors"]
 
 [deps]


### PR DESCRIPTION
Version bump `1.16.1` → `1.17.0` (minor) for release.

## Changes since v1.16.1
- **Added:** `LivePulsePlotCallback` for live pulse plotting during solves
- Docs: first-gate tutorial now uses the `plot_pulse` API; local-RNG note added to drive validator docstrings

Merge once CI is green, then JuliaRegistrator will be triggered on `main`.