### PR TITLE
Add dual-rail encoding and sparse embedded operators

### DIFF
--- a/src/quantum/_quantum.jl
+++ b/src/quantum/_quantum.jl
@@ -31,6 +31,10 @@ include("primitives/isomorphisms.jl")
 include("primitives/pulses.jl")
 @reexport using .Pulses
 
+# Encodings (depend on gates)
+include("encodings/dual_rail.jl")
+@reexport using .DualRailEncodings
+
 # Object utils (depends on gates)
 include("object_utils.jl")
 @reexport using .QuantumObjectUtils

--- a/src/quantum/encodings/dual_rail.jl
+++ b/src/quantum/encodings/dual_rail.jl
@@ -1,0 +1,211 @@
+module DualRailEncodings
+
+export DualRailEncoding
+export logical_basis_states
+export reduce_to_subspace
+export subspace_transform
+export target_states
+
+using ..Gates
+
+using LinearAlgebra
+using SparseArrays
+using TestItems
+
+@doc raw"""
+    DualRailEncoding(; n_qubits, levels_per_rail, conservation=:exact_N, N=n_qubits)
+
+Describe a dual-rail encoding of `n_qubits` logical qubits in `2n_qubits`
+physical modes. Logical zero and one are represented by occupations `|1,0>` and
+`|0,1>`, respectively.
+
+Use [`subspace_transform`](@ref) to reduce full-space Hamiltonians, then construct
+a system from the reduced Hamiltonians and pass `EmbeddedOperator(:CX, enc)` as
+the goal of a `UnitaryTrajectory`.
+"""
+struct DualRailEncoding
+    n_qubits::Int
+    levels_per_rail::Int
+    n_rails::Int
+    subspace_levels::Vector{Int}
+    conservation::Symbol
+    N::Int
+
+    function DualRailEncoding(;
+        n_qubits::Int,
+        levels_per_rail::Int,
+        conservation::Symbol = :exact_N,
+        N::Int = n_qubits,
+    )
+        n_qubits > 0 || throw(ArgumentError("n_qubits must be positive."))
+        levels_per_rail >= 2 || throw(ArgumentError("levels_per_rail must be at least 2."))
+        conservation in (:exact_N, :upto_N) ||
+            throw(ArgumentError("conservation must be :exact_N or :upto_N."))
+        N >= 0 || throw(ArgumentError("N must be non-negative."))
+        N <= 2n_qubits * (levels_per_rail - 1) ||
+            throw(ArgumentError("N exceeds the maximum excitation number."))
+
+        n_rails = 2n_qubits
+        return new(
+            n_qubits,
+            levels_per_rail,
+            n_rails,
+            fill(levels_per_rail, n_rails),
+            conservation,
+            N,
+        )
+    end
+end
+
+function _occupation_index(occupations::AbstractVector{Int}, levels::AbstractVector{Int})
+    index = 1
+    stride = 1
+    for rail in Iterators.reverse(eachindex(levels))
+        index += occupations[rail] * stride
+        stride *= levels[rail]
+    end
+    return index
+end
+
+"""
+    subspace_transform(enc::DualRailEncoding)
+
+Return the sparse isometry from the selected excitation sector to the full
+tensor-product space and the corresponding full-space basis indices.
+"""
+function subspace_transform(enc::DualRailEncoding)
+    full_dimension = prod(enc.subspace_levels)
+    good_indices = Int[]
+
+    for linear_index = 0:(full_dimension-1)
+        remainder = linear_index
+        excitation_number = 0
+        for level in Iterators.reverse(enc.subspace_levels)
+            excitation_number += remainder % level
+            remainder = div(remainder, level)
+        end
+        keep =
+            enc.conservation === :exact_N ? excitation_number == enc.N :
+            excitation_number <= enc.N
+        keep && push!(good_indices, linear_index + 1)
+    end
+
+    T = sparse(
+        good_indices,
+        eachindex(good_indices),
+        ones(ComplexF64, length(good_indices)),
+        full_dimension,
+        length(good_indices),
+    )
+    return T, good_indices
+end
+
+function reduce_to_subspace(operator::AbstractMatrix, enc::DualRailEncoding)
+    T, _ = subspace_transform(enc)
+    return T' * operator * T
+end
+
+function reduce_to_subspace(state::AbstractVector, enc::DualRailEncoding)
+    T, _ = subspace_transform(enc)
+    return T' * state
+end
+
+function _logical_basis_indices(enc::DualRailEncoding)
+    indices = Int[]
+    occupations = zeros(Int, enc.n_rails)
+    for logical_index = 0:(2^enc.n_qubits-1)
+        fill!(occupations, 0)
+        for qubit = 1:enc.n_qubits
+            bit = (logical_index >> (enc.n_qubits - qubit)) & 1
+            occupations[2qubit-1+bit] = 1
+        end
+        push!(indices, _occupation_index(occupations, enc.subspace_levels))
+    end
+    return indices
+end
+
+"""
+    logical_basis_states(enc::DualRailEncoding)
+
+Return full physical-space kets for the computational basis of the logical
+register, ordered from `|0...0>` through `|1...1>`.
+"""
+function logical_basis_states(enc::DualRailEncoding)
+    full_dimension = prod(enc.subspace_levels)
+    return [
+        sparsevec([index], ComplexF64[1], full_dimension) for
+        index in _logical_basis_indices(enc)
+    ]
+end
+
+"""
+    target_states(gate::Symbol, enc::DualRailEncoding)
+
+Apply a logical gate to every logical computational-basis input and encode the
+result in the full physical space.
+"""
+function target_states(gate::Symbol, enc::DualRailEncoding)
+    gate in keys(GATES) || throw(ArgumentError("Unknown gate: $gate."))
+    logical_gate = GATES[gate]
+    logical_dimension = 2^enc.n_qubits
+    size(logical_gate) == (logical_dimension, logical_dimension) || throw(
+        DimensionMismatch(
+            "Gate $gate acts on $(size(logical_gate, 1)) states, " *
+            "but the encoding has $logical_dimension logical states.",
+        ),
+    )
+
+    encoded_basis = logical_basis_states(enc)
+    return [
+        sum(logical_gate[row, column] * encoded_basis[row] for row = 1:logical_dimension)
+        for column = 1:logical_dimension
+    ]
+end
+
+@testitem "Dual-rail encoding" begin
+    using LinearAlgebra
+    using SparseArrays
+
+    enc = DualRailEncoding(n_qubits = 2, levels_per_rail = 2)
+    T, indices = subspace_transform(enc)
+    @test T isa SparseMatrixCSC{ComplexF64}
+    @test T' * T == I(size(T, 2))
+    @test nnz(T) == 6
+
+    full_operator = spdiagm(0 => ComplexF64.(1:size(T, 1)))
+    @test reduce_to_subspace(full_operator, enc) == T' * full_operator * T
+    full_state = sparsevec([indices[1]], ComplexF64[1], size(T, 1))
+    @test reduce_to_subspace(full_state, enc) == T' * full_state
+
+    basis = logical_basis_states(enc)
+    targets = target_states(:CX, enc)
+    @test targets == basis[[1, 2, 4, 3]]
+
+    open_enc = DualRailEncoding(n_qubits = 2, levels_per_rail = 2, conservation = :upto_N)
+    _, open_indices = subspace_transform(open_enc)
+    @test issubset(indices, open_indices)
+    @test length(open_indices) > length(indices)
+end
+
+@testitem "Three-qubit dual-rail targets" begin
+    using SparseArrays
+
+    single_qubit_enc = DualRailEncoding(n_qubits = 1, levels_per_rail = 2)
+    for gate in (:I, :X, :Y, :Z, :H)
+        @test length(target_states(gate, single_qubit_enc)) == 2
+    end
+
+    two_qubit_enc = DualRailEncoding(n_qubits = 2, levels_per_rail = 2)
+    for gate in (:CX, :CZ)
+        @test length(target_states(gate, two_qubit_enc)) == 4
+    end
+
+    enc = DualRailEncoding(n_qubits = 3, levels_per_rail = 2)
+    basis = logical_basis_states(enc)
+    T, _ = subspace_transform(enc)
+    @test nnz(T) == binomial(6, 3)
+    @test target_states(:CCX, enc) == basis[[1, 2, 3, 4, 5, 6, 8, 7]]
+    @test target_states(:CCZ, enc) == [basis[1:7]..., -basis[8]]
+end
+
+end

--- a/src/quantum/operators/embedded_operators.jl
+++ b/src/quantum/operators/embedded_operators.jl
@@ -12,12 +12,14 @@ export get_iso_vec_leakage_indices
 export get_iso_vec_subspace_indices
 
 using ..Gates
+using ..DualRailEncodings
 using ..Isomorphisms
 using ..LiftedOperators
 using ..QuantumObjectUtils
 using ..QuantumSystems
 
 using LinearAlgebra
+using SparseArrays
 using TestItems
 
 # ----------------------------------------------------------------------------- #
@@ -38,6 +40,16 @@ function embed(
     op_embedded = zeros(R, levels, levels)
     op_embedded[subspace, subspace] = operator
     return op_embedded
+end
+
+function embed(
+    operator::SparseMatrixCSC{R},
+    subspace::AbstractVector{Int},
+    levels::Int,
+) where {R<:Number}
+    @assert size(operator, 1) == size(operator, 2) "Operator must be square."
+    rows, columns, values = findnz(operator)
+    return sparse(subspace[rows], subspace[columns], values, levels, levels)
 end
 
 """
@@ -61,13 +73,13 @@ Embedded operator type to represent an operator embedded in a subspace of a larg
 quantum system.
 
 # Fields
-- `operator::Matrix{<:Number}`: Embedded operator of size
+- `operator::AbstractMatrix{<:Number}`: Embedded operator of size
     `prod(subsystem_levels) x prod(subsystem_levels)`.
 - `subspace::Vector{Int}`: Indices of the subspace the operator is embedded in.
 - `subsystem_levels::Vector{Int}`: Levels of the subsystems in the composite system.
 """
-struct EmbeddedOperator{T<:Number}
-    operator::Matrix{T}
+struct EmbeddedOperator{T<:Number,M<:AbstractMatrix{T}}
+    operator::M
     subspace::Vector{Int}
     subsystem_levels::Vector{Int}
 
@@ -83,7 +95,11 @@ struct EmbeddedOperator{T<:Number}
         subsystem_levels::AbstractVector{Int},
     ) where {T<:Number}
         embedded_operator = embed(subspace_operator, subspace, prod(subsystem_levels))
-        return new{T}(embedded_operator, subspace, subsystem_levels)
+        return new{T,typeof(embedded_operator)}(
+            embedded_operator,
+            subspace,
+            subsystem_levels,
+        )
     end
 end
 
@@ -160,6 +176,99 @@ function EmbeddedOperator(subspace_operator::Symbol, args...; kwargs...)
         )
     end
     return EmbeddedOperator(GATES[subspace_operator], args...; kwargs...)
+end
+
+function _sparse_lift_qubit_operator(
+    operator::AbstractMatrix{<:Number},
+    qubit_indices::AbstractVector{Int},
+    n_qubits::Int,
+)
+    logical_dimension = 2^n_qubits
+    sparse_operator = sparse(ComplexF64.(operator))
+    operator_rows, operator_columns, operator_values = findnz(sparse_operator)
+    output_rows = Int[]
+    output_columns = Int[]
+    output_values = ComplexF64[]
+
+    for full_column = 0:(logical_dimension-1)
+        selected_column = 0
+        for qubit in qubit_indices
+            selected_column <<= 1
+            selected_column |= (full_column >> (n_qubits - qubit)) & 1
+        end
+
+        for nz_index in eachindex(operator_values)
+            operator_columns[nz_index] == selected_column + 1 || continue
+            full_row = full_column
+            selected_row = operator_rows[nz_index] - 1
+            for (position, qubit) in enumerate(qubit_indices)
+                bit = (selected_row >> (length(qubit_indices) - position)) & 1
+                mask = 1 << (n_qubits - qubit)
+                full_row = bit == 1 ? full_row | mask : full_row & ~mask
+            end
+            push!(output_rows, full_row + 1)
+            push!(output_columns, full_column + 1)
+            push!(output_values, operator_values[nz_index])
+        end
+    end
+
+    return sparse(
+        output_rows,
+        output_columns,
+        output_values,
+        logical_dimension,
+        logical_dimension,
+    )
+end
+
+function EmbeddedOperator(
+    subspace_operator::AbstractMatrix{<:Number},
+    enc::DualRailEncoding;
+    qubit_indices::AbstractVector{Int} = 1:enc.n_qubits,
+)
+    all(qubit -> 1 <= qubit <= enc.n_qubits, qubit_indices) ||
+        throw(ArgumentError("qubit_indices must refer to logical qubits in the encoding."))
+    length(unique(qubit_indices)) == length(qubit_indices) ||
+        throw(ArgumentError("qubit_indices must be unique."))
+    expected_dimension = 2^length(qubit_indices)
+    size(subspace_operator) == (expected_dimension, expected_dimension) || throw(
+        DimensionMismatch(
+            "Operator dimension must be $expected_dimension x $expected_dimension " *
+            "for $(length(qubit_indices)) selected qubits.",
+        ),
+    )
+
+    lifted_operator =
+        _sparse_lift_qubit_operator(subspace_operator, qubit_indices, enc.n_qubits)
+    return EmbeddedOperator(
+        lifted_operator,
+        DualRailEncodings._logical_basis_indices(enc),
+        enc.subspace_levels,
+    )
+end
+
+function EmbeddedOperator(
+    gate::Symbol,
+    enc::DualRailEncoding;
+    qubit_indices::AbstractVector{Int} = 1:enc.n_qubits,
+)
+    gate in keys(GATES) || throw(ArgumentError("Unknown gate: $gate."))
+    return EmbeddedOperator(GATES[gate], enc; qubit_indices = qubit_indices)
+end
+
+@testitem "Dual-rail embedded operators" begin
+    using LinearAlgebra
+    using SparseArrays
+
+    enc = DualRailEncoding(n_qubits = 3, levels_per_rail = 2)
+    embedded_cx = EmbeddedOperator(:CX, enc, qubit_indices = [1, 3])
+    @test embedded_cx.operator isa SparseMatrixCSC{ComplexF64}
+    @test unembed(embedded_cx)' * unembed(embedded_cx) == I(8)
+    @test nnz(embedded_cx.operator) == 8
+
+    basis = logical_basis_states(enc)
+    @test embedded_cx.operator * basis[6] == basis[5]
+    @test embedded_cx.operator * basis[8] == basis[7]
 end
 
 @doc raw"""

--- a/src/quantum/primitives/gates.jl
+++ b/src/quantum/primitives/gates.jl
@@ -37,6 +37,8 @@ A constant dictionary `GATES` containing common quantum gate matrices as complex
 - `GATES[:H]` - Hadamard: Creates superposition by transforming basis states.
 - `GATES[:CX]` - Controlled-X (CNOT): Flips the 2nd qubit (target) if the first qubit (control) is |1⟩.
 - `GATES[:CZ]` - Controlled-Z (CZ): Flips the phase of the 2nd qubit (target) if the 1st qubit (control) is |1⟩.
+- `GATES[:CCX]` - Toffoli: Flips the 3rd qubit if the first two qubits are |1⟩.
+- `GATES[:CCZ]` - Controlled-controlled-Z: Flips the phase of |111⟩.
 - `GATES[:XI]` - Complex: A gate for complex operations.
 - `GATES[:sqrtiSWAP]` - Square root of iSWAP: Partially swaps two qubits with a phase.
 """
@@ -60,6 +62,26 @@ const GATES = (
         0 1 0 0
         0 0 1 0
         0 0 0 -1
+    ],
+    CCX = ComplexF64[
+        1 0 0 0 0 0 0 0
+        0 1 0 0 0 0 0 0
+        0 0 1 0 0 0 0 0
+        0 0 0 1 0 0 0 0
+        0 0 0 0 1 0 0 0
+        0 0 0 0 0 1 0 0
+        0 0 0 0 0 0 0 1
+        0 0 0 0 0 0 1 0
+    ],
+    CCZ = ComplexF64[
+        1 0 0 0 0 0 0 0
+        0 1 0 0 0 0 0 0
+        0 0 1 0 0 0 0 0
+        0 0 0 1 0 0 0 0
+        0 0 0 0 1 0 0 0
+        0 0 0 0 0 1 0 0
+        0 0 0 0 0 0 1 0
+        0 0 0 0 0 0 0 -1
     ],
     XI = ComplexF64[
         0 0 -im 0


### PR DESCRIPTION
Closes #197

## Summary
- add `DualRailEncoding` with exact-N and up-to-N sparse subspace transforms
- add sparse-aware operator/state reduction, logical basis kets, and target states for I/X/Y/Z/H/CX/CZ/CCX/CCZ
- add encoding-aware `EmbeddedOperator` constructors, including selected logical-qubit embedding, while preserving sparse matrices
- add CCX and CCZ to `GATES`

## Validation
- 23/23 focused dual-rail tests passed
- 41 existing/focused `EmbeddedOperator` and `GATES` tests passed; 1 repository test remained pre-marked Broken
- JuliaFormatter applied to all changed Julia files
- `git diff --check` and Julia syntax parsing passed
- full `Pkg.test()` was attempted but exceeded 20 minutes during environment precompilation without reporting a test failure

## AI disclosure
This contribution was developed with assistance from OpenAI Codex for repository exploration, implementation, and test drafting. The resulting behavior was verified through the focused test suites and checks listed above.