### PR TITLE
fix: require DirectTrajOpt 0.9.5, bump to 1.18.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Piccolo"
 uuid = "c4671d76-df94-11ed-2057-43d4fd632fad"
-version = "1.17.0"
+version = "1.18.0"
 authors = ["Aaron Trowbridge <aaron@harmoniqs.co> and contributors"]
 
 [deps]
@@ -41,7 +41,7 @@ PiccoloQuantumToolboxExt = ["QuantumToolbox", "Makie"]
 Aqua = "0.8"
 CairoMakie = "0.15"
 DataInterpolations = "8.9"
-DirectTrajOpt = "0.8, 0.9"
+DirectTrajOpt = "0.9.5"
 Distributions = "0.25"
 ExponentialAction = "0.2"
 ForwardDiff = "1.3"


### PR DESCRIPTION
## Problem

Loading Piccolo on a fresh resolve fails to precompile `PiccoloMakieExt`:

```
WARNING: Imported binding DirectTrajOpt.AbstractIntermediateCallback was undeclared at import time during import to PiccoloMakieExt.
ERROR: LoadError: UndefVarError: `AbstractIntermediateCallback` not defined in `PiccoloMakieExt`
```

`ext/PiccoloMakieExt.jl` imports `DirectTrajOpt.AbstractIntermediateCallback` (the supertype for `_LivePulsePlotCallback`). That symbol was **only added in DirectTrajOpt 0.9.5** — none of 0.8.x or 0.9.0–0.9.4 define it. The compat bound was `0.8, 0.9`, so a resolve could (and did) pick an older version, breaking extension precompilation.

## Fix

Tighten compat to `DirectTrajOpt = "0.9.5"` (i.e. `>=0.9.5, <0.10`) so any resolve provides the binding. Minor version bump (1.17.0 → 1.18.0) since this drops 0.8 support.

## Verification

- `Pkg.resolve()` succeeds and pins DirectTrajOpt 0.9.5
- `using Piccolo` loads cleanly; `PiccoloMakieExt` precompiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)