### PR TITLE
Add dual-rail encoding utilities

### DIFF
--- a/src/quantum/_quantum.jl
+++ b/src/quantum/_quantum.jl
@@ -35,6 +35,10 @@ include("primitives/pulses.jl")
 include("object_utils.jl")
 @reexport using .QuantumObjectUtils
 
+# Encodings (depend on gates)
+include("encodings/dual_rail.jl")
+@reexport using .DualRailEncodings
+
 # Operators - lifted (no dependencies)
 include("operators/lifted_operators.jl")
 @reexport using .LiftedOperators

--- a/src/quantum/encodings/dual_rail.jl
+++ b/src/quantum/encodings/dual_rail.jl
@@ -1,0 +1,199 @@
+module DualRailEncodings
+
+export DualRailEncoding
+export subspace_transform
+export reduce_to_subspace
+export logical_basis_states
+export target_states
+
+using ..Gates
+
+using LinearAlgebra
+using SparseArrays
+
+@doc raw"""
+    DualRailEncoding(; n_qubits, levels_per_rail, conservation=:exact_N, N=n_qubits)
+
+Describe a dual-rail logical encoding where each logical qubit is represented by
+two physical rails. Logical `0` occupies the first rail in a pair and logical `1`
+occupies the second rail.
+
+# Example
+
+```julia
+enc = DualRailEncoding(n_qubits=2, levels_per_rail=2, conservation=:exact_N, N=2)
+T, idxs = subspace_transform(enc)
+goal = EmbeddedOperator(:CX, enc)
+```
+"""
+struct DualRailEncoding
+    n_qubits::Int
+    levels_per_rail::Int
+    n_rails::Int
+    subspace_levels::Vector{Int}
+    conservation::Symbol
+    N::Int
+end
+
+function DualRailEncoding(;
+    n_qubits::Int,
+    levels_per_rail::Int,
+    conservation::Symbol = :exact_N,
+    N::Int = n_qubits,
+)
+    n_qubits > 0 || throw(ArgumentError("n_qubits must be positive."))
+    levels_per_rail > 1 || throw(ArgumentError("levels_per_rail must be at least 2."))
+    conservation in (:exact_N, :upto_N) ||
+        throw(ArgumentError("conservation must be :exact_N or :upto_N."))
+    N ≥ 0 || throw(ArgumentError("N must be non-negative."))
+
+    n_rails = 2n_qubits
+    return DualRailEncoding(
+        n_qubits,
+        levels_per_rail,
+        n_rails,
+        fill(levels_per_rail, n_rails),
+        conservation,
+        N,
+    )
+end
+
+function _occupations(index::Int, levels::AbstractVector{Int})
+    offset = index - 1
+    occupations = Vector{Int}(undef, length(levels))
+
+    for i in eachindex(levels)
+        stride = prod(@view levels[(i+1):end]; init = 1)
+        occupations[i] = offset ÷ stride
+        offset %= stride
+    end
+
+    return occupations
+end
+
+function _basis_index(occupations::AbstractVector{Int}, levels::AbstractVector{Int})
+    length(occupations) == length(levels) ||
+        throw(ArgumentError("occupations and levels must have the same length."))
+
+    index = 1
+    for i in eachindex(levels)
+        0 ≤ occupations[i] < levels[i] ||
+            throw(ArgumentError("occupation $(occupations[i]) is outside rail level $(levels[i])."))
+        stride = prod(@view levels[(i+1):end]; init = 1)
+        index += occupations[i] * stride
+    end
+    return index
+end
+
+function _subspace_indices(enc::DualRailEncoding)
+    levels = enc.subspace_levels
+    indices = Int[]
+
+    for index in 1:prod(levels)
+        excitation_count = sum(_occupations(index, levels))
+        if enc.conservation == :exact_N
+            excitation_count == enc.N && push!(indices, index)
+        else
+            excitation_count ≤ enc.N && push!(indices, index)
+        end
+    end
+
+    return indices
+end
+
+"""
+    subspace_transform(enc) -> (T, idxs)
+
+Return the sparse transform `T` from encoded subspace coordinates to full-space
+coordinates plus the full-space basis indices in the selected excitation sector.
+"""
+function subspace_transform(enc::DualRailEncoding)
+    indices = _subspace_indices(enc)
+    rows = indices
+    cols = collect(1:length(indices))
+    vals = ones(ComplexF64, length(indices))
+    transform = sparse(rows, cols, vals, prod(enc.subspace_levels), length(indices))
+    return transform, indices
+end
+
+function reduce_to_subspace(operator::AbstractMatrix, enc::DualRailEncoding)
+    transform, _ = subspace_transform(enc)
+    return transform' * operator * transform
+end
+
+function reduce_to_subspace(state::AbstractVector, enc::DualRailEncoding)
+    transform, _ = subspace_transform(enc)
+    return transform' * state
+end
+
+function _logical_bits(logical_index::Int, n_qubits::Int)
+    value = logical_index - 1
+    bits = Vector{Int}(undef, n_qubits)
+
+    for i in 1:n_qubits
+        stride = 2^(n_qubits - i)
+        bits[i] = value ÷ stride
+        value %= stride
+    end
+
+    return bits
+end
+
+function logical_subspace_indices(enc::DualRailEncoding)
+    indices = Int[]
+
+    for logical_index in 1:(2^enc.n_qubits)
+        bits = _logical_bits(logical_index, enc.n_qubits)
+        occupations = zeros(Int, enc.n_rails)
+
+        for (qubit, bit) in enumerate(bits)
+            first_rail = 2qubit - 1
+            occupations[first_rail + bit] = 1
+        end
+
+        push!(indices, _basis_index(occupations, enc.subspace_levels))
+    end
+
+    return indices
+end
+
+function logical_basis_states(enc::DualRailEncoding)
+    states = Vector{Vector{ComplexF64}}()
+    full_dimension = prod(enc.subspace_levels)
+
+    for index in logical_subspace_indices(enc)
+        state = zeros(ComplexF64, full_dimension)
+        state[index] = 1
+        push!(states, state)
+    end
+
+    return states
+end
+
+function target_states(gate::Symbol, enc::DualRailEncoding)
+    haskey(GATES, gate) ||
+        throw(ArgumentError("Operator must be a valid gate. See Piccolo.GATES."))
+    return target_states(GATES[gate], enc)
+end
+
+function target_states(gate::AbstractMatrix{<:Number}, enc::DualRailEncoding)
+    expected_dimension = 2^enc.n_qubits
+    size(gate) == (expected_dimension, expected_dimension) ||
+        throw(DimensionMismatch("gate must act on all $(enc.n_qubits) logical qubits."))
+
+    logical_states = logical_basis_states(enc)
+    targets = Vector{Vector{ComplexF64}}()
+
+    for col in 1:expected_dimension
+        target = zeros(ComplexF64, length(logical_states[1]))
+        for row in 1:expected_dimension
+            coefficient = gate[row, col]
+            !iszero(coefficient) && (target .+= coefficient .* logical_states[row])
+        end
+        push!(targets, target)
+    end
+
+    return targets
+end
+
+end

--- a/src/quantum/operators/embedded_operators.jl
+++ b/src/quantum/operators/embedded_operators.jl
@@ -12,12 +12,14 @@ export get_iso_vec_leakage_indices
 export get_iso_vec_subspace_indices
 
 using ..Gates
+using ..DualRailEncodings
 using ..Isomorphisms
 using ..LiftedOperators
 using ..QuantumObjectUtils
 using ..QuantumSystems
 
 using LinearAlgebra
+using SparseArrays
 using TestItems
 
 # ----------------------------------------------------------------------------- #
@@ -66,8 +68,8 @@ quantum system.
 - `subspace::Vector{Int}`: Indices of the subspace the operator is embedded in.
 - `subsystem_levels::Vector{Int}`: Levels of the subsystems in the composite system.
 """
-struct EmbeddedOperator{T<:Number}
-    operator::Matrix{T}
+struct EmbeddedOperator{T<:Number,M<:AbstractMatrix{T}}
+    operator::M
     subspace::Vector{Int}
     subsystem_levels::Vector{Int}
 
@@ -81,9 +83,17 @@ struct EmbeddedOperator{T<:Number}
         subspace_operator::AbstractMatrix{T},
         subspace::AbstractVector{Int},
         subsystem_levels::AbstractVector{Int},
+        ;
+        embedded::Bool = false,
     ) where {T<:Number}
-        embedded_operator = embed(subspace_operator, subspace, prod(subsystem_levels))
-        return new{T}(embedded_operator, subspace, subsystem_levels)
+        embedded_operator = embedded ?
+                            subspace_operator :
+                            embed(subspace_operator, subspace, prod(subsystem_levels))
+        return new{T,typeof(embedded_operator)}(
+            embedded_operator,
+            collect(subspace),
+            collect(subsystem_levels),
+        )
     end
 end
 
@@ -161,6 +171,56 @@ function EmbeddedOperator(subspace_operator::Symbol, args...; kwargs...)
     end
     return EmbeddedOperator(GATES[subspace_operator], args...; kwargs...)
 end
+
+function _sparse_embed(
+    operator::AbstractMatrix{T},
+    subspace::AbstractVector{Int},
+    levels::Int,
+) where {T<:Number}
+    sparse_operator = sparse(operator)
+    rows = Int[]
+    cols = Int[]
+    vals = T[]
+
+    for col in 1:size(sparse_operator, 2)
+        for row_index in nzrange(sparse_operator, col)
+            row = rowvals(sparse_operator)[row_index]
+            push!(rows, subspace[row])
+            push!(cols, subspace[col])
+            push!(vals, nonzeros(sparse_operator)[row_index])
+        end
+    end
+
+    return sparse(rows, cols, vals, levels, levels)
+end
+
+function EmbeddedOperator(
+    subspace_operator::AbstractMatrix{<:Number},
+    enc::DualRailEncoding;
+    qubit_indices::AbstractVector{Int} = collect(1:enc.n_qubits),
+)
+    @assert all(1 ≤ qubit ≤ enc.n_qubits for qubit in qubit_indices)
+    expected_dimension = 2^length(qubit_indices)
+    size(subspace_operator) == (expected_dimension, expected_dimension) ||
+        throw(DimensionMismatch("subspace_operator must act on $(length(qubit_indices)) logical qubits."))
+
+    logical_operator = length(qubit_indices) == enc.n_qubits ?
+                       subspace_operator :
+                       lift_operator(subspace_operator, qubit_indices, fill(2, enc.n_qubits))
+    logical_subspace = DualRailEncodings.logical_subspace_indices(enc)
+    levels = prod(enc.subspace_levels)
+    embedded_operator = _sparse_embed(logical_operator, logical_subspace, levels)
+
+    return EmbeddedOperator(
+        embedded_operator,
+        logical_subspace,
+        enc.subspace_levels;
+        embedded = true,
+    )
+end
+
+EmbeddedOperator(gate::Symbol, enc::DualRailEncoding; kwargs...) =
+    EmbeddedOperator(GATES[gate], enc; kwargs...)
 
 @doc raw"""
     EmbeddedOperator(

--- a/src/quantum/primitives/gates.jl
+++ b/src/quantum/primitives/gates.jl
@@ -37,6 +37,8 @@ A constant dictionary `GATES` containing common quantum gate matrices as complex
 - `GATES[:H]` - Hadamard: Creates superposition by transforming basis states.
 - `GATES[:CX]` - Controlled-X (CNOT): Flips the 2nd qubit (target) if the first qubit (control) is |1⟩.
 - `GATES[:CZ]` - Controlled-Z (CZ): Flips the phase of the 2nd qubit (target) if the 1st qubit (control) is |1⟩.
+- `GATES[:CCX]` - Toffoli gate: Flips the 3rd qubit if the first two qubits are |1⟩.
+- `GATES[:CCZ]` - Controlled-controlled-Z gate: Flips the phase of |111⟩.
 - `GATES[:XI]` - Complex: A gate for complex operations.
 - `GATES[:sqrtiSWAP]` - Square root of iSWAP: Partially swaps two qubits with a phase.
 """
@@ -60,6 +62,26 @@ const GATES = (
         0 1 0 0
         0 0 1 0
         0 0 0 -1
+    ],
+    CCX = ComplexF64[
+        1 0 0 0 0 0 0 0
+        0 1 0 0 0 0 0 0
+        0 0 1 0 0 0 0 0
+        0 0 0 1 0 0 0 0
+        0 0 0 0 1 0 0 0
+        0 0 0 0 0 1 0 0
+        0 0 0 0 0 0 0 1
+        0 0 0 0 0 0 1 0
+    ],
+    CCZ = ComplexF64[
+        1 0 0 0 0 0 0 0
+        0 1 0 0 0 0 0 0
+        0 0 1 0 0 0 0 0
+        0 0 0 1 0 0 0 0
+        0 0 0 0 1 0 0 0
+        0 0 0 0 0 1 0 0
+        0 0 0 0 0 0 1 0
+        0 0 0 0 0 0 0 -1
     ],
     XI = ComplexF64[
         0 0 -im 0

--- a/test/encodings/dual_rail.jl
+++ b/test/encodings/dual_rail.jl
@@ -1,0 +1,70 @@
+using TestItems
+
+@testitem "DualRailEncoding subspace transforms" begin
+    using LinearAlgebra
+    using Piccolo
+    using SparseArrays
+
+    enc = DualRailEncoding(n_qubits = 2, levels_per_rail = 2, conservation = :exact_N, N = 2)
+    T, idxs = subspace_transform(enc)
+
+    @test issparse(T)
+    @test size(T) == (16, 6)
+    @test nnz(T) == 6
+    @test T' * T == I(6)
+    @test idxs == [4, 6, 7, 10, 11, 13]
+
+    upto = DualRailEncoding(n_qubits = 2, levels_per_rail = 2, conservation = :upto_N, N = 2)
+    _, upto_idxs = subspace_transform(upto)
+    @test issubset(idxs, upto_idxs)
+    @test length(upto_idxs) > length(idxs)
+end
+
+@testitem "reduce_to_subspace matches explicit projection" begin
+    using LinearAlgebra
+    using Piccolo
+    using SparseArrays
+
+    enc = DualRailEncoding(n_qubits = 1, levels_per_rail = 2, conservation = :exact_N, N = 1)
+    T, _ = subspace_transform(enc)
+    full_op = sparse(Diagonal(ComplexF64[1, 2, 3, 4]))
+    full_state = ComplexF64[1, 2, 3, 4]
+
+    @test reduce_to_subspace(full_op, enc) == T' * full_op * T
+    @test reduce_to_subspace(full_state, enc) == T' * full_state
+end
+
+@testitem "target_states returns encoded CX and CCX outputs" begin
+    using Piccolo
+
+    enc2 = DualRailEncoding(n_qubits = 2, levels_per_rail = 2, conservation = :exact_N, N = 2)
+    logical2 = logical_basis_states(enc2)
+    cx_targets = target_states(:CX, enc2)
+
+    @test cx_targets[1] == logical2[1] # 00 -> 00
+    @test cx_targets[2] == logical2[2] # 01 -> 01
+    @test cx_targets[3] == logical2[4] # 10 -> 11
+    @test cx_targets[4] == logical2[3] # 11 -> 10
+
+    enc3 = DualRailEncoding(n_qubits = 3, levels_per_rail = 2, conservation = :exact_N, N = 3)
+    logical3 = logical_basis_states(enc3)
+    ccx_targets = target_states(:CCX, enc3)
+
+    @test ccx_targets[7] == logical3[8] # 110 -> 111
+    @test ccx_targets[8] == logical3[7] # 111 -> 110
+end
+
+@testitem "EmbeddedOperator accepts dual rail encodings" begin
+    using LinearAlgebra
+    using Piccolo
+    using SparseArrays
+
+    enc = DualRailEncoding(n_qubits = 2, levels_per_rail = 2, conservation = :exact_N, N = 2)
+    op = EmbeddedOperator(:CX, enc)
+
+    @test issparse(op.operator)
+    @test op.subsystem_levels == [2, 2, 2, 2]
+
+    sub = unembed(op)
+    @test sub' * sub ≈ I(size(sub, 1))
+end


### PR DESCRIPTION
## Summary
- add `DualRailEncoding` with sparse exact/up-to excitation subspace transforms
- add subspace reduction, logical basis states, and encoded target-state helpers
- add sparse `EmbeddedOperator(..., enc)` support for dual-rail encodings
- add `CCX` and `CCZ` gates for logical target-state construction

## Verification
- `@run_package_tests` filtered to `test/encodings/dual_rail.jl`: 18 passed
- gate/embedded-operator smoke check passed
- `git diff --check` clean, with only Windows LF-to-CRLF warnings

Full `Pkg.test()` was not completed locally because the full suite exceeded the command timeout on this machine.

Closes #197

AI use: implemented with Codex assistance and local review; focused tests are passing.