### PR TITLE
Add first-class dual-rail encoding support

### DIFF
--- a/docs/src/lib.md
+++ b/docs/src/lib.md
@@ -54,6 +54,12 @@ Modules = [Piccolo.Quantum.Pulses]
 Modules = [Piccolo.Quantum.Rollouts]
 ```
 
+## [Encodings](@id lib-encodings)
+
+```@autodocs
+Modules = [Piccolo.Quantum.Encodings]
+```
+
 ## [Embedded Operators](@id lib-embedded-operators)
 
 ```@autodocs

--- a/src/quantum/_quantum.jl
+++ b/src/quantum/_quantum.jl
@@ -43,6 +43,10 @@ include("operators/lifted_operators.jl")
 include("systems/_quantum_systems.jl")
 @reexport using .QuantumSystems
 
+# Encodings
+include("encodings/dual_rail.jl")
+@reexport using .Encodings
+
 # Operators - embedded and direct_sums (depend on systems)
 include("operators/embedded_operators.jl")
 @reexport using .EmbeddedOperators

--- a/src/quantum/encodings/dual_rail.jl
+++ b/src/quantum/encodings/dual_rail.jl
@@ -77,12 +77,20 @@ function DualRailEncoding(;
     conservation::Symbol = :exact_N,
     N::Int = n_qubits,
 )
-    @assert n_qubits ≥ 1 "n_qubits must be ≥ 1"
-    @assert levels_per_rail ≥ 2 "levels_per_rail must be ≥ 2"
-    @assert conservation ∈ (:exact_N, :upto_N) "conservation must be :exact_N or :upto_N"
-    @assert N % n_qubits == 0 "N ($N) must be divisible by n_qubits ($n_qubits)"
+    n_qubits ≥ 1 ||
+        throw(ArgumentError("n_qubits must be ≥ 1, got $n_qubits"))
+    levels_per_rail ≥ 2 ||
+        throw(ArgumentError("levels_per_rail must be ≥ 2, got $levels_per_rail"))
+    conservation ∈ (:exact_N, :upto_N) ||
+        throw(ArgumentError("conservation must be :exact_N or :upto_N, got $conservation"))
+    N % n_qubits == 0 ||
+        throw(ArgumentError("N ($N) must be divisible by n_qubits ($n_qubits)"))
     n_per_qubit = N ÷ n_qubits
-    @assert n_per_qubit ≤ levels_per_rail - 1 "per-qubit excitation ($n_per_qubit) exceeds levels_per_rail - 1 ($(levels_per_rail - 1))"
+    n_per_qubit ≤ levels_per_rail - 1 || throw(
+        ArgumentError(
+            "per-qubit excitation ($n_per_qubit) exceeds levels_per_rail - 1 ($(levels_per_rail - 1))",
+        ),
+    )
     n_rails = 2 * n_qubits
     subspace_levels = fill(levels_per_rail, n_rails)
     return DualRailEncoding(
@@ -251,7 +259,11 @@ function target_states(gate::Symbol, enc::DualRailEncoding)
     end
     U = GATES[gate]
     n = enc.n_qubits
-    @assert size(U, 1) == 2^n "Gate dimension $(size(U, 1)) does not match 2^n_qubits = $(2^n)."
+    size(U, 1) == 2^n || throw(
+        ArgumentError(
+            "Gate dimension $(size(U, 1)) does not match 2^n_qubits = $(2^n).",
+        ),
+    )
     ψ_logical = logical_basis_states(enc)
     full_dim = length(ψ_logical[1])
     targets = Vector{Vector{ComplexF64}}(undef, 2^n)

--- a/src/quantum/encodings/dual_rail.jl
+++ b/src/quantum/encodings/dual_rail.jl
@@ -1,0 +1,268 @@
+module Encodings
+
+export DualRailEncoding
+
+export subspace_transform
+export reduce_to_subspace
+export logical_basis_states
+export logical_state_indices
+export target_states
+
+using ..Gates
+
+using SparseArrays
+using TestItems
+
+# ----------------------------------------------------------------------------- #
+#                              DualRailEncoding                                 #
+# ----------------------------------------------------------------------------- #
+
+@doc raw"""
+    DualRailEncoding
+
+Encoding of `n_qubits` logical qubits into `2 * n_qubits` physical modes (rails),
+each truncated to `levels_per_rail` levels. Each logical qubit occupies a pair of
+rails, with the convention
+
+```math
+|0\rangle_L \leftrightarrow |n, 0\rangle, \qquad |1\rangle_L \leftrightarrow |0, n\rangle
+```
+
+where ``n`` is the per-qubit excitation number `N ÷ n_qubits` (typically `1`, the
+single-excitation dual-rail code). The pattern works for any excitation-conserving
+system (bosonic, spin, fermionic), not just photonics.
+
+# Fields
+- `n_qubits::Int`: number of logical qubits.
+- `levels_per_rail::Int`: local Hilbert dimension per rail.
+- `n_rails::Int`: `2 * n_qubits`.
+- `subspace_levels::Vector{Int}`: full tensor-product dims, `fill(levels_per_rail, n_rails)`.
+- `conservation::Symbol`: `:exact_N` (closed, ``\sum_i n_i = N``) or `:upto_N`
+  (open / lossy, ``\sum_i n_i \le N``).
+- `N::Int`: target excitation number (typically `n_qubits`).
+
+# Keyword constructor
+    DualRailEncoding(; n_qubits, levels_per_rail=2, conservation=:exact_N, N=n_qubits)
+
+# Notes
+The encoding intentionally does *not* carry a Hamiltonian — that is the user's
+responsibility. Build a `QuantumSystem` from your own `H_drift` / `H_drives`, then
+pass an encoding-aware goal into a trajectory:
+
+```julia
+using Piccolo
+
+enc = DualRailEncoding(n_qubits = 2, levels_per_rail = 2, conservation = :exact_N, N = 2)
+
+# user-supplied Hamiltonian on the full rail space
+system = QuantumSystem(H_drift, H_drives, drive_bounds)
+
+# encoding-aware goal for a logical CX
+U_goal = EmbeddedOperator(:CX, enc)
+traj = UnitaryTrajectory(system, pulse, U_goal)
+```
+"""
+struct DualRailEncoding
+    n_qubits::Int
+    levels_per_rail::Int
+    n_rails::Int
+    subspace_levels::Vector{Int}
+    conservation::Symbol
+    N::Int
+end
+
+function DualRailEncoding(;
+    n_qubits::Int,
+    levels_per_rail::Int = 2,
+    conservation::Symbol = :exact_N,
+    N::Int = n_qubits,
+)
+    @assert n_qubits ≥ 1 "n_qubits must be ≥ 1"
+    @assert levels_per_rail ≥ 2 "levels_per_rail must be ≥ 2"
+    @assert conservation ∈ (:exact_N, :upto_N) "conservation must be :exact_N or :upto_N"
+    @assert N % n_qubits == 0 "N ($N) must be divisible by n_qubits ($n_qubits)"
+    n_per_qubit = N ÷ n_qubits
+    @assert n_per_qubit ≤ levels_per_rail - 1 "per-qubit excitation ($n_per_qubit) exceeds levels_per_rail - 1 ($(levels_per_rail - 1))"
+    n_rails = 2 * n_qubits
+    subspace_levels = fill(levels_per_rail, n_rails)
+    return DualRailEncoding(
+        n_qubits,
+        levels_per_rail,
+        n_rails,
+        subspace_levels,
+        conservation,
+        N,
+    )
+end
+
+"""
+    excitation_per_qubit(enc::DualRailEncoding)
+
+Per-qubit excitation number, `N ÷ n_qubits`.
+"""
+excitation_per_qubit(enc::DualRailEncoding) = enc.N ÷ enc.n_qubits
+
+# ----------------------------------------------------------------------------- #
+#                            Index <-> occupation                              #
+# ----------------------------------------------------------------------------- #
+# Convention matches `EmbeddedOperators.basis_labels(...; baseline=0)`: the first
+# rail is the most significant digit (changes slowest), indices are 1-based.
+
+function index_to_occupation(idx::Int, levels::AbstractVector{Int})
+    r = idx - 1
+    n = length(levels)
+    occ = zeros(Int, n)
+    for k = n:-1:1
+        occ[k] = r % levels[k]
+        r ÷= levels[k]
+    end
+    return occ
+end
+
+function occupation_to_index(occ::AbstractVector{Int}, levels::AbstractVector{Int})
+    idx = 0
+    for k in eachindex(levels)
+        idx = idx * levels[k] + occ[k]
+    end
+    return idx + 1
+end
+
+# ----------------------------------------------------------------------------- #
+#                            Subspace transform                                #
+# ----------------------------------------------------------------------------- #
+
+"""
+    good_indices(enc::DualRailEncoding) -> Vector{Int}
+
+The "good" full-space basis indices of the excitation-number subspace: occupation
+tuples with ``\\sum_i n_i = N`` for `:exact_N`, or ``\\le N`` for `:upto_N`.
+"""
+function good_indices(enc::DualRailEncoding)
+    levels = enc.subspace_levels
+    full_dim = prod(levels)
+    keep = enc.conservation == :exact_N ? (s -> s == enc.N) : (s -> s ≤ enc.N)
+    idxs = Int[]
+    for idx = 1:full_dim
+        occ = index_to_occupation(idx, levels)
+        if keep(sum(occ))
+            push!(idxs, idx)
+        end
+    end
+    return idxs
+end
+
+@doc raw"""
+    subspace_transform(enc::DualRailEncoding) -> (T::SparseMatrixCSC{ComplexF64}, idxs::Vector{Int})
+
+Projector mapping subspace coordinates to full coordinates, ``|\psi_\text{full}\rangle = T |\psi_\text{sub}\rangle``,
+together with the list of "good" basis indices `idxs`. `T` is `full_dim × length(idxs)`
+with a single unit entry per column. Supports both `:exact_N` and `:upto_N`.
+"""
+function subspace_transform(enc::DualRailEncoding)
+    idxs = good_indices(enc)
+    full_dim = prod(enc.subspace_levels)
+    k = length(idxs)
+    T = sparse(idxs, collect(1:k), ones(ComplexF64, k), full_dim, k)
+    return T, idxs
+end
+
+"""
+    reduce_to_subspace(O::AbstractMatrix, enc::DualRailEncoding)
+    reduce_to_subspace(ψ::AbstractVector, enc::DualRailEncoding)
+
+Reduce a full-space operator (`T' * O * T`) or state (`T' * ψ`) to the encoded
+subspace. Sparse-aware.
+"""
+function reduce_to_subspace(O::AbstractMatrix, enc::DualRailEncoding)
+    T, _ = subspace_transform(enc)
+    return T' * O * T
+end
+
+function reduce_to_subspace(ψ::AbstractVector, enc::DualRailEncoding)
+    T, _ = subspace_transform(enc)
+    return T' * ψ
+end
+
+# ----------------------------------------------------------------------------- #
+#                            Logical states                                    #
+# ----------------------------------------------------------------------------- #
+
+"""
+    logical_state_indices(enc::DualRailEncoding) -> Vector{Int}
+
+Full-space indices of the `2^n_qubits` logical basis states, ordered
+`|0…0⟩, …, |1…1⟩` (first qubit most significant). For qubit `i` (rails `2i-1`, `2i`),
+bit `0` places `n` excitations in the first rail (`|n,0⟩`) and bit `1` in the second
+(`|0,n⟩`), where `n = N ÷ n_qubits`.
+"""
+function logical_state_indices(enc::DualRailEncoding)
+    n = enc.n_qubits
+    n_per = excitation_per_qubit(enc)
+    levels = enc.subspace_levels
+    indices = Vector{Int}(undef, 2^n)
+    for j = 0:(2^n-1)
+        occ = zeros(Int, enc.n_rails)
+        for i = 1:n
+            bit = (j >> (n - i)) & 1
+            if bit == 0
+                occ[2i-1] = n_per
+            else
+                occ[2i] = n_per
+            end
+        end
+        indices[j+1] = occupation_to_index(occ, levels)
+    end
+    return indices
+end
+
+"""
+    logical_basis_states(enc::DualRailEncoding) -> Vector{Vector{ComplexF64}}
+
+The `2^n_qubits` physical kets (full-space dimension) corresponding to the logical
+basis states `|0…0⟩, …, |1…1⟩`.
+"""
+function logical_basis_states(enc::DualRailEncoding)
+    full_dim = prod(enc.subspace_levels)
+    idxs = logical_state_indices(enc)
+    states = Vector{Vector{ComplexF64}}(undef, length(idxs))
+    for (j, idx) in enumerate(idxs)
+        ψ = zeros(ComplexF64, full_dim)
+        ψ[idx] = 1
+        states[j] = ψ
+    end
+    return states
+end
+
+"""
+    target_states(gate::Symbol, enc::DualRailEncoding) -> Vector{Vector{ComplexF64}}
+
+For each logical input basis state, the encoded physical output ket under the logical
+`gate`. The logical unitary is looked up in `Piccolo.GATES` and must act on the full
+register (`size == 2^n_qubits`). Supports `:I, :X, :Y, :Z, :H, :CX, :CZ, :CCX, :CCZ`
+(any gate present in `GATES` of the right dimension).
+"""
+function target_states(gate::Symbol, enc::DualRailEncoding)
+    if gate ∉ keys(GATES)
+        throw(
+            ArgumentError(
+                "Gate must be a valid gate. See Piccolo.GATES for available gates.",
+            ),
+        )
+    end
+    U = GATES[gate]
+    n = enc.n_qubits
+    @assert size(U, 1) == 2^n "Gate dimension $(size(U, 1)) does not match 2^n_qubits = $(2^n)."
+    ψ_logical = logical_basis_states(enc)
+    full_dim = length(ψ_logical[1])
+    targets = Vector{Vector{ComplexF64}}(undef, 2^n)
+    for j = 1:(2^n)
+        out = zeros(ComplexF64, full_dim)
+        for i = 1:(2^n)
+            out .+= U[i, j] .* ψ_logical[i]
+        end
+        targets[j] = out
+    end
+    return targets
+end
+
+end

--- a/src/quantum/encodings/dual_rail.jl
+++ b/src/quantum/encodings/dual_rail.jl
@@ -77,8 +77,7 @@ function DualRailEncoding(;
     conservation::Symbol = :exact_N,
     N::Int = n_qubits,
 )
-    n_qubits ≥ 1 ||
-        throw(ArgumentError("n_qubits must be ≥ 1, got $n_qubits"))
+    n_qubits ≥ 1 || throw(ArgumentError("n_qubits must be ≥ 1, got $n_qubits"))
     levels_per_rail ≥ 2 ||
         throw(ArgumentError("levels_per_rail must be ≥ 2, got $levels_per_rail"))
     conservation ∈ (:exact_N, :upto_N) ||
@@ -260,9 +259,7 @@ function target_states(gate::Symbol, enc::DualRailEncoding)
     U = GATES[gate]
     n = enc.n_qubits
     size(U, 1) == 2^n || throw(
-        ArgumentError(
-            "Gate dimension $(size(U, 1)) does not match 2^n_qubits = $(2^n).",
-        ),
+        ArgumentError("Gate dimension $(size(U, 1)) does not match 2^n_qubits = $(2^n)."),
     )
     ψ_logical = logical_basis_states(enc)
     full_dim = length(ψ_logical[1])

--- a/src/quantum/operators/embedded_operators.jl
+++ b/src/quantum/operators/embedded_operators.jl
@@ -185,9 +185,15 @@ function EmbeddedOperator(
     qubit_indices::AbstractVector{Int} = collect(1:enc.n_qubits),
 )
     k = length(qubit_indices)
-    @assert size(subspace_operator, 1) == size(subspace_operator, 2) "Operator must be square."
-    @assert size(subspace_operator, 1) == 2^k "Operator dimension $(size(subspace_operator, 1)) does not match 2^length(qubit_indices) = $(2^k)."
-    @assert all(1 ≤ q ≤ enc.n_qubits for q ∈ qubit_indices) "qubit_indices must lie in 1:$(enc.n_qubits)."
+    size(subspace_operator, 1) == size(subspace_operator, 2) ||
+        throw(ArgumentError("Operator must be square."))
+    size(subspace_operator, 1) == 2^k || throw(
+        ArgumentError(
+            "Operator dimension $(size(subspace_operator, 1)) does not match 2^length(qubit_indices) = $(2^k).",
+        ),
+    )
+    all(1 ≤ q ≤ enc.n_qubits for q ∈ qubit_indices) ||
+        throw(ArgumentError("qubit_indices must lie in 1:$(enc.n_qubits)."))
 
     # Lift the (sub-register) logical operator to the full 2^n_qubits logical space.
     U_full =

--- a/src/quantum/operators/embedded_operators.jl
+++ b/src/quantum/operators/embedded_operators.jl
@@ -16,6 +16,7 @@ using ..Isomorphisms
 using ..LiftedOperators
 using ..QuantumObjectUtils
 using ..QuantumSystems
+using ..Encodings
 
 using LinearAlgebra
 using TestItems
@@ -148,6 +149,58 @@ function EmbeddedOperator(
     ),
 )
     return EmbeddedOperator(subspace_operator, subsystem_indices, subspaces, system)
+end
+
+@doc raw"""
+    EmbeddedOperator(
+        subspace_operator::AbstractMatrix{<:Number},
+        enc::DualRailEncoding;
+        qubit_indices::AbstractVector{Int} = 1:enc.n_qubits,
+    )
+
+Embed a logical `subspace_operator` into the physical rail space described by a
+[`DualRailEncoding`](@ref). The operator may act on the whole logical register
+(`size == 2^enc.n_qubits`) or on a subset of `qubit_indices` (e.g. a 2-qubit gate
+on a specific pair within a larger register), in which case it is lifted to the full
+register with identities on the remaining qubits before being embedded at the
+dual-rail logical basis indices.
+
+The resulting `EmbeddedOperator` has `subsystem_levels == enc.subspace_levels` and a
+`subspace` given by the encoding's logical-state indices.
+
+# Examples
+```julia
+enc = DualRailEncoding(n_qubits = 3, levels_per_rail = 2, conservation = :exact_N, N = 3)
+
+# Toffoli on the full 3-qubit register
+U_goal = EmbeddedOperator(:CCX, enc)
+
+# CX on qubits 1 and 2 of the register
+U_goal = EmbeddedOperator(GATES[:CX], enc; qubit_indices = [1, 2])
+```
+"""
+function EmbeddedOperator(
+    subspace_operator::AbstractMatrix{<:Number},
+    enc::DualRailEncoding;
+    qubit_indices::AbstractVector{Int} = collect(1:enc.n_qubits),
+)
+    k = length(qubit_indices)
+    @assert size(subspace_operator, 1) == size(subspace_operator, 2) "Operator must be square."
+    @assert size(subspace_operator, 1) == 2^k "Operator dimension $(size(subspace_operator, 1)) does not match 2^length(qubit_indices) = $(2^k)."
+    @assert all(1 ≤ q ≤ enc.n_qubits for q ∈ qubit_indices) "qubit_indices must lie in 1:$(enc.n_qubits)."
+
+    # Lift the (sub-register) logical operator to the full 2^n_qubits logical space.
+    U_full =
+        k == enc.n_qubits && collect(qubit_indices) == collect(1:enc.n_qubits) ?
+        Matrix{ComplexF64}(subspace_operator) :
+        lift_operator(
+            Matrix{ComplexF64}(subspace_operator),
+            collect(qubit_indices),
+            enc.n_qubits,
+        )
+
+    subspace = logical_state_indices(enc)
+    return EmbeddedOperator(U_full, subspace, enc.subspace_levels)
 end
 
 function EmbeddedOperator(subspace_operator::Symbol, args...; kwargs...)

--- a/src/quantum/primitives/gates.jl
+++ b/src/quantum/primitives/gates.jl
@@ -37,6 +37,8 @@ A constant dictionary `GATES` containing common quantum gate matrices as complex
 - `GATES[:H]` - Hadamard: Creates superposition by transforming basis states.
 - `GATES[:CX]` - Controlled-X (CNOT): Flips the 2nd qubit (target) if the first qubit (control) is |1⟩.
 - `GATES[:CZ]` - Controlled-Z (CZ): Flips the phase of the 2nd qubit (target) if the 1st qubit (control) is |1⟩.
+- `GATES[:CCX]` - Toffoli (CCNOT): Flips the 3rd qubit (target) if both control qubits are |1⟩.
+- `GATES[:CCZ]` - Controlled-controlled-Z: Flips the phase of |111⟩.
 - `GATES[:XI]` - Complex: A gate for complex operations.
 - `GATES[:sqrtiSWAP]` - Square root of iSWAP: Partially swaps two qubits with a phase.
 """
@@ -60,6 +62,26 @@ const GATES = (
         0 1 0 0
         0 0 1 0
         0 0 0 -1
+    ],
+    CCX = ComplexF64[
+        1 0 0 0 0 0 0 0
+        0 1 0 0 0 0 0 0
+        0 0 1 0 0 0 0 0
+        0 0 0 1 0 0 0 0
+        0 0 0 0 1 0 0 0
+        0 0 0 0 0 1 0 0
+        0 0 0 0 0 0 0 1
+        0 0 0 0 0 0 1 0
+    ],
+    CCZ = ComplexF64[
+        1 0 0 0 0 0 0 0
+        0 1 0 0 0 0 0 0
+        0 0 1 0 0 0 0 0
+        0 0 0 1 0 0 0 0
+        0 0 0 0 1 0 0 0
+        0 0 0 0 0 1 0 0
+        0 0 0 0 0 0 1 0
+        0 0 0 0 0 0 0 -1
     ],
     XI = ComplexF64[
         0 0 -im 0
@@ -85,6 +107,27 @@ const GATES = (
     for k in keys(GATES)
         @test typeof(GATES[k]) == Matrix{ComplexF64}
     end
+end
+
+@testitem "Three-qubit controlled gates" begin
+    using LinearAlgebra: I, Diagonal
+
+    # Both are 8×8 and unitary
+    @test size(GATES[:CCX]) == (8, 8)
+    @test size(GATES[:CCZ]) == (8, 8)
+    @test GATES[:CCX]'GATES[:CCX] ≈ I(8)
+    @test GATES[:CCZ]'GATES[:CCZ] ≈ I(8)
+
+    # CCX swaps |110⟩ (index 7) and |111⟩ (index 8), identity elsewhere
+    expected_CCX = Matrix{ComplexF64}(I(8))
+    expected_CCX[7, 7] = 0
+    expected_CCX[8, 8] = 0
+    expected_CCX[7, 8] = 1
+    expected_CCX[8, 7] = 1
+    @test GATES[:CCX] == expected_CCX
+
+    # CCZ adds a phase only to |111⟩ (index 8)
+    @test GATES[:CCZ] == Matrix(Diagonal(ComplexF64[1, 1, 1, 1, 1, 1, 1, -1]))
 end
 
 @testitem "Paulis are complex matrices" begin

--- a/test/encodings/dual_rail.jl
+++ b/test/encodings/dual_rail.jl
@@ -1,0 +1,144 @@
+@testitem "DualRailEncoding: construction and validation" begin
+    enc =
+        DualRailEncoding(n_qubits = 3, levels_per_rail = 2, conservation = :exact_N, N = 3)
+    @test enc.n_qubits == 3
+    @test enc.levels_per_rail == 2
+    @test enc.n_rails == 6
+    @test enc.subspace_levels == fill(2, 6)
+    @test enc.conservation == :exact_N
+    @test enc.N == 3
+
+    # Defaults: levels_per_rail = 2, conservation = :exact_N, N = n_qubits
+    enc_default = DualRailEncoding(n_qubits = 2)
+    @test enc_default.levels_per_rail == 2
+    @test enc_default.conservation == :exact_N
+    @test enc_default.N == 2
+
+    # Invalid conservation symbol
+    @test_throws AssertionError DualRailEncoding(n_qubits = 2, conservation = :bogus)
+    # N not divisible by n_qubits
+    @test_throws AssertionError DualRailEncoding(n_qubits = 2, N = 3)
+    # per-qubit excitation exceeds levels_per_rail - 1
+    @test_throws AssertionError DualRailEncoding(n_qubits = 1, levels_per_rail = 2, N = 2)
+end
+
+@testitem "DualRailEncoding: subspace_transform round-trip T'T = I" begin
+    using LinearAlgebra: I
+    using SparseArrays
+
+    for conservation in (:exact_N, :upto_N)
+        enc = DualRailEncoding(
+            n_qubits = 3,
+            levels_per_rail = 2,
+            conservation = conservation,
+            N = 3,
+        )
+        T, idxs = subspace_transform(enc)
+        @test T isa SparseMatrixCSC{ComplexF64}
+        @test size(T) == (prod(enc.subspace_levels), length(idxs))
+        @test Matrix(T' * T) ≈ I(length(idxs))
+    end
+end
+
+@testitem "DualRailEncoding: reduce_to_subspace matches naive T'OT" begin
+    using LinearAlgebra
+    using SparseArrays
+
+    enc =
+        DualRailEncoding(n_qubits = 2, levels_per_rail = 2, conservation = :exact_N, N = 2)
+    T, idxs = subspace_transform(enc)
+    full_dim = prod(enc.subspace_levels)
+
+    O = rand(ComplexF64, full_dim, full_dim)
+    @test Matrix(reduce_to_subspace(O, enc)) ≈ Matrix(T' * O * T)
+
+    ψ = rand(ComplexF64, full_dim)
+    @test Vector(reduce_to_subspace(ψ, enc)) ≈ Vector(T' * ψ)
+
+    # Reduced operator picks out exactly the good-index block
+    @test Matrix(reduce_to_subspace(O, enc)) ≈ O[idxs, idxs]
+end
+
+@testitem "DualRailEncoding: target_states(:CX) for n=2" begin
+    using LinearAlgebra: norm
+
+    enc =
+        DualRailEncoding(n_qubits = 2, levels_per_rail = 2, conservation = :exact_N, N = 2)
+    ψ = logical_basis_states(enc)
+    @test length(ψ) == 4
+    @test all(norm(s) ≈ 1 for s in ψ)
+
+    tg = target_states(:CX, enc)
+    @test length(tg) == 4
+    # CX: |00>->|00>, |01>->|01>, |10>->|11>, |11>->|10>
+    @test tg[1] == ψ[1]
+    @test tg[2] == ψ[2]
+    @test tg[3] == ψ[4]
+    @test tg[4] == ψ[3]
+end
+
+@testitem "DualRailEncoding: target_states(:CCX) for n=3" begin
+    enc =
+        DualRailEncoding(n_qubits = 3, levels_per_rail = 2, conservation = :exact_N, N = 3)
+    ψ = logical_basis_states(enc)
+    @test length(ψ) == 8
+
+    tg = target_states(:CCX, enc)
+    @test length(tg) == 8
+    # CCX swaps |110> (idx 7) and |111> (idx 8), identity elsewhere
+    for j = 1:6
+        @test tg[j] == ψ[j]
+    end
+    @test tg[7] == ψ[8]
+    @test tg[8] == ψ[7]
+end
+
+@testitem "DualRailEncoding: EmbeddedOperator(:CX) is unitary on subspace" begin
+    using LinearAlgebra: I
+
+    enc =
+        DualRailEncoding(n_qubits = 2, levels_per_rail = 2, conservation = :exact_N, N = 2)
+    op = EmbeddedOperator(:CX, enc)
+    @test op.subsystem_levels == enc.subspace_levels
+    @test length(op.subspace) == 4
+
+    U = unembed(op)
+    @test U ≈ GATES[:CX]
+    @test U'U ≈ I(4)
+
+    # Embedding a 2-qubit gate on a specific pair of a 3-qubit register
+    enc3 =
+        DualRailEncoding(n_qubits = 3, levels_per_rail = 2, conservation = :exact_N, N = 3)
+    op_pair = EmbeddedOperator(GATES[:CX], enc3; qubit_indices = [1, 2])
+    Up = unembed(op_pair)
+    @test Up ≈ kron(GATES[:CX], GATES[:I])
+    @test Up'Up ≈ I(8)
+
+    op_pair23 = EmbeddedOperator(GATES[:CX], enc3; qubit_indices = [2, 3])
+    @test unembed(op_pair23) ≈ kron(GATES[:I], GATES[:CX])
+end
+
+@testitem "DualRailEncoding: sparsity nnz(T) matches combinatorial count" begin
+    using SparseArrays
+
+    # n_qubits=3, levels_per_rail=2, exact_N, N=3:
+    # weight-3 occupation tuples over 6 binary rails = C(6,3) = 20
+    enc =
+        DualRailEncoding(n_qubits = 3, levels_per_rail = 2, conservation = :exact_N, N = 3)
+    T, idxs = subspace_transform(enc)
+    @test nnz(T) == 20
+    @test length(idxs) == 20
+end
+
+@testitem "DualRailEncoding: upto_N strictly contains exact_N" begin
+    enc_exact =
+        DualRailEncoding(n_qubits = 2, levels_per_rail = 2, conservation = :exact_N, N = 2)
+    enc_upto =
+        DualRailEncoding(n_qubits = 2, levels_per_rail = 2, conservation = :upto_N, N = 2)
+
+    _, idx_exact = subspace_transform(enc_exact)
+    _, idx_upto = subspace_transform(enc_upto)
+
+    @test issubset(Set(idx_exact), Set(idx_upto))
+    @test length(idx_upto) > length(idx_exact)
+end

--- a/test/encodings/dual_rail.jl
+++ b/test/encodings/dual_rail.jl
@@ -102,6 +102,39 @@ end
     @test all(norm(s) ≈ 1 for s in tg)
 end
 
+@testitem "DualRailEncoding: logical basis state indices" begin
+    using LinearAlgebra: I, norm
+
+    # one logical qubit, one excitation per pair: |0⟩_L → |1,0⟩, |1⟩_L → |0,1⟩
+    enc1 = DualRailEncoding(n_qubits = 1)
+    ψ1 = logical_basis_states(enc1)
+    @test logical_state_indices(enc1) == [3, 2]
+    @test ψ1[1][3] == 1.0 && norm(ψ1[1]) == 1.0
+    @test ψ1[2][2] == 1.0 && norm(ψ1[2]) == 1.0
+
+    # two logical qubits: |00⟩, |01⟩, |10⟩, |11⟩ in kron order (rail 1 most significant)
+    enc2 = DualRailEncoding(n_qubits = 2)
+    ψ2 = logical_basis_states(enc2)
+    @test logical_state_indices(enc2) == [11, 10, 7, 6]
+    Ψ = reduce(hcat, ψ2)
+    @test Ψ' * Ψ ≈ I
+
+    # m = 2 excitations per pair on 3-level rails: |0⟩_L → |2,0⟩, |1⟩_L → |0,2⟩
+    enc_m = DualRailEncoding(n_qubits = 1, levels_per_rail = 3, N = 2)
+    ψ_m = logical_basis_states(enc_m)
+    @test logical_state_indices(enc_m) == [7, 3]
+    @test ψ_m[1][7] == 1.0 && norm(ψ_m[1]) == 1.0
+    @test ψ_m[2][3] == 1.0 && norm(ψ_m[2]) == 1.0
+    _, idxs_m = subspace_transform(enc_m)
+    @test idxs_m == [3, 5, 7]
+
+    # logical kets are fixed points of the subspace projector
+    T, _ = subspace_transform(enc2)
+    for ψ in ψ2
+        @test T * T' * ψ ≈ ψ
+    end
+end
+
 @testitem "DualRailEncoding: target_states(:CCX) for n=3" begin
     enc =
         DualRailEncoding(n_qubits = 3, levels_per_rail = 2, conservation = :exact_N, N = 3)

--- a/test/encodings/dual_rail.jl
+++ b/test/encodings/dual_rail.jl
@@ -15,11 +15,11 @@
     @test enc_default.N == 2
 
     # Invalid conservation symbol
-    @test_throws AssertionError DualRailEncoding(n_qubits = 2, conservation = :bogus)
+    @test_throws ArgumentError DualRailEncoding(n_qubits = 2, conservation = :bogus)
     # N not divisible by n_qubits
-    @test_throws AssertionError DualRailEncoding(n_qubits = 2, N = 3)
+    @test_throws ArgumentError DualRailEncoding(n_qubits = 2, N = 3)
     # per-qubit excitation exceeds levels_per_rail - 1
-    @test_throws AssertionError DualRailEncoding(n_qubits = 1, levels_per_rail = 2, N = 2)
+    @test_throws ArgumentError DualRailEncoding(n_qubits = 1, levels_per_rail = 2, N = 2)
 end
 
 @testitem "DualRailEncoding: subspace_transform round-trip T'T = I" begin
@@ -59,6 +59,18 @@ end
     @test Matrix(reduce_to_subspace(O, enc)) ≈ O[idxs, idxs]
 end
 
+@testitem "DualRailEncoding: reduce_to_subspace preserves sparsity" begin
+    using SparseArrays
+
+    enc =
+        DualRailEncoding(n_qubits = 2, levels_per_rail = 2, conservation = :exact_N, N = 2)
+    full_dim = prod(enc.subspace_levels)
+    O = sprand(ComplexF64, full_dim, full_dim, 0.2)
+
+    O_sub = reduce_to_subspace(O, enc)
+    @test O_sub isa SparseMatrixCSC
+end
+
 @testitem "DualRailEncoding: target_states(:CX) for n=2" begin
     using LinearAlgebra: norm
 
@@ -75,6 +87,19 @@ end
     @test tg[2] == ψ[2]
     @test tg[3] == ψ[4]
     @test tg[4] == ψ[3]
+end
+
+@testitem "DualRailEncoding: target_states(:H) superposition re-encoding" begin
+    using LinearAlgebra: norm
+
+    enc =
+        DualRailEncoding(n_qubits = 1, levels_per_rail = 2, conservation = :exact_N, N = 1)
+    ψ = logical_basis_states(enc)
+    tg = target_states(:H, enc)
+
+    @test tg[1] ≈ (ψ[1] + ψ[2]) / √2
+    @test tg[2] ≈ (ψ[1] - ψ[2]) / √2
+    @test all(norm(s) ≈ 1 for s in tg)
 end
 
 @testitem "DualRailEncoding: target_states(:CCX) for n=3" begin


### PR DESCRIPTION
Lift subspace bookkeeping, logical state mapping, and encoding-aware EmbeddedOperator construction into Piccolo so dual-rail setups no longer require hand-rolled index logic.

Resolves #197 

I used Cursor to help plan the implementation