### PR TITLE
Add pulse evolution animations (supersedes #195)

### DIFF
--- a/docs/literate/guides/visualization.jl
+++ b/docs/literate/guides/visualization.jl
@@ -235,45 +235,83 @@ fig = plot_pulse_phases(pulse_iq; title = "Polar view (|·|, ∠·)")
 # ## Pulse Animations
 #
 # `animate_pulse` shows a pulse drawing itself over time. Rendering delegates to
-# `plot_pulse!`, so each pulse type animates with its native primitive (stairs for
-# `ZeroOrderPulse`, knot-to-knot for `LinearSplinePulse`, smooth curves for
-# cubic/analytic), with a faint ghost of the full pulse behind the playhead.
+# `plot_pulse!`, so each pulse type animates with its native primitive — a faint
+# ghost of the full pulse sits behind a curve that reveals up to a moving
+# playhead. Use `mode = :record` with `CairoMakie` to write a `.gif`/`.mp4`
+# (as below); use `mode = :inline` with `GLMakie` for a looping interactive
+# preview.
 #
-# Use `mode = :record` with `CairoMakie` to export an `.mp4`/`.gif`; use
-# `mode = :inline` with `GLMakie` for a looping interactive preview.
+# A `ZeroOrderPulse` animates as **stairs** (step-and-hold):
+
+zoh_times = collect(range(0, T, length = 12))
+zoh_controls = vcat(
+    permutedims(0.6 .* sin.(2π .* zoh_times ./ T)),
+    permutedims(0.4 .* cos.(2π .* zoh_times ./ T)),
+)
+zoh_pulse = ZeroOrderPulse(zoh_controls, zoh_times)
+
+animate_pulse(
+    zoh_pulse;
+    mode = :record,
+    filename = "pulse_zoh.gif",
+    fps = 24,
+    n_samples = 80,
+    labels = ["Ω_x", "Ω_y"],
+    title = "ZeroOrderPulse",
+)
+nothing # hide
+
+# ![ZeroOrderPulse revealing as stairs](pulse_zoh.gif)
+#
+# A `CubicSplinePulse` animates as a **smooth curve** through its knots — same
+# call, different pulse type, correct primitive chosen automatically:
+
+cubic_times = collect(range(0, T, length = 9))
+cubic_controls = vcat(
+    permutedims(0.5 .* sin.(2π .* cubic_times ./ T)),
+    permutedims(0.3 .* cos.(π .* cubic_times ./ T)),
+)
+cubic_pulse = CubicSplinePulse(cubic_controls, cubic_times)
+
+animate_pulse(
+    cubic_pulse;
+    mode = :record,
+    filename = "pulse_cubic.gif",
+    fps = 24,
+    n_samples = 80,
+    labels = ["Ω_x", "Ω_y"],
+    title = "CubicSplinePulse",
+)
+nothing # hide
+
+# ![CubicSplinePulse revealing as a smooth curve](pulse_cubic.gif)
+#
+# You can add state or population traces in a second panel by passing a matrix
+# whose rows are populations and whose columns are time samples — useful for
+# showing the control pulse and the quantum response in one animation:
 
 animation_pulse = GaussianPulse([0.8, 0.45], T / 6, T)
-
-fig = animate_pulse(
-    animation_pulse;
-    mode = :inline, # use mode = :record and filename = "pulse_evolution.mp4" to export
-    fps = 24,
-    n_samples = 120,
-    labels = ["Ω_x", "Ω_y"],
-    title = "Gaussian control pulse",
-)
-
-# You can add state or population traces underneath the controls by passing a
-# matrix whose rows are populations and whose columns are time samples. This is
-# useful for showing the control pulse and the quantum response in one animation.
-
-population_times = collect(range(0, T, length = 120))
+population_times = collect(range(0, T, length = 80))
 population_trace = vcat(
-    reshape(cos.(π .* population_times ./ (2T)) .^ 2, 1, :),
-    reshape(sin.(π .* population_times ./ (2T)) .^ 2, 1, :),
+    permutedims(cos.(π .* population_times ./ (2T)) .^ 2),
+    permutedims(sin.(π .* population_times ./ (2T)) .^ 2),
 )
 
-fig = animate_pulse(
+animate_pulse(
     animation_pulse;
-    mode = :inline, # use mode = :record and filename = "pulse_with_populations.mp4" to export
+    mode = :record,
+    filename = "pulse_populations.gif",
     fps = 24,
-    n_samples = 120,
+    n_samples = 80,
     labels = ["Ω_x", "Ω_y"],
     populations = population_trace,
     population_times,
     population_labels = ["|0⟩", "|1⟩"],
     title = "Pulse with population evolution",
 )
+nothing # hide
+
+# ![Pulse with population evolution](pulse_populations.gif)
 
 # ## Custom Plotting
 #

--- a/docs/literate/guides/visualization.jl
+++ b/docs/literate/guides/visualization.jl
@@ -232,6 +232,49 @@ fig = plot_pulse_IQ(pulse_iq; title = "IQ view (Ω, α)")
 
 fig = plot_pulse_phases(pulse_iq; title = "Polar view (|·|, ∠·)")
 
+# ## Pulse Animations
+#
+# `animate_pulse` shows a pulse drawing itself over time. Rendering delegates to
+# `plot_pulse!`, so each pulse type animates with its native primitive (stairs for
+# `ZeroOrderPulse`, knot-to-knot for `LinearSplinePulse`, smooth curves for
+# cubic/analytic), with a faint ghost of the full pulse behind the playhead.
+#
+# Use `mode = :record` with `CairoMakie` to export an `.mp4`/`.gif`; use
+# `mode = :inline` with `GLMakie` for a looping interactive preview.
+
+animation_pulse = GaussianPulse([0.8, 0.45], T / 6, T)
+
+fig = animate_pulse(
+    animation_pulse;
+    mode = :inline, # use mode = :record and filename = "pulse_evolution.mp4" to export
+    fps = 24,
+    n_samples = 120,
+    labels = ["Ω_x", "Ω_y"],
+    title = "Gaussian control pulse",
+)
+
+# You can add state or population traces underneath the controls by passing a
+# matrix whose rows are populations and whose columns are time samples. This is
+# useful for showing the control pulse and the quantum response in one animation.
+
+population_times = collect(range(0, T, length = 120))
+population_trace = vcat(
+    reshape(cos.(π .* population_times ./ (2T)) .^ 2, 1, :),
+    reshape(sin.(π .* population_times ./ (2T)) .^ 2, 1, :),
+)
+
+fig = animate_pulse(
+    animation_pulse;
+    mode = :inline, # use mode = :record and filename = "pulse_with_populations.mp4" to export
+    fps = 24,
+    n_samples = 120,
+    labels = ["Ω_x", "Ω_y"],
+    populations = population_trace,
+    population_times,
+    population_labels = ["|0⟩", "|1⟩"],
+    title = "Pulse with population evolution",
+)
+
 # ## Custom Plotting
 #
 # For full control, extract trajectory data and use Makie directly.

--- a/ext/PiccoloMakieExt.jl
+++ b/ext/PiccoloMakieExt.jl
@@ -149,15 +149,24 @@ function Piccolo.animate_pulse(
         n_pop = size(population_values, 1)
         pop_times =
             isnothing(population_times) ?
-            collect(range(pulse_times[1], pulse_times[end], length = size(population_values, 2))) :
-            collect(population_times)
-        length(pop_times) == size(population_values, 2) ||
-            throw(ArgumentError("population_times must match the number of population samples."))
+            collect(
+                range(
+                    pulse_times[1],
+                    pulse_times[end],
+                    length = size(population_values, 2),
+                ),
+            ) : collect(population_times)
+        length(pop_times) == size(population_values, 2) || throw(
+            ArgumentError("population_times must match the number of population samples."),
+        )
         pop_labels = if isnothing(population_labels)
             ["Population $i" for i = 1:n_pop]
         else
-            length(population_labels) == n_pop ||
-                throw(ArgumentError("population_labels must contain one entry per population row."))
+            length(population_labels) == n_pop || throw(
+                ArgumentError(
+                    "population_labels must contain one entry per population row.",
+                ),
+            )
             collect(population_labels)
         end
     end
@@ -224,8 +233,17 @@ function Piccolo.animate_pulse(
                 linewidth = 1,
             )
             xs = @lift pop_times[1:max(1, searchsortedlast(pop_times, $t_max))]
-            ys = @lift vec(population_values[j, 1:max(1, searchsortedlast(pop_times, $t_max))])
-            lines!(population_axis, xs, ys; color = c, linewidth = 3, label = string(pop_labels[j]))
+            ys = @lift vec(
+                population_values[j, 1:max(1, searchsortedlast(pop_times, $t_max))],
+            )
+            lines!(
+                population_axis,
+                xs,
+                ys;
+                color = c,
+                linewidth = 3,
+                label = string(pop_labels[j]),
+            )
             mk = @lift begin
                 k = max(1, searchsortedlast(pop_times, $t_max))
                 [Point2f(pop_times[k], population_values[j, k])]

--- a/ext/PiccoloMakieExt.jl
+++ b/ext/PiccoloMakieExt.jl
@@ -89,6 +89,172 @@ end
 
 
 # ---------------------------------------------------------------------------- #
+# animate_pulse — implementation of stub in src/visualizations/animations.jl
+# ---------------------------------------------------------------------------- #
+#
+# Pure orchestration: rendering is delegated to `plot_pulse!`, which already
+# chooses the correct per-type primitive (stairs / knot-lines / dense curve),
+# theme-aware colors, and zero-reference handling. This file only drives the
+# `t_max` playhead observable and lays out the figure.
+
+# Symmetric padding around a value range so the axis limits don't clip the curve
+# or rescale mid-animation. Degenerate (flat) ranges get a unit window.
+function _padded_extrema(values; pad::Float64 = 0.08)
+    lo, hi = extrema(values)
+    if lo == hi
+        return lo - 0.5, hi + 0.5
+    end
+    margin = pad * (hi - lo)
+    return lo - margin, hi + margin
+end
+
+function Piccolo.animate_pulse(
+    pulse::Piccolo.AbstractPulse;
+    fps::Int = 24,
+    mode::Symbol = :inline,
+    filename::String = "pulse_animation.mp4",
+    n_samples::Int = 240,
+    labels = nothing,
+    populations = nothing,
+    population_times = nothing,
+    population_labels = nothing,
+    title::AbstractString = "Pulse evolution",
+)
+    n_samples >= 2 || throw(ArgumentError("n_samples must be at least 2, got $n_samples."))
+
+    nd = n_drives(pulse)
+    pulse_times = collect(range(0.0, duration(pulse), length = n_samples))
+    # Full static sample is only used to lock axis limits and find the ghost extent;
+    # the actual revealed curve is drawn by `plot_pulse!` via the `t_max` observable.
+    pulse_values = sample(pulse, pulse_times)
+
+    drive_labels = if isnothing(labels)
+        QuantumObjectPlots._default_drive_labels(pulse)
+    else
+        length(labels) == nd ||
+            throw(ArgumentError("labels must contain one entry per pulse drive ($nd)."))
+        collect(labels)
+    end
+
+    # --- optional population panel -------------------------------------------
+    has_populations = !isnothing(populations)
+    population_values = nothing
+    pop_times = nothing
+    pop_labels = nothing
+    n_pop = 0
+    if has_populations
+        population_values = Matrix(populations)
+        size(population_values, 2) >= 2 ||
+            throw(ArgumentError("populations must have at least two time samples."))
+        n_pop = size(population_values, 1)
+        pop_times =
+            isnothing(population_times) ?
+            collect(range(pulse_times[1], pulse_times[end], length = size(population_values, 2))) :
+            collect(population_times)
+        length(pop_times) == size(population_values, 2) ||
+            throw(ArgumentError("population_times must match the number of population samples."))
+        pop_labels = if isnothing(population_labels)
+            ["Population $i" for i = 1:n_pop]
+        else
+            length(population_labels) == n_pop ||
+                throw(ArgumentError("population_labels must contain one entry per population row."))
+            collect(population_labels)
+        end
+    end
+
+    # --- figure + pulse panel ------------------------------------------------
+    fig = Figure(size = has_populations ? (900, 620) : (900, 380))
+    pulse_axis = Axis(
+        fig[1, 1];
+        xlabel = has_populations ? "" : "Time",
+        xticklabelsvisible = !has_populations,
+        ylabel = "Amplitude",
+        title = title,
+        titlealign = :left,
+    )
+    xlims!(pulse_axis, pulse_times[1], pulse_times[end])
+    ylims!(pulse_axis, _padded_extrema(pulse_values)...)
+
+    t_max = Observable(pulse_times[1])
+
+    # (1) Type-aware ghost: full pulse at low alpha, via the same dispatch.
+    ghost_colors = [(QuantumObjectPlots._drive_color(i), 0.18) for i = 1:nd]
+    plot_pulse!(pulse_axis, pulse; show_knots = false, colors = ghost_colors)
+
+    # (2) Type-aware reveal: observable-driven, correct primitive per pulse type.
+    reveal_colors = [QuantumObjectPlots._drive_color(i) for i = 1:nd]
+    plot_pulse!(pulse_axis, pulse; show_knots = false, colors = reveal_colors, t_max)
+
+    # (3) Leading-edge marker per drive. `pulse(t)` gives the right value for any
+    # type automatically; the marker also carries the legend label.
+    for i = 1:nd
+        c = QuantumObjectPlots._drive_color(i)
+        pt = @lift [Point2f($t_max, pulse($t_max)[i])]
+        scatter!(
+            pulse_axis,
+            pt;
+            color = c,
+            markersize = 10,
+            strokewidth = 1,
+            strokecolor = :white,
+            label = string(drive_labels[i]),
+        )
+    end
+    axislegend(pulse_axis, position = :rt)
+
+    # --- population panel (generic line reveal; not pulse-specific) -----------
+    if has_populations
+        population_axis = Axis(
+            fig[2, 1];
+            xlabel = "Time",
+            ylabel = "Population",
+            title = "State populations",
+            titlealign = :left,
+        )
+        xlims!(population_axis, pop_times[1], pop_times[end])
+        ylims!(population_axis, _padded_extrema(population_values)...)
+
+        for j = 1:n_pop
+            c = QuantumObjectPlots._drive_color(nd + j)
+            lines!(
+                population_axis,
+                pop_times,
+                vec(population_values[j, :]);
+                color = (c, 0.18),
+                linewidth = 1,
+            )
+            xs = @lift pop_times[1:max(1, searchsortedlast(pop_times, $t_max))]
+            ys = @lift vec(population_values[j, 1:max(1, searchsortedlast(pop_times, $t_max))])
+            lines!(population_axis, xs, ys; color = c, linewidth = 3, label = string(pop_labels[j]))
+            mk = @lift begin
+                k = max(1, searchsortedlast(pop_times, $t_max))
+                [Point2f(pop_times[k], population_values[j, k])]
+            end
+            scatter!(
+                population_axis,
+                mk;
+                color = c,
+                markersize = 10,
+                strokewidth = 1,
+                strokecolor = :white,
+            )
+        end
+        axislegend(population_axis, position = :rt)
+    end
+
+    update_frame!(i) = (t_max[] = pulse_times[i])
+    return Piccolo.animate_figure(
+        fig,
+        1:n_samples,
+        update_frame!;
+        mode = mode,
+        fps = fps,
+        filename = filename,
+    )
+end
+
+
+# ---------------------------------------------------------------------------- #
 # LivePulsePlotCallback — implementation of stub in src/visualizations/live_callbacks.jl
 # ---------------------------------------------------------------------------- #
 
@@ -251,6 +417,90 @@ end
 
     @test_throws ArgumentError LivePulsePlotCallback(qtraj, qcp.prob.trajectory; every = 0)
     @test_throws ArgumentError LivePulsePlotCallback(qtraj, qcp.prob.trajectory; every = -1)
+end
+
+
+@testitem "animate_pulse: :record writes mp4 (ZeroOrderPulse, type-aware reveal)" begin
+    using CairoMakie
+
+    times = collect(range(0, 4.0, length = 12))
+    controls = vcat((0.6 .* sin.(times))', (0.4 .* cos.(times))')
+    pulse = ZeroOrderPulse(controls, times)
+
+    file = tempname() * ".mp4"
+    fig = animate_pulse(
+        pulse;
+        mode = :record,
+        filename = file,
+        n_samples = 20,
+        title = "ZOH evolution",
+    )
+
+    # Exercises the record path (CI coverage) and the ZeroOrderPulse stairs reveal.
+    @test fig isa Figure
+    @test isfile(file)
+    @test filesize(file) > 0
+end
+
+@testitem "animate_pulse: LinearSplinePulse reveal (:inline)" begin
+    using CairoMakie
+
+    times = collect(range(0, 3.0, length = 8))
+    controls = vcat((0.5 .* times)', (-0.3 .* times)')
+    pulse = LinearSplinePulse(controls, times)
+
+    fig = animate_pulse(pulse; mode = :inline, n_samples = 12)
+    @test fig isa Figure
+end
+
+@testitem "animate_pulse: no populations (Gaussian, :inline)" begin
+    using CairoMakie
+
+    T = 6.0
+    pulse = GaussianPulse([0.8, 0.45], T / 6, T)
+
+    # Exercises the populations-off branch.
+    fig = animate_pulse(pulse; mode = :inline, n_samples = 16, labels = ["Ω_x", "Ω_y"])
+    @test fig isa Figure
+end
+
+@testitem "animate_pulse: with populations (Gaussian, :inline)" begin
+    using CairoMakie
+
+    T = 6.0
+    pulse = GaussianPulse([0.8, 0.45], T / 6, T)
+    ts = collect(range(0, T, length = 30))
+    pops = vcat((cos.(π .* ts ./ (2T)) .^ 2)', (sin.(π .* ts ./ (2T)) .^ 2)')
+
+    fig = animate_pulse(
+        pulse;
+        mode = :inline,
+        n_samples = 16,
+        populations = pops,
+        population_times = ts,
+        population_labels = ["|0⟩", "|1⟩"],
+    )
+    @test fig isa Figure
+end
+
+@testitem "animate_pulse: error contract" begin
+    using CairoMakie
+
+    T = 4.0
+    pulse = GaussianPulse([0.5, 0.3], T / 6, T)  # 2 drives
+
+    # n_samples must be >= 2
+    @test_throws ArgumentError animate_pulse(pulse; n_samples = 1)
+    # labels must match drive count
+    @test_throws ArgumentError animate_pulse(pulse; labels = ["only-one"])
+    # populations need >= 2 time samples
+    @test_throws ArgumentError animate_pulse(pulse; populations = reshape([0.1, 0.9], 2, 1))
+    # population_labels must match population row count
+    @test_throws ArgumentError animate_pulse(
+        pulse;
+        populations = reshape([0.1, 0.9, 0.2, 0.8], 2, 2),
+        population_labels = ["only-one"],
+    )
 end
 
 

--- a/src/control/display/inspect.jl
+++ b/src/control/display/inspect.jl
@@ -407,8 +407,9 @@ end
 
 _goal_summary(qtraj::UnitaryTrajectory) = _goal_summary_unitary(qtraj.goal)
 _goal_summary(qtraj::KetTrajectory) = "|ψ_init⟩ → |ψ_goal⟩  (dim=$(length(qtraj.goal)))"
-_goal_summary(qtraj::MultiKetTrajectory) =
-    "$(length(qtraj.goals)) state transfers  (dim=$(length(first(qtraj.goals))))"
+_goal_summary(
+    qtraj::MultiKetTrajectory,
+) = "$(length(qtraj.goals)) state transfers  (dim=$(length(first(qtraj.goals))))"
 _goal_summary(qtraj::DensityTrajectory) = "ρ_init → ρ_goal"
 _goal_summary(qtraj::SamplingTrajectory) = "sampled ensemble (n=$(length(qtraj.systems)))"
 _goal_summary(qtraj::AbstractQuantumTrajectory) = string(_typename(qtraj), " goal")

--- a/src/visualizations/animations.jl
+++ b/src/visualizations/animations.jl
@@ -2,6 +2,7 @@ module AnimatedPlots
 
 export animate_figure
 export animate_name
+export animate_pulse
 
 """
     animate_figure(
@@ -117,5 +118,58 @@ See also: `animate_figure`, `animate_bloch`, and
 [`NamedTrajectories.plot`](https://docs.harmoniqs.co/NamedTrajectories/dev/generated/plotting/).
 """
 function animate_name end
+
+"""
+    animate_pulse(
+        pulse::AbstractPulse;
+        fps::Int = 24,
+        mode::Symbol = :inline,
+        filename::String = "pulse_animation.mp4",
+        n_samples::Int = 240,
+        labels = nothing,
+        populations = nothing,
+        population_times = nothing,
+        population_labels = nothing,
+        title::AbstractString = "Pulse evolution",
+    ) -> Figure
+
+Animate a pulse drawing itself over time, optionally with population/state traces
+in a second panel.
+
+Rendering delegates to `plot_pulse!`, so each pulse type animates with its native
+primitive: `ZeroOrderPulse` reveals as stairs, `LinearSplinePulse` knot-to-knot,
+and cubic/analytic pulses as smooth curves. A faint "ghost" of the full pulse sits
+behind the revealed curve and a marker tracks the leading edge.
+
+Defined as a stub here; the implementation is provided by the `PiccoloMakieExt`
+extension and is loaded when a Makie backend (`CairoMakie`, `GLMakie`, `WGLMakie`)
+is available.
+
+# Arguments
+- `pulse::AbstractPulse`: The pulse to animate.
+
+# Keyword Arguments
+- `fps::Int`: Frames per second. Default `24`.
+- `mode::Symbol`: `:inline` (interactive, requires `GLMakie`) or `:record` (save to
+  file, works with `CairoMakie`). Default `:inline`.
+- `filename::String`: Output path when `mode = :record`. Default `"pulse_animation.mp4"`.
+- `n_samples::Int`: Number of animation frames / pulse sample points (must be ≥ 2).
+- `labels`: Optional drive labels, one per drive. Defaults to the pulse's drive name.
+- `populations`: Optional matrix (rows = populations, columns = time samples) drawn
+  in a second panel.
+- `population_times`: Optional time grid for the population samples.
+- `population_labels`: Optional labels for the population rows.
+- `title::AbstractString`: Title for the pulse panel.
+
+# Returns
+- A Makie `Figure` (potentially mutated by the animation loop).
+
+# Backend Compatibility
+- **GLMakie**: both `:inline` and `:record`.
+- **CairoMakie**: `:record` only (`:inline` cannot re-render).
+
+See also: `animate_figure`, `animate_name`, `plot_pulse`.
+"""
+function animate_pulse end
 
 end

--- a/src/visualizations/quantum_objects/pulse_plots.jl
+++ b/src/visualizations/quantum_objects/pulse_plots.jl
@@ -268,6 +268,7 @@ end
         show_tangents=false,
         tangent_scale=0.1,
         colors=nothing,
+        t_max=nothing,
         kwargs...
     )
 
@@ -282,6 +283,13 @@ Dispatches rendering based on pulse type for visually accurate results.
 - `show_tangents`: Show derivative tangent whiskers (CubicSplinePulse only).
 - `tangent_scale`: Length scale for tangent whiskers (fraction of duration).
 - `colors`: Vector of colors, one per drive index. Defaults to the active theme palette.
+- `t_max`: Optional `Observable{<:Real}` playhead time. When `nothing` (default),
+  the full static pulse is drawn. When set, each channel is drawn as an
+  observable-driven curve revealed up to `t_max[]`, using the same per-type
+  primitive (stairs for `ZeroOrderPulse`, knot-to-knot lines for
+  `LinearSplinePulse`, dense curve for cubic/analytic). This is what
+  `animate_pulse` drives; static knot/tangent overlays are suppressed while
+  revealing. Backward-compatible: omit it for unchanged behavior.
 - `kwargs...`: Forwarded to the underlying Makie plot calls.
 """
 function plot_pulse!(
@@ -293,6 +301,7 @@ function plot_pulse!(
     show_tangents::Bool = false,
     tangent_scale::Float64 = 0.1,
     colors::Union{Nothing,AbstractVector} = nothing,
+    t_max::Union{Nothing,Observable} = nothing,
     kwargs...,
 )
     if isnothing(colors)
@@ -308,6 +317,7 @@ function plot_pulse!(
         show_tangents,
         tangent_scale,
         colors,
+        t_max,
         kwargs...,
     )
 end
@@ -315,6 +325,22 @@ end
 # ============================================================================ #
 # Type-specific rendering dispatches
 # ============================================================================ #
+
+# Animation reveal helper. Returns the (xs, ys) for the portion of one drive of
+# `pulse` visible at playhead time `t_max`. A single helper works for every pulse
+# type because `pulse(t)` already dispatches to the correct per-type evaluation
+# (held value for ZOH, linear/cubic interpolation, analytic form for Gaussian/Erf).
+# `render_times` is the type-appropriate base grid (knot times for step/linear,
+# dense grid for cubic/analytic); the synthetic endpoint at `t_max` makes the
+# revealed curve terminate exactly at the playhead instead of at the last grid
+# point behind it. `render_times` must be sorted ascending.
+function _reveal_xy(pulse, render_times, drive_index::Int, t_max::Real)
+    tmax = float(t_max)
+    k = searchsortedlast(render_times, tmax)
+    xs = k == 0 ? [tmax] : vcat(render_times[1:k], tmax)
+    ys = [pulse(t)[drive_index] for t in xs]
+    return xs, ys
+end
 
 # ---------------------------------------------------------------------------- #
 # ZeroOrderPulse — stairs (step function)
@@ -329,23 +355,32 @@ function _plot_pulse_type!(
     show_tangents,  # unused
     tangent_scale,  # unused
     colors,
+    t_max = nothing,
     kwargs...,
 )
     knot_times = collect(get_knot_times(pulse))
     knot_vals = sample(pulse, knot_times)
 
     for (ci, i) in enumerate(drive_indices)
-        stairs!(
-            ax,
-            knot_times,
-            knot_vals[i, :];
-            color = colors[ci],
-            linewidth = 2,
-            step = :post,
-            kwargs...,
-        )
+        if isnothing(t_max)
+            stairs!(
+                ax,
+                knot_times,
+                knot_vals[i, :];
+                color = colors[ci],
+                linewidth = 2,
+                step = :post,
+                kwargs...,
+            )
+        else
+            xs = @lift(_reveal_xy(pulse, knot_times, i, $t_max)[1])
+            ys = @lift(_reveal_xy(pulse, knot_times, i, $t_max)[2])
+            stairs!(ax, xs, ys; color = colors[ci], linewidth = 2, step = :post, kwargs...)
+        end
 
-        if show_knots
+        # Knot markers are static structure; suppress during a reveal so future
+        # knots don't appear ahead of the playhead.
+        if show_knots && isnothing(t_max)
             scatter!(
                 ax,
                 knot_times,
@@ -372,22 +407,29 @@ function _plot_pulse_type!(
     show_tangents,  # unused
     tangent_scale,  # unused
     colors,
+    t_max = nothing,
     kwargs...,
 )
     knot_times = collect(get_knot_times(pulse))
     knot_vals = get_knot_values(pulse)
 
     for (ci, i) in enumerate(drive_indices)
-        lines!(
-            ax,
-            knot_times,
-            collect(knot_vals[i, :]);
-            color = colors[ci],
-            linewidth = 2,
-            kwargs...,
-        )
+        if isnothing(t_max)
+            lines!(
+                ax,
+                knot_times,
+                collect(knot_vals[i, :]);
+                color = colors[ci],
+                linewidth = 2,
+                kwargs...,
+            )
+        else
+            xs = @lift(_reveal_xy(pulse, knot_times, i, $t_max)[1])
+            ys = @lift(_reveal_xy(pulse, knot_times, i, $t_max)[2])
+            lines!(ax, xs, ys; color = colors[ci], linewidth = 2, kwargs...)
+        end
 
-        if show_knots
+        if show_knots && isnothing(t_max)
             scatter!(
                 ax,
                 knot_times,
@@ -414,13 +456,26 @@ function _plot_pulse_type!(
     show_tangents,
     tangent_scale,
     colors,
+    t_max = nothing,
     kwargs...,
 )
     # Dense sampling for smooth curve
     controls, times = sample(pulse, n_samples)
 
     for (ci, i) in enumerate(drive_indices)
-        lines!(ax, times, controls[i, :]; color = colors[ci], linewidth = 2, kwargs...)
+        if isnothing(t_max)
+            lines!(ax, times, controls[i, :]; color = colors[ci], linewidth = 2, kwargs...)
+        else
+            xs = @lift(_reveal_xy(pulse, times, i, $t_max)[1])
+            ys = @lift(_reveal_xy(pulse, times, i, $t_max)[2])
+            lines!(ax, xs, ys; color = colors[ci], linewidth = 2, kwargs...)
+        end
+    end
+
+    # Static knot markers and tangent whiskers are suppressed during a reveal
+    # so future structure doesn't appear ahead of the playhead.
+    if !isnothing(t_max)
+        return
     end
 
     # Knot markers
@@ -486,12 +541,19 @@ function _plot_pulse_type!(
     show_tangents,  # unused
     tangent_scale,  # unused
     colors,
+    t_max = nothing,
     kwargs...,
 )
     controls, times = sample(pulse, n_samples)
 
     for (ci, i) in enumerate(drive_indices)
-        lines!(ax, times, controls[i, :]; color = colors[ci], linewidth = 2, kwargs...)
+        if isnothing(t_max)
+            lines!(ax, times, controls[i, :]; color = colors[ci], linewidth = 2, kwargs...)
+        else
+            xs = @lift(_reveal_xy(pulse, times, i, $t_max)[1])
+            ys = @lift(_reveal_xy(pulse, times, i, $t_max)[2])
+            lines!(ax, xs, ys; color = colors[ci], linewidth = 2, kwargs...)
+        end
     end
 end
 


### PR DESCRIPTION
Closes #59. Supersedes #195 (credit to @grantf04 — see below).

## Summary
Adds `animate_pulse` as a Makie-backed animation for any `AbstractPulse`, with an optional population/state panel. Rather than reimplementing pulse rendering, it **delegates to `plot_pulse!`**, which is now animation-aware.

- `plot_pulse!` gains a `t_max::Union{Nothing,Observable}` kwarg. When `nothing` (default) behavior is unchanged; when set, each `_plot_pulse_type!` method draws an observable-driven curve revealed up to the playhead using its **native primitive** — `ZeroOrderPulse` animates as stairs, `LinearSplinePulse` knot-to-knot, cubic/analytic as smooth curves. A single `_reveal_xy` helper works for every type because `pulse(t)` already does the per-type math.
- `animate_pulse` collapses to orchestration: a low-alpha **ghost** layer, the observable **reveal** layer, and a leading-edge **marker** — all via `plot_pulse!`, so theme-aware colors (`_drive_color`), labels (`_default_drive_labels`), and per-type dispatch come along for free.

## Relationship to #195
This carries over @grantf04's original contribution — the `animate_pulse` public API, the populations feature, the stub in `animations.jl`, and the docs example — credited via `Co-authored-by`. The rendering was rewritten to address the review on #195:
- type-aware reveal (was dense `lines!` for every type),
- no duplicated color/label/zero-line logic,
- removed the defensive `sample`-contract asserts and the silent `try/catch` around `drive_name`.

## Validation
Verified locally (Julia 1.12.5, CairoMakie) — `PiccoloMakieExt` precompiles clean, and a script exercising every pulse type passed:
- `:record` mode writes non-empty mp4 for ZOH / linear / cubic / Gaussian and Gaussian+populations
- error contract: `n_samples=1`, label-count mismatch, and <2-sample populations all throw `ArgumentError`
- `:inline` returns a `Figure`

Static frames confirm the type-aware reveal (ZOH renders as stairs, cubic as a smooth curve) with the ghost ahead of the playhead.

New `@testitem`s cover the record path, the no-populations branch, non-Gaussian pulses (ZOH + linear reveal regression), and the error contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)