### PR TITLE
Piccolo matrix-free objective-constructor slice

### DIFF
--- a/src/control/objectives.jl
+++ b/src/control/objectives.jl
@@ -177,7 +177,7 @@ function _coherent_ket_lowrank_factor(
     A = zeros(Float64, 2, m)
     inv_K = 1.0 / K
     offset = 0
-    for i in 1:K
+    for i = 1:K
         d_iso = state_dims[i]
         @assert iseven(d_iso) "iso-state $i has odd dim $(d_iso); expected even"
         d_c = d_iso ÷ 2
@@ -191,11 +191,11 @@ function _coherent_ket_lowrank_factor(
         #   ⟨gᵢ, ψᵢ⟩ = (Re(g) − i·Im(g))ᵀ (Re(ψ) + i·Im(ψ))
         #             = Re(g)ᵀRe(ψ) + Im(g)ᵀIm(ψ)  +  i (Re(g)ᵀIm(ψ) − Im(g)ᵀRe(ψ))
         # Row 1 (Re(S)) — scaled by 1/K
-        A[1, offset .+ (1:d_c)]         .= inv_K .* re_g
+        A[1, offset .+ (1:d_c)] .= inv_K .* re_g
         A[1, offset .+ ((d_c+1):d_iso)] .= inv_K .* im_g
         # Row 2 (Im(S)) — scaled by 1/K
-        A[2, offset .+ (1:d_c)]         .= -inv_K .* im_g
-        A[2, offset .+ ((d_c+1):d_iso)] .=  inv_K .* re_g
+        A[2, offset .+ (1:d_c)] .= -inv_K .* im_g
+        A[2, offset .+ ((d_c+1):d_iso)] .= inv_K .* re_g
         offset += d_iso
     end
     return A
@@ -351,8 +351,8 @@ function _unitary_lowrank_factor(U_goal::AbstractMatrix{<:Number})
     @assert size(U_goal, 2) == n "U_goal must be square; got $(size(U_goal))"
     A = zeros(Float64, 2, 2 * n^2)
     inv_n = 1.0 / n
-    for i in 0:(n - 1)
-        col = @view U_goal[:, i + 1]
+    for i = 0:(n-1)
+        col = @view U_goal[:, i+1]
         re_g = real(col)
         im_g = imag(col)
         # Per-column block of `Ũ⃗`: `i*2n + (1:n)` is Re, `i*2n + (n+1:2n)` is Im.
@@ -360,11 +360,11 @@ function _unitary_lowrank_factor(U_goal::AbstractMatrix{<:Number})
         #             = Re(g)ᵀRe(U) + Im(g)ᵀIm(U)  +  i (Re(g)ᵀIm(U) − Im(g)ᵀRe(U))
         # Sum over columns gives S = Σᵢ ⟨gᵢ, Uᵢ⟩ = tr(U_goal† U).
         # Row 1 (Re(S)/n)
-        A[1, i * 2n .+ (1:n)]         .= inv_n .* re_g
-        A[1, i * 2n .+ ((n + 1):2n)]  .= inv_n .* im_g
+        A[1, i*2n .+ (1:n)] .= inv_n .* re_g
+        A[1, i*2n .+ ((n+1):2n)] .= inv_n .* im_g
         # Row 2 (Im(S)/n)
-        A[2, i * 2n .+ (1:n)]         .= -inv_n .* im_g
-        A[2, i * 2n .+ ((n + 1):2n)]  .=  inv_n .* re_g
+        A[2, i*2n .+ (1:n)] .= -inv_n .* im_g
+        A[2, i*2n .+ ((n+1):2n)] .= inv_n .* re_g
     end
     return A
 end
@@ -509,11 +509,8 @@ using TestItems
     u = randn(1, N)
     Δt = fill(0.1, N)
 
-    traj = NamedTrajectory(
-        (ψ̃1 = ψ̃1, ψ̃2 = ψ̃2, u = u, Δt = Δt);
-        timestep = :Δt,
-        controls = :u,
-    )
+    traj =
+        NamedTrajectory((ψ̃1 = ψ̃1, ψ̃2 = ψ̃2, u = u, Δt = Δt); timestep = :Δt, controls = :u)
 
     # Goal states for X gate: |0⟩→|1⟩ and |1⟩→|0⟩
     ψ0 = ComplexF64[1.0, 0.0]
@@ -776,9 +773,7 @@ end
             @test size(cap.A) == (2, K * ket_dim)
 
             # Index map for the terminal-knot concatenated iso-state.
-            knot_idx = vcat(
-                [slice(N, traj.components[nm], traj.dim) for nm in names_K]...,
-            )
+            knot_idx = vcat([slice(N, traj.components[nm], traj.dim) for nm in names_K]...)
             z = vec(traj)
             z_k = z[knot_idx]
 
@@ -793,7 +788,7 @@ end
 
             # Dense apply at the same knot, via Symmetric(get_full_hessian, :U)·v.
             H_full = Matrix(get_full_hessian(obj, traj))
-            Hv_dense = (Symmetric(H_full, :U) * v)[knot_idx]
+            Hv_dense = (Symmetric(H_full, :U)*v)[knot_idx]
 
             @test Hv_mf ≈ Hv_dense atol = 1e-12
         end
@@ -851,7 +846,7 @@ end
             Hv_mf = Q * G * (A' * (A * v_k))
 
             H_full = Matrix(get_full_hessian(obj, traj))
-            Hv_dense = (Symmetric(H_full, :U) * v)[knot_idx]
+            Hv_dense = (Symmetric(H_full, :U)*v)[knot_idx]
 
             @test Hv_mf ≈ Hv_dense atol = 1e-12
         end
@@ -871,11 +866,7 @@ end
     Utilde = randn(iso_dim, N)
     u = randn(1, N)
     Δt = fill(0.1, N)
-    traj = NamedTrajectory(
-        (Utilde = Utilde, u = u, Δt = Δt);
-        timestep = :Δt,
-        controls = :u,
-    )
+    traj = NamedTrajectory((Utilde = Utilde, u = u, Δt = Δt); timestep = :Δt, controls = :u)
 
     # 2x2 X gate embedded in a 4-dim ambient space (subspace = 1:2).
     op = EmbeddedOperator(ComplexF64[0 1; 1 0], 1:2, n_full)
@@ -904,11 +895,7 @@ end
     ψ̃1 = randn(ket_dim, N)
     u = randn(1, N)
     Δt = fill(0.1, N)
-    traj = NamedTrajectory(
-        (ψ̃1 = ψ̃1, u = u, Δt = Δt);
-        timestep = :Δt,
-        controls = :u,
-    )
+    traj = NamedTrajectory((ψ̃1 = ψ̃1, u = u, Δt = Δt); timestep = :Δt, controls = :u)
 
     ℓ = x -> sum(x .^ 2) + 0.3 * sum(sin.(x))  # any non-trivial C² loss
     Q = 7.0
@@ -916,14 +903,14 @@ end
     cap = ConstantLowRankHVP(fake_A, :neg2_sign)
 
     obj_none = KnotPointObjective(ℓ, :ψ̃1, traj; Qs = [Q], times = [N], knot_hvp = nothing)
-    obj_pop  = KnotPointObjective(ℓ, :ψ̃1, traj; Qs = [Q], times = [N], knot_hvp = cap)
+    obj_pop = KnotPointObjective(ℓ, :ψ̃1, traj; Qs = [Q], times = [N], knot_hvp = cap)
 
     # Value: literally equal.
     @test objective_value(obj_none, traj) === objective_value(obj_pop, traj)
 
     # Gradient: literally equal (elementwise, no tolerance).
     ∇_none = zeros(traj.dim * traj.N + traj.global_dim)
-    ∇_pop  = zeros(traj.dim * traj.N + traj.global_dim)
+    ∇_pop = zeros(traj.dim * traj.N + traj.global_dim)
     gradient!(∇_none, obj_none, traj)
     gradient!(∇_pop, obj_pop, traj)
     @test ∇_none == ∇_pop

--- a/src/control/objectives.jl
+++ b/src/control/objectives.jl
@@ -151,8 +151,54 @@ function CoherentKetInfidelityObjective(
         return abs(1 - coherent_ket_fidelity(ψ̃s, goals))
     end
 
+    # Declarable matrix-free per-knot HVP. The coherent loss is exactly
+    # `ℓ = |1 - F|` with `F = ‖A·z‖²`, so the per-knot Hessian factors as
+    # `Aᵀ · G · A` with `G = -2·sign(1 - F)·I_2` (the `:neg2_sign` rule).
+    A = _coherent_ket_lowrank_factor(goals, state_dims)
+    cap = ConstantLowRankHVP(A, :neg2_sign)
+
     # Pass vector of component names for multi-component terminal objective
-    return TerminalObjective(ℓ, ψ̃_names, traj; Q = Q)
+    return TerminalObjective(ℓ, ψ̃_names, traj; Q = Q, knot_hvp = cap)
+end
+
+# Build the constant rank-2 factor `A :: Matrix{Float64}` of size
+# `(2, sum(state_dims))` such that `[A·z]_1 = Re(S)`, `[A·z]_2 = Im(S)`,
+# where `S = (1/K) · Σᵢ ⟨gᵢ, ψᵢ⟩` is the coherent overlap and the
+# concatenated iso-state `z = [ψ̃₁; ψ̃₂; …; ψ̃_K]` follows the per-ket
+# `[real(ψᵢ); imag(ψᵢ)]` convention from `ket_to_iso`.
+# Then `‖A·z‖² = |S|² = F` exactly.
+function _coherent_ket_lowrank_factor(
+    goals::AbstractVector{<:AbstractVector{<:Complex}},
+    state_dims::AbstractVector{Int},
+)
+    K = length(goals)
+    @assert length(state_dims) == K
+    m = sum(state_dims)
+    A = zeros(Float64, 2, m)
+    inv_K = 1.0 / K
+    offset = 0
+    for i in 1:K
+        d_iso = state_dims[i]
+        @assert iseven(d_iso) "iso-state $i has odd dim $(d_iso); expected even"
+        d_c = d_iso ÷ 2
+        @assert length(goals[i]) == d_c (
+            "goal $i has $(length(goals[i])) entries; expected $(d_c) " *
+            "(half the iso-state dim)"
+        )
+        re_g = real(goals[i])
+        im_g = imag(goals[i])
+        # Block layout per ket: `ψ̃ᵢ = [Re(ψᵢ); Im(ψᵢ)]` (length d_iso).
+        #   ⟨gᵢ, ψᵢ⟩ = (Re(g) − i·Im(g))ᵀ (Re(ψ) + i·Im(ψ))
+        #             = Re(g)ᵀRe(ψ) + Im(g)ᵀIm(ψ)  +  i (Re(g)ᵀIm(ψ) − Im(g)ᵀRe(ψ))
+        # Row 1 (Re(S)) — scaled by 1/K
+        A[1, offset .+ (1:d_c)]         .= inv_K .* re_g
+        A[1, offset .+ ((d_c+1):d_iso)] .= inv_K .* im_g
+        # Row 2 (Im(S)) — scaled by 1/K
+        A[2, offset .+ (1:d_c)]         .= -inv_K .* im_g
+        A[2, offset .+ ((d_c+1):d_iso)] .=  inv_K .* re_g
+        offset += d_iso
+    end
+    return A
 end
 
 # ---------------------------------------------------------
@@ -275,7 +321,7 @@ function unitary_fidelity_loss(Ũ⃗::AbstractVector{<:Real}, op::EmbeddedOpera
 end
 
 function UnitaryInfidelityObjective(
-    U_goal::AbstractPiccoloOperator,
+    U_goal::AbstractPiccoloOperator,  # full-op (AbstractMatrix) gets knot_hvp; EmbeddedOperator stays on fallback
     Ũ⃗_name::Symbol,
     traj::NamedTrajectory;
     Q = 100.0,

--- a/src/control/objectives.jl
+++ b/src/control/objectives.jl
@@ -734,53 +734,69 @@ end
     Δt = fill(0.1, N)
     Q = 7.0  # non-default so the scaling threads through
 
-    goals = [ComplexF64[0.0, 1.0], ComplexF64[1.0, 0.0]]
+    # K=1 (single-ket) and K=2 (two-ket) — issue #257 AC requires ≥1 and ≥2 goals.
+    goal_bank = [ComplexF64[0.0, 1.0], ComplexF64[1.0, 0.0]]
 
-    # Build a trajectory with a scaled copy of the goals at the terminal knot.
-    # `scale < 1` puts F below the kink; `scale > 1` puts F above it.
-    function _make_traj(scale)
-        ψ̃1 = randn(ket_dim, N)
-        ψ̃2 = randn(ket_dim, N)
-        ψ̃1[:, N] .= scale .* ket_to_iso(goals[1])
-        ψ̃2[:, N] .= scale .* ket_to_iso(goals[2])
-        return NamedTrajectory(
-            (ψ̃1 = ψ̃1, ψ̃2 = ψ̃2, u = u, Δt = Δt);
-            timestep = :Δt,
-            controls = :u,
-        )
-    end
+    for K in (1, 2)
+        goals_K = goal_bank[1:K]
+        names_K = K == 1 ? [:ψ̃1] : [:ψ̃1, :ψ̃2]
 
-    for scale in (0.4, 1.2)  # F < 1 and F > 1
-        traj = _make_traj(scale)
-        obj = CoherentKetInfidelityObjective(goals, [:ψ̃1, :ψ̃2], traj; Q = Q)
+        # Build a K-ket trajectory with a scaled copy of the goals at the
+        # terminal knot. `scale < 1` puts F below the kink; `scale > 1`
+        # puts F above.
+        function _make_traj(scale)
+            if K == 1
+                ψ̃1 = randn(ket_dim, N)
+                ψ̃1[:, N] .= scale .* ket_to_iso(goals_K[1])
+                return NamedTrajectory(
+                    (ψ̃1 = ψ̃1, u = u, Δt = Δt);
+                    timestep = :Δt,
+                    controls = :u,
+                )
+            else
+                ψ̃1 = randn(ket_dim, N)
+                ψ̃2 = randn(ket_dim, N)
+                ψ̃1[:, N] .= scale .* ket_to_iso(goals_K[1])
+                ψ̃2[:, N] .= scale .* ket_to_iso(goals_K[2])
+                return NamedTrajectory(
+                    (ψ̃1 = ψ̃1, ψ̃2 = ψ̃2, u = u, Δt = Δt);
+                    timestep = :Δt,
+                    controls = :u,
+                )
+            end
+        end
 
-        cap = knot_hvp(obj, traj)
-        @test cap isa ConstantLowRankHVP
-        @test cap.core === :neg2_sign
-        @test size(cap.A) == (2, 2 * ket_dim)
+        for scale in (0.4, 1.2)  # F < 1 and F > 1
+            traj = _make_traj(scale)
+            obj = CoherentKetInfidelityObjective(goals_K, names_K, traj; Q = Q)
 
-        # Index map for the terminal-knot concatenated iso-state.
-        knot_idx = vcat(
-            slice(N, traj.components[:ψ̃1], traj.dim),
-            slice(N, traj.components[:ψ̃2], traj.dim),
-        )
-        z = vec(traj)
-        z_k = z[knot_idx]
+            cap = knot_hvp(obj, traj)
+            @test cap isa ConstantLowRankHVP
+            @test cap.core === :neg2_sign
+            @test size(cap.A) == (2, K * ket_dim)
 
-        # Matrix-free apply at the terminal knot:
-        #   H · v_k = Q · (-2·sign(1-F)) · Aᵀ · (A · v_k)
-        A = cap.A
-        F = sum(abs2, A * z_k)
-        G = -2.0 * sign(1.0 - F)
-        v = randn(length(z))
-        v_k = v[knot_idx]
-        Hv_mf = Q * G * (A' * (A * v_k))
+            # Index map for the terminal-knot concatenated iso-state.
+            knot_idx = vcat(
+                [slice(N, traj.components[nm], traj.dim) for nm in names_K]...,
+            )
+            z = vec(traj)
+            z_k = z[knot_idx]
 
-        # Dense apply at the same knot, via Symmetric(get_full_hessian, :U)·v.
-        H_full = Matrix(get_full_hessian(obj, traj))
-        Hv_dense = (Symmetric(H_full, :U) * v)[knot_idx]
+            # Matrix-free apply at the terminal knot:
+            #   H · v_k = Q · (-2·sign(1-F)) · Aᵀ · (A · v_k)
+            A = cap.A
+            F = sum(abs2, A * z_k)
+            G = -2.0 * sign(1.0 - F)
+            v = randn(length(z))
+            v_k = v[knot_idx]
+            Hv_mf = Q * G * (A' * (A * v_k))
 
-        @test Hv_mf ≈ Hv_dense atol = 1e-10
+            # Dense apply at the same knot, via Symmetric(get_full_hessian, :U)·v.
+            H_full = Matrix(get_full_hessian(obj, traj))
+            Hv_dense = (Symmetric(H_full, :U) * v)[knot_idx]
+
+            @test Hv_mf ≈ Hv_dense atol = 1e-12
+        end
     end
 end
 
@@ -792,50 +808,53 @@ end
     using LinearAlgebra
     using Random
 
-    Random.seed!(43)
-    n = 2  # 2-level system
-    iso_dim = 2 * n^2
     N = 10
     u = randn(1, N)
     Δt = fill(0.1, N)
     Q = 5.0
 
-    U_goal = ComplexF64[0 1; 1 0]   # X gate; doesn't need to be unitary for this test
+    # Issue #248 AC requires coverage across n = 2, 3, 4.
+    for n in (2, 3, 4)
+        Random.seed!(43 + n)             # per-n seed for reproducibility
+        iso_dim = 2 * n^2
+        # Random complex goal (no unitarity required for the parity test).
+        U_goal = randn(ComplexF64, n, n)
 
-    function _make_traj(scale)
-        Utilde = randn(iso_dim, N)
-        Utilde[:, N] .= scale .* operator_to_iso_vec(U_goal)
-        return NamedTrajectory(
-            (Utilde = Utilde, u = u, Δt = Δt);
-            timestep = :Δt,
-            controls = :u,
-        )
-    end
+        function _make_traj(scale)
+            Utilde = randn(iso_dim, N)
+            Utilde[:, N] .= scale .* operator_to_iso_vec(U_goal)
+            return NamedTrajectory(
+                (Utilde = Utilde, u = u, Δt = Δt);
+                timestep = :Δt,
+                controls = :u,
+            )
+        end
 
-    for scale in (0.4, 1.2)  # F < 1 and F > 1
-        traj = _make_traj(scale)
-        obj = UnitaryInfidelityObjective(U_goal, :Utilde, traj; Q = Q)
+        for scale in (0.4, 1.2)  # F < 1 and F > 1
+            traj = _make_traj(scale)
+            obj = UnitaryInfidelityObjective(U_goal, :Utilde, traj; Q = Q)
 
-        cap = knot_hvp(obj, traj)
-        @test cap isa ConstantLowRankHVP
-        @test cap.core === :neg2_sign
-        @test size(cap.A) == (2, iso_dim)
+            cap = knot_hvp(obj, traj)
+            @test cap isa ConstantLowRankHVP
+            @test cap.core === :neg2_sign
+            @test size(cap.A) == (2, iso_dim)
 
-        knot_idx = slice(N, traj.components[:Utilde], traj.dim)
-        z = vec(traj)
-        z_k = z[knot_idx]
+            knot_idx = slice(N, traj.components[:Utilde], traj.dim)
+            z = vec(traj)
+            z_k = z[knot_idx]
 
-        A = cap.A
-        F = sum(abs2, A * z_k)
-        G = -2.0 * sign(1.0 - F)
-        v = randn(length(z))
-        v_k = v[knot_idx]
-        Hv_mf = Q * G * (A' * (A * v_k))
+            A = cap.A
+            F = sum(abs2, A * z_k)
+            G = -2.0 * sign(1.0 - F)
+            v = randn(length(z))
+            v_k = v[knot_idx]
+            Hv_mf = Q * G * (A' * (A * v_k))
 
-        H_full = Matrix(get_full_hessian(obj, traj))
-        Hv_dense = (Symmetric(H_full, :U) * v)[knot_idx]
+            H_full = Matrix(get_full_hessian(obj, traj))
+            Hv_dense = (Symmetric(H_full, :U) * v)[knot_idx]
 
-        @test Hv_mf ≈ Hv_dense atol = 1e-10
+            @test Hv_mf ≈ Hv_dense atol = 1e-12
+        end
     end
 end
 
@@ -864,6 +883,50 @@ end
 
     # Embedded path stays on the dense fallback — no declared knot_hvp.
     @test knot_hvp(obj, traj) === nothing
+end
+
+@testitem "knot_hvp field does not leak into KnotPointObjective value/gradient" begin
+    using NamedTrajectories
+    using DirectTrajOpt
+    using DirectTrajOpt.Objectives: ConstantLowRankHVP
+    using LinearAlgebra
+    using Random
+
+    # Issue #257 AC 3 / #248 AC 4: "Value and gradient of the objective are
+    # byte-for-byte unchanged — only the `knot_hvp` field is newly populated."
+    # Construct two `KnotPointObjective`s that differ ONLY in `knot_hvp`
+    # (one `nothing`, one a populated `ConstantLowRankHVP`) and assert
+    # `objective_value` and `gradient!` are literally equal on both.
+
+    Random.seed!(44)
+    N = 10
+    ket_dim = 4
+    ψ̃1 = randn(ket_dim, N)
+    u = randn(1, N)
+    Δt = fill(0.1, N)
+    traj = NamedTrajectory(
+        (ψ̃1 = ψ̃1, u = u, Δt = Δt);
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    ℓ = x -> sum(x .^ 2) + 0.3 * sum(sin.(x))  # any non-trivial C² loss
+    Q = 7.0
+    fake_A = randn(2, ket_dim)                  # arbitrary; must not affect value/grad
+    cap = ConstantLowRankHVP(fake_A, :neg2_sign)
+
+    obj_none = KnotPointObjective(ℓ, :ψ̃1, traj; Qs = [Q], times = [N], knot_hvp = nothing)
+    obj_pop  = KnotPointObjective(ℓ, :ψ̃1, traj; Qs = [Q], times = [N], knot_hvp = cap)
+
+    # Value: literally equal.
+    @test objective_value(obj_none, traj) === objective_value(obj_pop, traj)
+
+    # Gradient: literally equal (elementwise, no tolerance).
+    ∇_none = zeros(traj.dim * traj.N + traj.global_dim)
+    ∇_pop  = zeros(traj.dim * traj.N + traj.global_dim)
+    gradient!(∇_none, obj_none, traj)
+    gradient!(∇_pop, obj_pop, traj)
+    @test ∇_none == ∇_pop
 end
 
 end

--- a/src/control/objectives.jl
+++ b/src/control/objectives.jl
@@ -326,8 +326,47 @@ function UnitaryInfidelityObjective(
     traj::NamedTrajectory;
     Q = 100.0,
 )
+    # Declarable matrix-free per-knot HVP. The full-operator
+    # `ℓ = |1 − |tr(U†_goal · U)|²/n²|` factors exactly as `|1 − ‖A·Ũ⃗‖²|`
+    # with a constant rank-2 `A` (consumer-side rule `:neg2_sign`).
+    # The embedded-operator branch has a different (mixed-regularizer)
+    # form and stays on the dense fallback.
     ℓ = Ũ⃗ -> abs(1 - unitary_fidelity_loss(Ũ⃗, U_goal))
-    return TerminalObjective(ℓ, Ũ⃗_name, traj; Q = Q)
+    cap = if U_goal isa AbstractMatrix{<:Number}
+        ConstantLowRankHVP(_unitary_lowrank_factor(U_goal), :neg2_sign)
+    else
+        nothing
+    end
+    return TerminalObjective(ℓ, Ũ⃗_name, traj; Q = Q, knot_hvp = cap)
+end
+
+# Build the constant rank-2 factor `A :: Matrix{Float64}` of size
+# `(2, 2·n²)` such that `[A·Ũ⃗]_1 = Re(S)/n`, `[A·Ũ⃗]_2 = Im(S)/n`,
+# where `S = tr(U_goal† · U)` and the iso-vec `Ũ⃗` follows the
+# `operator_to_iso_vec` convention: per column i (0-indexed),
+# block of length 2n is `[Re(U[:, i+1]); Im(U[:, i+1])]`.
+# Then `‖A·Ũ⃗‖² = |S|²/n² = F` exactly.
+function _unitary_lowrank_factor(U_goal::AbstractMatrix{<:Number})
+    n = size(U_goal, 1)
+    @assert size(U_goal, 2) == n "U_goal must be square; got $(size(U_goal))"
+    A = zeros(Float64, 2, 2 * n^2)
+    inv_n = 1.0 / n
+    for i in 0:(n - 1)
+        col = @view U_goal[:, i + 1]
+        re_g = real(col)
+        im_g = imag(col)
+        # Per-column block of `Ũ⃗`: `i*2n + (1:n)` is Re, `i*2n + (n+1:2n)` is Im.
+        #   ⟨gᵢ, Uᵢ⟩ = (Re(g) − i·Im(g))ᵀ (Re(U) + i·Im(U))
+        #             = Re(g)ᵀRe(U) + Im(g)ᵀIm(U)  +  i (Re(g)ᵀIm(U) − Im(g)ᵀRe(U))
+        # Sum over columns gives S = Σᵢ ⟨gᵢ, Uᵢ⟩ = tr(U_goal† U).
+        # Row 1 (Re(S)/n)
+        A[1, i * 2n .+ (1:n)]         .= inv_n .* re_g
+        A[1, i * 2n .+ ((n + 1):2n)]  .= inv_n .* im_g
+        # Row 2 (Im(S)/n)
+        A[2, i * 2n .+ (1:n)]         .= -inv_n .* im_g
+        A[2, i * 2n .+ ((n + 1):2n)]  .=  inv_n .* re_g
+    end
+    return A
 end
 
 function UnitaryFreePhaseInfidelityObjective(

--- a/src/control/objectives.jl
+++ b/src/control/objectives.jl
@@ -719,4 +719,151 @@ end
     gradient!(∇, obj, traj)
 end
 
+@testitem "knot_hvp matrix-free apply matches dense Hessian — CoherentKetInfidelityObjective" begin
+    using NamedTrajectories
+    using DirectTrajOpt
+    using DirectTrajOpt.Objectives: knot_hvp, ConstantLowRankHVP, get_full_hessian
+    using TrajectoryIndexingUtils
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(42)
+    N = 10
+    ket_dim = 4  # iso dim for 2-level system
+    u = randn(1, N)
+    Δt = fill(0.1, N)
+    Q = 7.0  # non-default so the scaling threads through
+
+    goals = [ComplexF64[0.0, 1.0], ComplexF64[1.0, 0.0]]
+
+    # Build a trajectory with a scaled copy of the goals at the terminal knot.
+    # `scale < 1` puts F below the kink; `scale > 1` puts F above it.
+    function _make_traj(scale)
+        ψ̃1 = randn(ket_dim, N)
+        ψ̃2 = randn(ket_dim, N)
+        ψ̃1[:, N] .= scale .* ket_to_iso(goals[1])
+        ψ̃2[:, N] .= scale .* ket_to_iso(goals[2])
+        return NamedTrajectory(
+            (ψ̃1 = ψ̃1, ψ̃2 = ψ̃2, u = u, Δt = Δt);
+            timestep = :Δt,
+            controls = :u,
+        )
+    end
+
+    for scale in (0.4, 1.2)  # F < 1 and F > 1
+        traj = _make_traj(scale)
+        obj = CoherentKetInfidelityObjective(goals, [:ψ̃1, :ψ̃2], traj; Q = Q)
+
+        cap = knot_hvp(obj, traj)
+        @test cap isa ConstantLowRankHVP
+        @test cap.core === :neg2_sign
+        @test size(cap.A) == (2, 2 * ket_dim)
+
+        # Index map for the terminal-knot concatenated iso-state.
+        knot_idx = vcat(
+            slice(N, traj.components[:ψ̃1], traj.dim),
+            slice(N, traj.components[:ψ̃2], traj.dim),
+        )
+        z = vec(traj)
+        z_k = z[knot_idx]
+
+        # Matrix-free apply at the terminal knot:
+        #   H · v_k = Q · (-2·sign(1-F)) · Aᵀ · (A · v_k)
+        A = cap.A
+        F = sum(abs2, A * z_k)
+        G = -2.0 * sign(1.0 - F)
+        v = randn(length(z))
+        v_k = v[knot_idx]
+        Hv_mf = Q * G * (A' * (A * v_k))
+
+        # Dense apply at the same knot, via Symmetric(get_full_hessian, :U)·v.
+        H_full = Matrix(get_full_hessian(obj, traj))
+        Hv_dense = (Symmetric(H_full, :U) * v)[knot_idx]
+
+        @test Hv_mf ≈ Hv_dense atol = 1e-10
+    end
+end
+
+@testitem "knot_hvp matrix-free apply matches dense Hessian — UnitaryInfidelityObjective (full-op)" begin
+    using NamedTrajectories
+    using DirectTrajOpt
+    using DirectTrajOpt.Objectives: knot_hvp, ConstantLowRankHVP, get_full_hessian
+    using TrajectoryIndexingUtils
+    using LinearAlgebra
+    using Random
+
+    Random.seed!(43)
+    n = 2  # 2-level system
+    iso_dim = 2 * n^2
+    N = 10
+    u = randn(1, N)
+    Δt = fill(0.1, N)
+    Q = 5.0
+
+    U_goal = ComplexF64[0 1; 1 0]   # X gate; doesn't need to be unitary for this test
+
+    function _make_traj(scale)
+        Utilde = randn(iso_dim, N)
+        Utilde[:, N] .= scale .* operator_to_iso_vec(U_goal)
+        return NamedTrajectory(
+            (Utilde = Utilde, u = u, Δt = Δt);
+            timestep = :Δt,
+            controls = :u,
+        )
+    end
+
+    for scale in (0.4, 1.2)  # F < 1 and F > 1
+        traj = _make_traj(scale)
+        obj = UnitaryInfidelityObjective(U_goal, :Utilde, traj; Q = Q)
+
+        cap = knot_hvp(obj, traj)
+        @test cap isa ConstantLowRankHVP
+        @test cap.core === :neg2_sign
+        @test size(cap.A) == (2, iso_dim)
+
+        knot_idx = slice(N, traj.components[:Utilde], traj.dim)
+        z = vec(traj)
+        z_k = z[knot_idx]
+
+        A = cap.A
+        F = sum(abs2, A * z_k)
+        G = -2.0 * sign(1.0 - F)
+        v = randn(length(z))
+        v_k = v[knot_idx]
+        Hv_mf = Q * G * (A' * (A * v_k))
+
+        H_full = Matrix(get_full_hessian(obj, traj))
+        Hv_dense = (Symmetric(H_full, :U) * v)[knot_idx]
+
+        @test Hv_mf ≈ Hv_dense atol = 1e-10
+    end
+end
+
+@testitem "knot_hvp returns nothing for EmbeddedOperator UnitaryInfidelityObjective" begin
+    using NamedTrajectories
+    using DirectTrajOpt
+    using DirectTrajOpt.Objectives: knot_hvp
+    using LinearAlgebra
+
+    n_full = 4   # ambient
+    iso_dim = 2 * n_full^2
+    N = 5
+
+    Utilde = randn(iso_dim, N)
+    u = randn(1, N)
+    Δt = fill(0.1, N)
+    traj = NamedTrajectory(
+        (Utilde = Utilde, u = u, Δt = Δt);
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    # 2x2 X gate embedded in a 4-dim ambient space (subspace = 1:2).
+    op = EmbeddedOperator(ComplexF64[0 1; 1 0], 1:2, n_full)
+    obj = UnitaryInfidelityObjective(op, :Utilde, traj; Q = 1.0)
+
+    # Embedded path stays on the dense fallback — no declared knot_hvp.
+    @test knot_hvp(obj, traj) === nothing
+end
+
 end

--- a/src/quantum/operators/direct_sums.jl
+++ b/src/quantum/operators/direct_sums.jl
@@ -34,9 +34,7 @@ end
 Returns the direct sum of two iso_vec operators.
 """
 function direct_sum(Ã⃗::AbstractVector, B̃⃗::AbstractVector)
-    return operator_to_iso_vec(
-        direct_sum(iso_vec_to_operator(Ã⃗), iso_vec_to_operator(B̃⃗)),
-    )
+    return operator_to_iso_vec(direct_sum(iso_vec_to_operator(Ã⃗), iso_vec_to_operator(B̃⃗)))
 end
 
 """

--- a/src/quantum/primitives/isomorphisms.jl
+++ b/src/quantum/primitives/isomorphisms.jl
@@ -76,8 +76,7 @@ function iso_vec_to_operator(Ũ⃗::AbstractVector{ℝ}) where {ℝ<:Real}
     N = Int(sqrt(Ũ⃗_dim))
     U = Matrix{complex(ℝ)}(undef, N, N)
     for i = 0:(N-1)
-        U[:, i+1] .=
-            @view(Ũ⃗[i*2N .+ (1:N)]) + one(ℝ) * im * @view(Ũ⃗[i*2N .+ ((N+1):2N)])
+        U[:, i+1] .= @view(Ũ⃗[i*2N .+ (1:N)]) + one(ℝ) * im * @view(Ũ⃗[i*2N .+ ((N+1):2N)])
     end
     return U
 end

--- a/src/quantum/systems/variational_quantum_systems.jl
+++ b/src/quantum/systems/variational_quantum_systems.jl
@@ -22,11 +22,8 @@ The variational operators represent directions of uncertainty or perturbation in
 
 See also [`QuantumSystem`](@ref Piccolo.Quantum.QuantumSystems.QuantumSystem), [`OpenQuantumSystem`](@ref).
 """
-struct VariationalQuantumSystem{
-    F1<:Function,
-    F2<:Function,
-    F⃗3<:AbstractVector{<:Function},
-} <: AbstractQuantumSystem
+struct VariationalQuantumSystem{F1<:Function,F2<:Function,F⃗3<:AbstractVector{<:Function}} <:
+       AbstractQuantumSystem
     H::F1
     G::F2
     G_vars::F⃗3

--- a/src/quantum/templates/transmons/transmon_system.jl
+++ b/src/quantum/templates/transmons/transmon_system.jl
@@ -440,8 +440,8 @@ function TransmonCavitySystem(;
 
     # Drift Hamiltonian
     H_drift =
-        Δ̃ * b̂' * b̂ - χ * â' * â * b̂' * b̂ - χ′ * b̂'^2 * b̂^2 * â' * â -
-        K_q * â'^2 * â^2 - K_c * b̂'^2 * b̂^2
+        Δ̃ * b̂' * b̂ - χ * â' * â * b̂' * b̂ - χ′ * b̂'^2 * b̂^2 * â' * â - K_q * â'^2 * â^2 -
+        K_c * b̂'^2 * b̂^2
 
     # Drive operators
     H_drives = [

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -88,12 +88,8 @@ function named_trajectory_type_1(; free_time = true)
             Δt = ([0.1], [0.30000000000000004]),
         )
     else
-        components = (
-            Ũ⃗ = data[1:8, :],
-            a = data[9:10, :],
-            da = data[11:12, :],
-            dda = data[13:14, :],
-        )
+        components =
+            (Ũ⃗ = data[1:8, :], a = data[9:10, :], da = data[11:12, :], dda = data[13:14, :])
         controls = (:dda,)
         timestep = 0.2
         bounds = (a = ([-1.0, -1.0], [1.0, 1.0]), dda = ([-1.0, -1.0], [1.0, 1.0]))


### PR DESCRIPTION
# Piccolo matrix-free objective-constructor slice — overall summary

**Branch:** `feat/matrix-free-obj-constr-test` in `harmoniqs/Piccolo.jl` (ahead of `feat/matrix-free-obj-constr` by one commit).
**Origin:** part of Piccolissimo #179; scoped into two Piccolo issues:

- [`../../inputs/matrix-free/257.md`](../../inputs/matrix-free/257.md)
  — `CoherentKetInfidelityObjective` slice.
- [`../../inputs/matrix-free/248.md`](../../inputs/matrix-free/248.md)
  — full-op `UnitaryInfidelityObjective` slice.

**Companion documents:**

- [`./dto-matrix-free-summary.v1.md`](./dto-matrix-free-summary.v1.md)
  — the upstream DTO #113 `KnotHVP` interface this consumes.
- [`./piccolo-issue-discrepancies.md`](./piccolo-issue-discrepancies.md)
  — review-gap analysis vs. issues #248 / #257.
- [`./piccolo-test-addendum.md`](./piccolo-test-addendum.md) —
  outcome of the review-pass edits.
- [`./piccolo-mfree-objconstr.md`](./piccolo-mfree-objconstr.md) —
  this document.

**Consumer (still pending):** the Piccolissimo #179 apply-side is
tracked in [`./piccolissimo-todos.md`](./piccolissimo-todos.md); its
work has not yet started. This document only summarizes the Piccolo
half of the coordinated PR pair.

---

## 1. Overall shape

Two of Piccolo's fidelity constructors now populate the DTO
`knot_hvp::Union{Nothing, KnotHVP}` field on their returned
`KnotPointObjective`, so Piccolissimo's Altissimo backend can pick
up an exact, constant, rank-2 factor and apply the per-knot Hessian
matrix-free — instead of rediscovering the same operator via the
`(6 + r)` nested-ForwardDiff probes + host SVD that PR #178
introduced.

The constructors affected:

- `CoherentKetInfidelityObjective` (multi-ket coherent fidelity)
- `UnitaryInfidelityObjective` on the full-operator branch (i.e.
  `U_goal isa AbstractMatrix`). The `EmbeddedOperator` branch and
  the `UnitaryFreePhaseInfidelityObjective` (θ-parameterized) stay
  on `knot_hvp = nothing` — deliberately out of scope, as their
  Hessian structures don't fit `ConstantLowRankHVP`.

Ket-family variants outside the coherent multi-ket case
(`KetInfidelityObjective`, `CoherentKetFreePhaseInfidelityObjective`,
`KetFreePhaseInfidelityObjective`), density objectives, and
`UnitarySensitivityObjective` are all untouched.

---

## 2. Files changed

| File | Kind | Change |
|---|---|---|
| `src/control/objectives.jl` | source | `CoherentKetInfidelityObjective` builds `A` via new helper, threads `knot_hvp` through `TerminalObjective`; new helper `_coherent_ket_lowrank_factor(goals, state_dims)` (~35 lines); `UnitaryInfidelityObjective` (full-op branch) builds `A` via new helper, threads `knot_hvp`; new helper `_unitary_lowrank_factor(U_goal)` (~24 lines); trailing signature comment on `U_goal::AbstractPiccoloOperator` distinguishing the full-op vs. embedded arms. |
| `src/control/objectives.jl` | tests | 3 new inline `@testitem` blocks (rank-2 factor round-trips + EmbeddedOperator fallthrough) + 1 review-pass byte-identity testitem; expanded test coverage per issue ACs. |

No new files. No API surface change (only a new keyword argument
that was already threaded by DTO #113). No public-symbol renaming.
No changes to value or gradient paths.

---

## 3. What each constructor now does

### 3.1 `CoherentKetInfidelityObjective` (issue #257)

The coherent overlap `S = (1/K) · Σᵢ ⟨gᵢ, ψᵢ⟩` is a **single complex
scalar linear in `z`**, where `z = [ψ̃₁; ψ̃₂; …; ψ̃_K]` is the
concatenated per-ket iso-state at the terminal knot and each `ψ̃ᵢ`
follows the `ket_to_iso` convention `[Re(ψᵢ); Im(ψᵢ)]` (length
`d_iso = 2 · ketdim`).

Because `S` is a scalar linear functional of `z`, the loss
`ℓ = |1 − |S|²|` factors exactly as `|1 − ‖A · z‖²|` with a
**constant `A` of shape `2 × sum(state_dims)`**:

- Row 1 of `A` captures `Re(S) = (1/K) · Σᵢ (Re(gᵢ)ᵀRe(ψᵢ) + Im(gᵢ)ᵀIm(ψᵢ))`
- Row 2 captures `Im(S) = (1/K) · Σᵢ (Re(gᵢ)ᵀIm(ψᵢ) − Im(gᵢ)ᵀRe(ψᵢ))`

with the `1/K` factor built into every entry of `A`, so
`‖A · z‖² = |S|² = F` exactly (no extra normalization needed at
the consumer). This is the `:neg2_sign` link-Hessian rule for
Piccolissimo: `H · v = -2 · sign(1 − F) · Aᵀ · (A · v)` (with the
kink at `F = 1` handled by explicit branch selection on the
Piccolissimo side).

The constructor now stashes `ConstantLowRankHVP(A, :neg2_sign)` via
the `knot_hvp` keyword forwarded to `TerminalObjective`.

### 3.2 `UnitaryInfidelityObjective` (issue #248), full-op branch

The overlap `S = tr(U_goal† · U(z))` is a **single complex scalar
linear in `z`**, where `z = Ũ⃗` follows the `operator_to_iso_vec`
convention (per column `i` of `U`, a length-`2n` block
`[Re(U[:,i+1]); Im(U[:,i+1])]`, total length `2n²`).

The fidelity is `F = |S|² / n²`, so the loss `ℓ = |1 − F|` factors
exactly as `|1 − ‖A · Ũ⃗‖²|` with a **constant `A` of shape
`2 × 2n²`**, with the `1/n` factor built into every entry so
`‖A · Ũ⃗‖² = |S|² / n² = F` exactly.

The constructor now stashes `ConstantLowRankHVP(A, :neg2_sign)`
when `U_goal isa AbstractMatrix{<:Number}`. When `U_goal isa
EmbeddedOperator`, `knot_hvp = nothing` is passed instead — the
embedded case has a mixed regularizer structure
(`1 / (n(n+1)) · (|tr(M†M)| + |tr(M)|²)`) that doesn't fit the
constant-rank-2 form and stays on the dense fallback.

### 3.3 Helper functions

Two new module-private helpers in `objectives.jl`:

- **`_coherent_ket_lowrank_factor(goals, state_dims)`** — builds
  the `(2, sum(state_dims))` factor from a vector of complex goal
  kets and their per-ket iso-dimensions. Handles arbitrary `K` and
  arbitrary per-ket dimensions (the API supports it, though in
  practice all kets share the same Hilbert space dim).
- **`_unitary_lowrank_factor(U_goal)`** — builds the `(2, 2n²)`
  factor from an `n × n` complex operator, per the
  `operator_to_iso_vec` column-major layout.

Both produce `Matrix{Float64}` (solver-precision real iso
representation), matching the DTO `ConstantLowRankHVP.A::Matrix{Float64}`
field type.

---

## 4. Acceptance criteria mapping

### 4.1 Issue #257 (`CoherentKetInfidelityObjective`)

| AC | Status | Evidence |
|---|:---:|---|
| Constructing returns objective with `knot_hvp isa ConstantLowRankHVP`, `core === :neg2_sign` (was `nothing`) | ✅ | Testitem `"knot_hvp matrix-free apply matches dense Hessian — CoherentKetInfidelityObjective"` asserts both directly. |
| `A` is `2 × sum(state_dims)` real, `1/K` scale, `F = ‖A·x_k‖²` = coherent fidelity to `~1e-12` for randomly sampled terminal states and goals, **across ≥1 and ≥2 goal states** | ✅ | Same testitem now loops `for K in (1, 2)` × `for scale in (0.4, 1.2)` (F<1, F>1) and asserts `size(cap.A) == (2, K * ket_dim)` plus `atol = 1e-12` parity. Review-pass expansion in [`./piccolo-test-addendum.md`](./piccolo-test-addendum.md). |
| Value and gradient are byte-for-byte unchanged | ✅ | New testitem `"knot_hvp field does not leak into KnotPointObjective value/gradient"` builds two `KnotPointObjective`s differing only in `knot_hvp` and asserts elementwise equality. Existing testitems (`CoherentKetInfidelityObjective`, `CoherentKetFreePhaseInfidelityObjective`, `coherent_ket_fidelity accepts generic Complex types`) still pass. |
| `[compat]` admits DTO release shipping `KnotHVP` | 🚧 deferred | Follow-up commit once DTO v0.9.7 is registered (see [`./piccolo-test-addendum.md`](./piccolo-test-addendum.md) *"Items deferred"*). |

### 4.2 Issue #248 (`UnitaryInfidelityObjective` full-op)

| AC | Status | Evidence |
|---|:---:|---|
| Constructing (full-op) returns objective with `knot_hvp isa ConstantLowRankHVP`, `core === :neg2_sign` (was `nothing`) | ✅ | Testitem `"knot_hvp matrix-free apply matches dense Hessian — UnitaryInfidelityObjective (full-op)"` asserts both. |
| `A` is `2 × 2n²` real, `1/n` scale, `F = ‖A·x_k‖² = |S|²/n²` to `~1e-12` **across `n = 2, 3, 4`** | ✅ | Same testitem now loops `for n in (2, 3, 4)` × `for scale in (0.4, 1.2)` and asserts `size(cap.A) == (2, iso_dim)` where `iso_dim = 2n²`, plus `atol = 1e-12` parity. Review-pass expansion in [`./piccolo-test-addendum.md`](./piccolo-test-addendum.md). |
| Embedded and free-phase constructors untouched (`knot_hvp = nothing`) | ✅ | Testitem `"knot_hvp returns nothing for EmbeddedOperator UnitaryInfidelityObjective"` asserts the embedded case directly. `UnitaryFreePhaseInfidelityObjective` constructor is unchanged in this branch (verified by inspection); an inline assertion could be added if desired. |
| Value and gradient are byte-for-byte unchanged | ✅ | Shared with #257 AC 4 above — the new byte-identity testitem is objective-agnostic (uses `KnotPointObjective` directly, which is the layer at which `knot_hvp` lives). |

---

## 5. Test coverage summary

Post-review-pass, `Piccolo.jl/src/control/objectives.jl` inline
testitems total **55 assertions** across 8 testitems (was 12 before
this branch, and 29 before the review pass — see
[`./piccolo-test-addendum.md`](./piccolo-test-addendum.md) for the
per-testitem breakdown). Wall time 16.6 s in the manual driver.

The added test surface:

- Round-trip parity vs. `Symmetric(get_full_hessian, :U) · v` at
  `F < 1` and `F > 1` — for coherent-ket at K ∈ {1, 2} and for
  full-op unitary at n ∈ {2, 3, 4}.
- Fallback verification: `EmbeddedOperator` case returns
  `knot_hvp === nothing` (scope guard).
- Byte-identity of value + gradient across a `knot_hvp = nothing`
  vs. `knot_hvp = ConstantLowRankHVP(random_A, :neg2_sign)`
  construction pair.
- No-regression: all 12 pre-branch assertions still pass unchanged.

---

## 6. Deferred / follow-up items

| Item | Reason | When it closes |
|---|---|---|
| `[compat] DirectTrajOpt = "0.9.7"` in `Piccolo.jl/Project.toml` | DTO v0.9.7 not yet in the registered General.jl set; `Pkg.resolve()` fails when the compat entry demands a version the registry doesn't have. | One-line follow-up commit once DTO v0.9.7 is tagged and registered upstream. |
| Free-phase `knot_hvp` declarers (`UnitaryFreePhaseInfidelityObjective`, `CoherentKetFreePhaseInfidelityObjective`, `KetFreePhaseInfidelityObjective`) | `A(θ)` is not constant — deferred with three candidate approaches (`CustomKnotHVP` closure, `ParametricLowRankHVP` carrier, exploit global linear constraints on θ). | Per [`./todos.md`](./todos.md) §2a: filed as a future sub-issue; needs a Phase-0 audit of the per-iterate rank of `A(θ)` before choosing an approach. |
| Piccolissimo consumer (Issue #179 apply side) | Half of the coordinated PR pair; produces the code that actually reads `knot_hvp(obj, traj)` and applies the constant-`A` HVP device-side. | Next in the workstream — implementation plan at [`./piccolissimo-todos.md`](./piccolissimo-todos.md), decisions locked in via [`../todos-conflicts.md`](../todos-conflicts.md) and [`./piccolissimo-saturation-guard-determination.md`](./piccolissimo-saturation-guard-determination.md). |

---

## 7. Non-goals

Recorded explicitly to keep the PR scope obvious:

- **Piccolissimo consumer** — a separate PR (item 1 of the workstream
  in [`./todos.md`](./todos.md)).
- **Sunset of PR #178's `_build_rank_r_block`** — item 4 in the
  workstream, not this PR.
- **Density objectives, `UnitarySensitivityObjective`, and the
  ket-family variants other than the coherent multi-ket case** —
  still `knot_hvp = nothing`. All either don't fit the constant-A
  rank-2 structure or are affine (zero block); their carve-outs are
  matched to the corresponding issue-scope statements.
- **New `core` symbols beyond `:neg2_sign`** — none in this branch.
  When a new structured family (e.g. an embedded-op declarer) is
  added later, the same slot can carry a new symbol paired with the
  corresponding apply-branch on the Piccolissimo side.
