### PR TITLE
feat(trajectories): rollout=:none fast path for MultiKetTrajectory (ALTISSIMO 1.5)

### DIFF
--- a/src/quantum/trajectories/abstract_trajectory.jl
+++ b/src/quantum/trajectories/abstract_trajectory.jl
@@ -19,6 +19,7 @@ abstract type AbstractQuantumTrajectory{P<:AbstractPulse} end
 
 export AbstractQuantumTrajectory
 export UnitaryTrajectory, KetTrajectory, MultiKetTrajectory, DensityTrajectory
+export RolloutStates
 export MultiDensityTrajectory, SamplingTrajectory
 export state_name, state_names, drive_name, time_name, timestep_name
 export get_system, get_pulse, get_initial, get_goal, get_solution

--- a/src/quantum/trajectories/ensemble_trajectory.jl
+++ b/src/quantum/trajectories/ensemble_trajectory.jl
@@ -30,6 +30,62 @@ mutable struct MultiKetTrajectory{P<:AbstractPulse,S} <: AbstractQuantumTrajecto
 end
 
 """
+    PerKetStates
+
+Per-ket protocol shim for a `RolloutStates` solution. Implements the two protocols the
+`MultiKetTrajectory` solution consumers rely on:
+- `(pk::PerKetStates)(t)` — the state at the nearest stored knot time ≤ `t`
+  (used by `qtraj(t)` and `NamedTrajectory` conversion sampling)
+- `pk.u` — vector of per-knot states, so `pk.u[end]` is the terminal state
+  (used by `fidelity`)
+"""
+struct PerKetStates{M<:AbstractMatrix{ComplexF64}}
+    mat::M                    # (ketdim, N_knots) — a view into the shared 3D array
+    times::Vector{Float64}
+end
+
+(pk::PerKetStates)(t::Real) =
+    getfield(pk, :mat)[:, max(searchsortedlast(getfield(pk, :times), t), 1)]
+
+# NOTE: `.u` materializes copies of all N columns per access — fine at current call
+# rates (fidelity reads one terminal state per call); do not use in hot loops.
+Base.getproperty(pk::PerKetStates, s::Symbol) =
+    s === :u ? [getfield(pk, :mat)[:, j] for j in axes(getfield(pk, :mat), 2)] :
+    getfield(pk, s)
+
+"""
+    RolloutStates
+
+No-ODE solution for `MultiKetTrajectory(...; rollout = :none)`. Holds knot states directly
+(initialized by tiling the initial kets — a legitimate warm-start guess that downstream
+`NamedTrajectory` sampling may consume) with a MUTABLE interior: a GPU rollout (e.g.
+Piccolissimo's `gpu_rollout!`) overwrites `states` in place and sets `real_states = true`,
+so the trajectory's solution type parameter never changes and `rollout!`'s
+solution-reassignment path is never exercised.
+
+`fidelity` on a trajectory whose `real_states` is still `false` warns (once) — a tiled
+placeholder must never be silently reported as a physical fidelity. Direct `rollout!` on a
+`RolloutStates` trajectory is an error (see `rollouts_extensions.jl`).
+"""
+# Concrete view type of one ket's (ketdim × N_knots) slice of the shared 3D array.
+# Computed (not hand-written) so the shims are guaranteed to be stored as VIEWS —
+# a Matrix-typed field would silently convert-and-COPY, leaving the shims stale
+# after an in-place `states .= ...` refresh (review-caught failure mode).
+const _KetStatesView = typeof(view(zeros(ComplexF64, 1, 1, 1), :, 1, :))
+
+mutable struct RolloutStates
+    states::Array{ComplexF64,3}   # (ketdim, K, N_knots) — shared storage
+    times::Vector{Float64}
+    real_states::Bool             # false until a real (GPU) rollout refreshes `states`
+    u::Vector{PerKetStates{_KetStatesView}}
+
+    function RolloutStates(states::Array{ComplexF64,3}, times::Vector{Float64}, real_states::Bool)
+        shims = [PerKetStates(view(states, :, k, :), times) for k in axes(states, 2)]
+        return new(states, times, real_states, shims)
+    end
+end
+
+"""
     MultiKetTrajectory(system, pulse, initials, goals; weights=..., algorithm=MagnusAdapt4(), abstol=1e-8, reltol=1e-8, n_save=101)
 
 Create a multi-ket trajectory by solving multiple Schrödinger equations.
@@ -57,9 +113,27 @@ function MultiKetTrajectory(
     abstol::Real = 1e-8,
     reltol::Real = 1e-8,
     n_save::Int = 101,
+    rollout::Symbol = :cpu,
 )
     @assert n_drives(pulse) == system.n_drives "Pulse has $(n_drives(pulse)) drives, system has $(system.n_drives)"
     @assert length(initials) == length(goals) == length(weights) "initials, goals, and weights must have same length"
+
+    if rollout === :none
+        # No-ODE fast path: knot states tiled from the initial kets (a readable
+        # warm-start guess); refresh later with a GPU rollout. See `RolloutStates`.
+        ψ0s = [Vector{ComplexF64}(ψ) for ψ in initials]
+        ψgs = [Vector{ComplexF64}(ψ) for ψ in goals]
+        ws = Vector{Float64}(weights)
+        kt = collect(Float64, get_knot_times(pulse))
+        states = Array{ComplexF64,3}(undef, system.levels, length(ψ0s), length(kt))
+        for (k, ψ) in enumerate(ψ0s), j in eachindex(kt)
+            states[:, k, j] = ψ
+        end
+        rs = RolloutStates(states, kt, false)
+        return MultiKetTrajectory{typeof(pulse),RolloutStates}(system, pulse, ψ0s, ψgs, ws, rs)
+    elseif rollout !== :cpu
+        throw(ArgumentError("rollout must be :cpu or :none, got $(repr(rollout))"))
+    end
 
     if isnothing(algorithm)
         algorithm = default_algorithm(system)
@@ -119,6 +193,7 @@ function MultiKetTrajectory(
     algorithm = nothing,
     abstol::Real = 1e-8,
     reltol::Real = 1e-8,
+    rollout::Symbol = :cpu,
 )
     times = [0.0, T]
     controls = vcat([rand(Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
@@ -132,6 +207,7 @@ function MultiKetTrajectory(
         algorithm,
         abstol,
         reltol,
+        rollout,
     )
 end
 
@@ -268,4 +344,43 @@ end
 
     # length(.solution.u) should be trajectory count, not scalar element count
     @test length(qtraj.solution.u) == 2
+end
+
+@testitem "MultiKetTrajectory: rollout=:none tiles initials, readable, guarded" begin
+    sys = QuantumSystem(PAULIS.Z, [PAULIS.X], [1.0])
+    ψ0 = [ComplexF64[1, 0], ComplexF64[0, 1]]
+    ψg = [ComplexF64[0, 1], ComplexF64[1, 0]]
+    qt = MultiKetTrajectory(sys, ψ0, ψg, 1.0; rollout = :none)
+    @test qt isa MultiKetTrajectory
+    @test qt.solution isa RolloutStates
+    @test !qt.solution.real_states
+
+    # placeholder reads SUCCEED (bootstrap requirement): tiled initial at every t
+    for (k, ψ) in enumerate(ψ0)
+        @test all(qt[k](t) ≈ ψ for t in (0.0, 0.5, 1.0))
+    end
+    @test qt(0.5) ≈ ψ0                      # trajectory callable samples all kets
+    @test qt[1].u[end] ≈ ψ0[1]              # fidelity's terminal-state protocol
+
+    # shims are VIEWS into the shared array — in-place refresh must be visible
+    # (guards the silent view→Matrix copy failure mode)
+    qt.solution.states[:, 1, :] .= ComplexF64[0, 1]
+    @test qt[1](0.5) ≈ ComplexF64[0, 1]
+    @test qt[1].u[end] ≈ ComplexF64[0, 1]
+
+    # rollout! is a hard error on BOTH methods
+    @test_throws ErrorException rollout!(qt, get_pulse(qt))
+    @test_throws ErrorException rollout!(qt)
+
+    # fidelity on a placeholder warns (once) but still returns a number
+    @test_logs (:warn, r"placeholder") match_mode = :any begin
+        f = fidelity(qt)
+        @test f isa Float64
+    end
+
+    # bad kwarg value rejected; legacy default unchanged
+    @test_throws ArgumentError MultiKetTrajectory(sys, ψ0, ψg, 1.0; rollout = :fast)
+    qt2 = MultiKetTrajectory(sys, ψ0, ψg, 1.0)
+    @test qt2 isa MultiKetTrajectory
+    @test !(qt2.solution isa RolloutStates)
 end

--- a/src/quantum/trajectories/ensemble_trajectory.jl
+++ b/src/quantum/trajectories/ensemble_trajectory.jl
@@ -79,7 +79,11 @@ mutable struct RolloutStates
     real_states::Bool             # false until a real (GPU) rollout refreshes `states`
     u::Vector{PerKetStates{_KetStatesView}}
 
-    function RolloutStates(states::Array{ComplexF64,3}, times::Vector{Float64}, real_states::Bool)
+    function RolloutStates(
+        states::Array{ComplexF64,3},
+        times::Vector{Float64},
+        real_states::Bool,
+    )
         shims = [PerKetStates(view(states, :, k, :), times) for k in axes(states, 2)]
         return new(states, times, real_states, shims)
     end
@@ -130,7 +134,14 @@ function MultiKetTrajectory(
             states[:, k, j] = ψ
         end
         rs = RolloutStates(states, kt, false)
-        return MultiKetTrajectory{typeof(pulse),RolloutStates}(system, pulse, ψ0s, ψgs, ws, rs)
+        return MultiKetTrajectory{typeof(pulse),RolloutStates}(
+            system,
+            pulse,
+            ψ0s,
+            ψgs,
+            ws,
+            rs,
+        )
     elseif rollout !== :cpu
         throw(ArgumentError("rollout must be :cpu or :none, got $(repr(rollout))"))
     end

--- a/src/quantum/trajectories/rollouts_extensions.jl
+++ b/src/quantum/trajectories/rollouts_extensions.jl
@@ -955,6 +955,38 @@ phase-rotated before computing the overlap. This matches the
 `subsystem_levels` specifies the Hilbert space dimensions of each subsystem
 (e.g., [2, 2, 2, 2] for 4 qubits). Required when `phases` is provided.
 """
+# ── rollout = :none (RolloutStates) guards ─────────────────────────────────────
+# A `RolloutStates` trajectory must never be CPU-rolled: `rollout!` REASSIGNS
+# `qtraj.solution`, and the solution type parameter S is fixed at construction —
+# the assignment would convert-error (worse: only AFTER the ODE ran). Placeholder
+# READS are fine (they are the bootstrap warm-start guess); only re-rollout and
+# placeholder fidelity are guarded.
+const _ROLLOUT_NONE_ERR =
+    "this MultiKetTrajectory was built with `rollout = :none` (placeholder states); " *
+    "CPU `rollout!` is not supported on it — refresh it with a GPU rollout " *
+    "(Piccolissimo `gpu_rollout!`) or reconstruct with `rollout = :cpu`"
+
+Rollouts.rollout!(
+    ::MultiKetTrajectory{<:AbstractPulse,RolloutStates},
+    ::AbstractPulse;
+    kwargs...,
+) = error(_ROLLOUT_NONE_ERR)
+
+Rollouts.rollout!(::MultiKetTrajectory{<:AbstractPulse,RolloutStates}; kwargs...) =
+    error(_ROLLOUT_NONE_ERR)
+
+function Rollouts.fidelity(
+    qtraj::MultiKetTrajectory{<:AbstractPulse,RolloutStates};
+    kwargs...,
+)
+    if !qtraj.solution.real_states
+        @warn "fidelity() on a rollout=:none placeholder trajectory — the states are " *
+              "the tiled initial-ket guess, NOT solved dynamics. Refresh with " *
+              "gpu_rollout! first." maxlog = 1
+    end
+    return invoke(Rollouts.fidelity, Tuple{MultiKetTrajectory}, qtraj; kwargs...)
+end
+
 function Rollouts.fidelity(
     qtraj::MultiKetTrajectory;
     phases::Union{Nothing,AbstractVector{<:Real}} = nothing,


### PR DESCRIPTION
## Summary

The Piccolo half of **ALTISSIMO 1.5** (GPU-resident build & rollout — harmoniqs/Piccolissimo.jl#196). Adds a **no-ODE `rollout = :none`** construction path to `MultiKetTrajectory`, so the eager ensemble-ODE rollout in the constructor (13 min at i=3, host-OOM-adjacent at i=4) can be replaced by a fast GPU rollout downstream (`Piccolissimo.gpu_rollout!`, companion PR).

### What changed
- **`rollout::Symbol = :cpu` kwarg** on both `MultiKetTrajectory` constructors. `:cpu` (default) is unchanged; `:none` fills knot states by tiling the initial kets (a readable warm-start guess) — no ODE solve.
- **`RolloutStates` solution wrapper** with a **mutable interior**: a GPU rollout overwrites `states` in place and flips `real_states`, so the trajectory's solution type parameter `S` never changes and `rollout!`'s solution-reassignment path is never exercised.
- **`PerKetStates` shims** implement the two consumer protocols (`pk(t)` for `qtraj(t)`/NamedTrajectory sampling, `pk.u[end]` for `fidelity`). They are stored as **views** into the shared `(ketdim, K, N)` array (via a computed `_KetStatesView` type — a `Matrix` field would silently convert-and-copy, leaving shims stale after an in-place refresh).
- **Guards:** `rollout!` on a `RolloutStates` trajectory is a hard error (both methods — the reassignment would convert-error *after* the ODE ran); `fidelity` on a not-yet-refreshed placeholder warns once (a tiled guess must never be reported as a physical fidelity). Placeholder *reads* succeed (the bootstrap's `NamedTrajectory(qt,N)` sampling consumes them).

### Validation
- **`rollout = :cpu` is bit-identical to `main`**: seeded i=2 baked-C ctor, `max|Δ| = 0.0` on sampled + terminal states (two-phase main-vs-branch check).
- **`rollout = :none` unit tests** (inline `@testitem`): tiled reads, view-staleness guard (in-place mutation visible through shims), both `rollout!` errors, the `fidelity` placeholder warning, kwarg validation.
- End-to-end (via the companion Piccolissimo PR, real A100): construction **905 s → 66 s** at i=3; GPU-rollout warm-start fid matches the CPU 1e-4 reference to 6 digits.

## Test plan
- [ ] CI passes (incl. the new inline testitems)

Part of ALTISSIMO 1.5 (harmoniqs/Piccolissimo.jl#196). The Piccolissimo consumer PR (`gpu_rollout!` + device-aware sync) depends on this — **merge this first**, then drop its temporary `[sources]` pin to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)