### PR TITLE
Move matrix-free HVP carriers out of Piccolo (→ Piccolissimo #214)

### DIFF
--- a/src/control/objectives.jl
+++ b/src/control/objectives.jl
@@ -426,11 +426,8 @@ using TestItems
     u = randn(1, N)
     Δt = fill(0.1, N)
 
-    traj = NamedTrajectory(
-        (ψ̃1 = ψ̃1, ψ̃2 = ψ̃2, u = u, Δt = Δt);
-        timestep = :Δt,
-        controls = :u,
-    )
+    traj =
+        NamedTrajectory((ψ̃1 = ψ̃1, ψ̃2 = ψ̃2, u = u, Δt = Δt); timestep = :Δt, controls = :u)
 
     # Goal states for X gate: |0⟩→|1⟩ and |1⟩→|0⟩
     ψ0 = ComplexF64[1.0, 0.0]

--- a/src/control/objectives.jl
+++ b/src/control/objectives.jl
@@ -34,7 +34,25 @@ Create a terminal objective for ket state infidelity, using the goal from `traj.
 function KetInfidelityObjective(ψ̃_name::Symbol, traj::NamedTrajectory; Q = 100.0)
     ψ_goal = iso_to_ket(traj.goal[ψ̃_name])
     ℓ = ψ̃ -> abs(1 - ket_fidelity_loss(ψ̃, ψ_goal))
-    return TerminalObjective(ℓ, ψ̃_name, traj; Q = Q)
+    return TerminalObjective(
+        ℓ, ψ̃_name, traj;
+        Q = Q, knot_hvp = _ket_infidelity_knot_hvp(ψ_goal),
+    )
+end
+
+# Declared matrix-free per-knot HVP for ℓ = |1 − |⟨g|ψ⟩|²| (DTO KnotHVP carrier):
+# with iso layout ψ̃ = [Re(ψ); Im(ψ)], the overlap S = ⟨g|ψ⟩ satisfies
+#   Re(S) = [gᵣ; gᵢ]ᵀψ̃,  Im(S) = [−gᵢ; gᵣ]ᵀψ̃  ⇒  F = ‖A·ψ̃‖² = |S|²
+# so the per-knot Hessian is the CONSTANT rank-2 form Aᵀ·G·A with the
+# `:neg2_sign` link rule G = −2·sign(1−F)·I. Declaring it bypasses the
+# nested-ForwardDiff rank probe and the per-iterate FD refactorization
+# (O(m²) per state term at optimizer scale).
+function _ket_infidelity_knot_hvp(ψ_goal::AbstractVector{<:Complex})
+    gr, gi = real(ψ_goal), imag(ψ_goal)
+    A = Matrix{Float64}(undef, 2, 2 * length(ψ_goal))
+    A[1, :] = vcat(gr, gi)
+    A[2, :] = vcat(-gi, gr)
+    return ConstantLowRankHVP(A, :neg2_sign)
 end
 
 """
@@ -60,7 +78,10 @@ function KetInfidelityObjective(
     Q = 100.0,
 )
     ℓ = ψ̃ -> abs(1 - ket_fidelity_loss(ψ̃, ComplexF64.(ψ_goal)))
-    return TerminalObjective(ℓ, ψ̃_name, traj; Q = Q)
+    return TerminalObjective(
+        ℓ, ψ̃_name, traj;
+        Q = Q, knot_hvp = _ket_infidelity_knot_hvp(ComplexF64.(ψ_goal)),
+    )
 end
 
 # ---------------------------------------------------------

--- a/src/control/objectives.jl
+++ b/src/control/objectives.jl
@@ -34,28 +34,7 @@ Create a terminal objective for ket state infidelity, using the goal from `traj.
 function KetInfidelityObjective(ψ̃_name::Symbol, traj::NamedTrajectory; Q = 100.0)
     ψ_goal = iso_to_ket(traj.goal[ψ̃_name])
     ℓ = ψ̃ -> abs(1 - ket_fidelity_loss(ψ̃, ψ_goal))
-    return TerminalObjective(
-        ℓ,
-        ψ̃_name,
-        traj;
-        Q = Q,
-        knot_hvp = _ket_infidelity_knot_hvp(ψ_goal),
-    )
-end
-
-# Declared matrix-free per-knot HVP for ℓ = |1 − |⟨g|ψ⟩|²| (DTO KnotHVP carrier):
-# with iso layout ψ̃ = [Re(ψ); Im(ψ)], the overlap S = ⟨g|ψ⟩ satisfies
-#   Re(S) = [gᵣ; gᵢ]ᵀψ̃,  Im(S) = [−gᵢ; gᵣ]ᵀψ̃  ⇒  F = ‖A·ψ̃‖² = |S|²
-# so the per-knot Hessian is the CONSTANT rank-2 form Aᵀ·G·A with the
-# `:neg2_sign` link rule G = −2·sign(1−F)·I. Declaring it bypasses the
-# nested-ForwardDiff rank probe and the per-iterate FD refactorization
-# (O(m²) per state term at optimizer scale).
-function _ket_infidelity_knot_hvp(ψ_goal::AbstractVector{<:Complex})
-    gr, gi = real(ψ_goal), imag(ψ_goal)
-    A = Matrix{Float64}(undef, 2, 2 * length(ψ_goal))
-    A[1, :] = vcat(gr, gi)
-    A[2, :] = vcat(-gi, gr)
-    return ConstantLowRankHVP(A, :neg2_sign)
+    return TerminalObjective(ℓ, ψ̃_name, traj; Q = Q)
 end
 
 """
@@ -81,13 +60,7 @@ function KetInfidelityObjective(
     Q = 100.0,
 )
     ℓ = ψ̃ -> abs(1 - ket_fidelity_loss(ψ̃, ComplexF64.(ψ_goal)))
-    return TerminalObjective(
-        ℓ,
-        ψ̃_name,
-        traj;
-        Q = Q,
-        knot_hvp = _ket_infidelity_knot_hvp(ComplexF64.(ψ_goal)),
-    )
+    return TerminalObjective(ℓ, ψ̃_name, traj; Q = Q)
 end
 
 # ---------------------------------------------------------
@@ -153,19 +126,9 @@ function CoherentKetInfidelityObjective(
     ψ̃_names::Vector{Symbol},
     traj::NamedTrajectory;
     Q::Float64 = 100.0,
-    weights::Union{Nothing,Vector{Float64}} = nothing,
 )
     n_states = length(ψ_goals)
     @assert length(ψ̃_names) == n_states "Number of names must match number of goals"
-    # Weighted coherent fidelity: F = |Σᵢ wᵢ⟨gᵢ|ψᵢ⟩ / Σw|². The unweighted
-    # amplitude sum treats every ket equally, so an expensive minority (e.g.
-    # the 2 hard kets of 32 in a C⁴X curriculum) contributes only 2/32 of the
-    # amplitude and gets abandoned at the optimum (measured at i=4). Weights
-    # INSIDE the sum reshape the optimum itself; uniform weights reproduce the
-    # unweighted objective exactly.
-    w = weights === nothing ? ones(n_states) : copy(weights)
-    @assert length(w) == n_states "weights length must match number of states"
-    wsum = sum(w)
 
     # Convert goals to ComplexF64
     goals = [ComplexF64.(g) for g in ψ_goals]
@@ -184,61 +147,13 @@ function CoherentKetInfidelityObjective(
             offset += state_dims[i]
         end
 
-        # Weighted coherent infidelity: 1 − |Σ wᵢ⟨gᵢ|ψᵢ⟩ / Σw|²
-        overlap = sum(w[i] * (goals[i]' * iso_to_ket(ψ̃s[i])) for i = 1:n_states)
-        return abs(1 - abs2(overlap / wsum))
+        # Coherent infidelity: 1 - F_coherent
+        return abs(1 - coherent_ket_fidelity(ψ̃s, goals))
     end
 
-    # Declarable matrix-free per-knot HVP. The coherent loss is exactly
-    # `ℓ = |1 - F|` with `F = ‖A·z‖²`, so the per-knot Hessian factors as
-    # `Aᵀ · G · A` with `G = -2·sign(1 - F)·I_2` (the `:neg2_sign` rule).
-    # Per-ket blocks of A scale by wᵢ/Σw (uniform ⇒ the original 1/K).
-    A = _coherent_ket_lowrank_factor(goals, state_dims, w ./ wsum)
-    cap = ConstantLowRankHVP(A, :neg2_sign)
-
-    # Pass vector of component names for multi-component terminal objective
-    return TerminalObjective(ℓ, ψ̃_names, traj; Q = Q, knot_hvp = cap)
-end
-
-# Build the constant rank-2 factor `A :: Matrix{Float64}` of size
-# `(2, sum(state_dims))` such that `[A·z]_1 = Re(S)`, `[A·z]_2 = Im(S)`,
-# where `S = (1/K) · Σᵢ ⟨gᵢ, ψᵢ⟩` is the coherent overlap and the
-# concatenated iso-state `z = [ψ̃₁; ψ̃₂; …; ψ̃_K]` follows the per-ket
-# `[real(ψᵢ); imag(ψᵢ)]` convention from `ket_to_iso`.
-# Then `‖A·z‖² = |S|² = F` exactly.
-function _coherent_ket_lowrank_factor(
-    goals::AbstractVector{<:AbstractVector{<:Complex}},
-    state_dims::AbstractVector{Int},
-    scales::Union{Nothing,AbstractVector{Float64}} = nothing,
-)
-    K = length(goals)
-    @assert length(state_dims) == K
-    m = sum(state_dims)
-    A = zeros(Float64, 2, m)
-    offset = 0
-    for i = 1:K
-        inv_K = scales === nothing ? 1.0 / K : scales[i]
-        d_iso = state_dims[i]
-        @assert iseven(d_iso) "iso-state $i has odd dim $(d_iso); expected even"
-        d_c = d_iso ÷ 2
-        @assert length(goals[i]) == d_c (
-            "goal $i has $(length(goals[i])) entries; expected $(d_c) " *
-            "(half the iso-state dim)"
-        )
-        re_g = real(goals[i])
-        im_g = imag(goals[i])
-        # Block layout per ket: `ψ̃ᵢ = [Re(ψᵢ); Im(ψᵢ)]` (length d_iso).
-        #   ⟨gᵢ, ψᵢ⟩ = (Re(g) − i·Im(g))ᵀ (Re(ψ) + i·Im(ψ))
-        #             = Re(g)ᵀRe(ψ) + Im(g)ᵀIm(ψ)  +  i (Re(g)ᵀIm(ψ) − Im(g)ᵀRe(ψ))
-        # Row 1 (Re(S)) — scaled by 1/K
-        A[1, offset .+ (1:d_c)] .= inv_K .* re_g
-        A[1, offset .+ ((d_c+1):d_iso)] .= inv_K .* im_g
-        # Row 2 (Im(S)) — scaled by 1/K
-        A[2, offset .+ (1:d_c)] .= -inv_K .* im_g
-        A[2, offset .+ ((d_c+1):d_iso)] .= inv_K .* re_g
-        offset += d_iso
-    end
-    return A
+    # Pass vector of component names for multi-component terminal objective.
+    # (Matrix-free per-knot HVP carrier construction lives in Piccolissimo.)
+    return TerminalObjective(ℓ, ψ̃_names, traj; Q = Q)
 end
 
 # ---------------------------------------------------------
@@ -361,52 +276,14 @@ function unitary_fidelity_loss(Ũ⃗::AbstractVector{<:Real}, op::EmbeddedOpera
 end
 
 function UnitaryInfidelityObjective(
-    U_goal::AbstractPiccoloOperator,  # full-op (AbstractMatrix) gets knot_hvp; EmbeddedOperator stays on fallback
+    U_goal::AbstractPiccoloOperator,
     Ũ⃗_name::Symbol,
     traj::NamedTrajectory;
     Q = 100.0,
 )
-    # Declarable matrix-free per-knot HVP. The full-operator
-    # `ℓ = |1 − |tr(U†_goal · U)|²/n²|` factors exactly as `|1 − ‖A·Ũ⃗‖²|`
-    # with a constant rank-2 `A` (consumer-side rule `:neg2_sign`).
-    # The embedded-operator branch has a different (mixed-regularizer)
-    # form and stays on the dense fallback.
+    # Matrix-free per-knot HVP carrier construction lives in Piccolissimo.
     ℓ = Ũ⃗ -> abs(1 - unitary_fidelity_loss(Ũ⃗, U_goal))
-    cap = if U_goal isa AbstractMatrix{<:Number}
-        ConstantLowRankHVP(_unitary_lowrank_factor(U_goal), :neg2_sign)
-    else
-        nothing
-    end
-    return TerminalObjective(ℓ, Ũ⃗_name, traj; Q = Q, knot_hvp = cap)
-end
-
-# Build the constant rank-2 factor `A :: Matrix{Float64}` of size
-# `(2, 2·n²)` such that `[A·Ũ⃗]_1 = Re(S)/n`, `[A·Ũ⃗]_2 = Im(S)/n`,
-# where `S = tr(U_goal† · U)` and the iso-vec `Ũ⃗` follows the
-# `operator_to_iso_vec` convention: per column i (0-indexed),
-# block of length 2n is `[Re(U[:, i+1]); Im(U[:, i+1])]`.
-# Then `‖A·Ũ⃗‖² = |S|²/n² = F` exactly.
-function _unitary_lowrank_factor(U_goal::AbstractMatrix{<:Number})
-    n = size(U_goal, 1)
-    @assert size(U_goal, 2) == n "U_goal must be square; got $(size(U_goal))"
-    A = zeros(Float64, 2, 2 * n^2)
-    inv_n = 1.0 / n
-    for i = 0:(n-1)
-        col = @view U_goal[:, i+1]
-        re_g = real(col)
-        im_g = imag(col)
-        # Per-column block of `Ũ⃗`: `i*2n + (1:n)` is Re, `i*2n + (n+1:2n)` is Im.
-        #   ⟨gᵢ, Uᵢ⟩ = (Re(g) − i·Im(g))ᵀ (Re(U) + i·Im(U))
-        #             = Re(g)ᵀRe(U) + Im(g)ᵀIm(U)  +  i (Re(g)ᵀIm(U) − Im(g)ᵀRe(U))
-        # Sum over columns gives S = Σᵢ ⟨gᵢ, Uᵢ⟩ = tr(U_goal† U).
-        # Row 1 (Re(S)/n)
-        A[1, i*2n .+ (1:n)] .= inv_n .* re_g
-        A[1, i*2n .+ ((n+1):2n)] .= inv_n .* im_g
-        # Row 2 (Im(S)/n)
-        A[2, i*2n .+ (1:n)] .= -inv_n .* im_g
-        A[2, i*2n .+ ((n+1):2n)] .= inv_n .* re_g
-    end
-    return A
+    return TerminalObjective(ℓ, Ũ⃗_name, traj; Q = Q)
 end
 
 function UnitaryFreePhaseInfidelityObjective(
@@ -757,206 +634,6 @@ end
     # Test gradient
     ∇ = zeros(traj.dim * traj.N + traj.global_dim)
     gradient!(∇, obj, traj)
-end
-
-@testitem "knot_hvp matrix-free apply matches dense Hessian — CoherentKetInfidelityObjective" begin
-    using NamedTrajectories
-    using DirectTrajOpt
-    using DirectTrajOpt.Objectives: knot_hvp, ConstantLowRankHVP, get_full_hessian
-    using TrajectoryIndexingUtils
-    using LinearAlgebra
-    using Random
-
-    Random.seed!(42)
-    N = 10
-    ket_dim = 4  # iso dim for 2-level system
-    u = randn(1, N)
-    Δt = fill(0.1, N)
-    Q = 7.0  # non-default so the scaling threads through
-
-    # K=1 (single-ket) and K=2 (two-ket) — issue #257 AC requires ≥1 and ≥2 goals.
-    goal_bank = [ComplexF64[0.0, 1.0], ComplexF64[1.0, 0.0]]
-
-    for K in (1, 2)
-        goals_K = goal_bank[1:K]
-        names_K = K == 1 ? [:ψ̃1] : [:ψ̃1, :ψ̃2]
-
-        # Build a K-ket trajectory with a scaled copy of the goals at the
-        # terminal knot. `scale < 1` puts F below the kink; `scale > 1`
-        # puts F above.
-        function _make_traj(scale)
-            if K == 1
-                ψ̃1 = randn(ket_dim, N)
-                ψ̃1[:, N] .= scale .* ket_to_iso(goals_K[1])
-                return NamedTrajectory(
-                    (ψ̃1 = ψ̃1, u = u, Δt = Δt);
-                    timestep = :Δt,
-                    controls = :u,
-                )
-            else
-                ψ̃1 = randn(ket_dim, N)
-                ψ̃2 = randn(ket_dim, N)
-                ψ̃1[:, N] .= scale .* ket_to_iso(goals_K[1])
-                ψ̃2[:, N] .= scale .* ket_to_iso(goals_K[2])
-                return NamedTrajectory(
-                    (ψ̃1 = ψ̃1, ψ̃2 = ψ̃2, u = u, Δt = Δt);
-                    timestep = :Δt,
-                    controls = :u,
-                )
-            end
-        end
-
-        for scale in (0.4, 1.2)  # F < 1 and F > 1
-            traj = _make_traj(scale)
-            obj = CoherentKetInfidelityObjective(goals_K, names_K, traj; Q = Q)
-
-            cap = knot_hvp(obj, traj)
-            @test cap isa ConstantLowRankHVP
-            @test cap.core === :neg2_sign
-            @test size(cap.A) == (2, K * ket_dim)
-
-            # Index map for the terminal-knot concatenated iso-state.
-            knot_idx = vcat([slice(N, traj.components[nm], traj.dim) for nm in names_K]...)
-            z = vec(traj)
-            z_k = z[knot_idx]
-
-            # Matrix-free apply at the terminal knot:
-            #   H · v_k = Q · (-2·sign(1-F)) · Aᵀ · (A · v_k)
-            A = cap.A
-            F = sum(abs2, A * z_k)
-            G = -2.0 * sign(1.0 - F)
-            v = randn(length(z))
-            v_k = v[knot_idx]
-            Hv_mf = Q * G * (A' * (A * v_k))
-
-            # Dense apply at the same knot, via Symmetric(get_full_hessian, :U)·v.
-            H_full = Matrix(get_full_hessian(obj, traj))
-            Hv_dense = (Symmetric(H_full, :U)*v)[knot_idx]
-
-            @test Hv_mf ≈ Hv_dense atol = 1e-12
-        end
-    end
-end
-
-@testitem "knot_hvp matrix-free apply matches dense Hessian — UnitaryInfidelityObjective (full-op)" begin
-    using NamedTrajectories
-    using DirectTrajOpt
-    using DirectTrajOpt.Objectives: knot_hvp, ConstantLowRankHVP, get_full_hessian
-    using TrajectoryIndexingUtils
-    using LinearAlgebra
-    using Random
-
-    N = 10
-    u = randn(1, N)
-    Δt = fill(0.1, N)
-    Q = 5.0
-
-    # Issue #248 AC requires coverage across n = 2, 3, 4.
-    for n in (2, 3, 4)
-        Random.seed!(43 + n)             # per-n seed for reproducibility
-        iso_dim = 2 * n^2
-        # Random complex goal (no unitarity required for the parity test).
-        U_goal = randn(ComplexF64, n, n)
-
-        function _make_traj(scale)
-            Utilde = randn(iso_dim, N)
-            Utilde[:, N] .= scale .* operator_to_iso_vec(U_goal)
-            return NamedTrajectory(
-                (Utilde = Utilde, u = u, Δt = Δt);
-                timestep = :Δt,
-                controls = :u,
-            )
-        end
-
-        for scale in (0.4, 1.2)  # F < 1 and F > 1
-            traj = _make_traj(scale)
-            obj = UnitaryInfidelityObjective(U_goal, :Utilde, traj; Q = Q)
-
-            cap = knot_hvp(obj, traj)
-            @test cap isa ConstantLowRankHVP
-            @test cap.core === :neg2_sign
-            @test size(cap.A) == (2, iso_dim)
-
-            knot_idx = slice(N, traj.components[:Utilde], traj.dim)
-            z = vec(traj)
-            z_k = z[knot_idx]
-
-            A = cap.A
-            F = sum(abs2, A * z_k)
-            G = -2.0 * sign(1.0 - F)
-            v = randn(length(z))
-            v_k = v[knot_idx]
-            Hv_mf = Q * G * (A' * (A * v_k))
-
-            H_full = Matrix(get_full_hessian(obj, traj))
-            Hv_dense = (Symmetric(H_full, :U)*v)[knot_idx]
-
-            @test Hv_mf ≈ Hv_dense atol = 1e-12
-        end
-    end
-end
-
-@testitem "knot_hvp returns nothing for EmbeddedOperator UnitaryInfidelityObjective" begin
-    using NamedTrajectories
-    using DirectTrajOpt
-    using DirectTrajOpt.Objectives: knot_hvp
-    using LinearAlgebra
-
-    n_full = 4   # ambient
-    iso_dim = 2 * n_full^2
-    N = 5
-
-    Utilde = randn(iso_dim, N)
-    u = randn(1, N)
-    Δt = fill(0.1, N)
-    traj = NamedTrajectory((Utilde = Utilde, u = u, Δt = Δt); timestep = :Δt, controls = :u)
-
-    # 2x2 X gate embedded in a 4-dim ambient space (subspace = 1:2).
-    op = EmbeddedOperator(ComplexF64[0 1; 1 0], 1:2, n_full)
-    obj = UnitaryInfidelityObjective(op, :Utilde, traj; Q = 1.0)
-
-    # Embedded path stays on the dense fallback — no declared knot_hvp.
-    @test knot_hvp(obj, traj) === nothing
-end
-
-@testitem "knot_hvp field does not leak into KnotPointObjective value/gradient" begin
-    using NamedTrajectories
-    using DirectTrajOpt
-    using DirectTrajOpt.Objectives: ConstantLowRankHVP
-    using LinearAlgebra
-    using Random
-
-    # Issue #257 AC 3 / #248 AC 4: "Value and gradient of the objective are
-    # byte-for-byte unchanged — only the `knot_hvp` field is newly populated."
-    # Construct two `KnotPointObjective`s that differ ONLY in `knot_hvp`
-    # (one `nothing`, one a populated `ConstantLowRankHVP`) and assert
-    # `objective_value` and `gradient!` are literally equal on both.
-
-    Random.seed!(44)
-    N = 10
-    ket_dim = 4
-    ψ̃1 = randn(ket_dim, N)
-    u = randn(1, N)
-    Δt = fill(0.1, N)
-    traj = NamedTrajectory((ψ̃1 = ψ̃1, u = u, Δt = Δt); timestep = :Δt, controls = :u)
-
-    ℓ = x -> sum(x .^ 2) + 0.3 * sum(sin.(x))  # any non-trivial C² loss
-    Q = 7.0
-    fake_A = randn(2, ket_dim)                  # arbitrary; must not affect value/grad
-    cap = ConstantLowRankHVP(fake_A, :neg2_sign)
-
-    obj_none = KnotPointObjective(ℓ, :ψ̃1, traj; Qs = [Q], times = [N], knot_hvp = nothing)
-    obj_pop = KnotPointObjective(ℓ, :ψ̃1, traj; Qs = [Q], times = [N], knot_hvp = cap)
-
-    # Value: literally equal.
-    @test objective_value(obj_none, traj) === objective_value(obj_pop, traj)
-
-    # Gradient: literally equal (elementwise, no tolerance).
-    ∇_none = zeros(traj.dim * traj.N + traj.global_dim)
-    ∇_pop = zeros(traj.dim * traj.N + traj.global_dim)
-    gradient!(∇_none, obj_none, traj)
-    gradient!(∇_pop, obj_pop, traj)
-    @test ∇_none == ∇_pop
 end
 
 end

--- a/src/control/objectives.jl
+++ b/src/control/objectives.jl
@@ -35,8 +35,11 @@ function KetInfidelityObjective(ψ̃_name::Symbol, traj::NamedTrajectory; Q = 10
     ψ_goal = iso_to_ket(traj.goal[ψ̃_name])
     ℓ = ψ̃ -> abs(1 - ket_fidelity_loss(ψ̃, ψ_goal))
     return TerminalObjective(
-        ℓ, ψ̃_name, traj;
-        Q = Q, knot_hvp = _ket_infidelity_knot_hvp(ψ_goal),
+        ℓ,
+        ψ̃_name,
+        traj;
+        Q = Q,
+        knot_hvp = _ket_infidelity_knot_hvp(ψ_goal),
     )
 end
 
@@ -79,8 +82,11 @@ function KetInfidelityObjective(
 )
     ℓ = ψ̃ -> abs(1 - ket_fidelity_loss(ψ̃, ComplexF64.(ψ_goal)))
     return TerminalObjective(
-        ℓ, ψ̃_name, traj;
-        Q = Q, knot_hvp = _ket_infidelity_knot_hvp(ComplexF64.(ψ_goal)),
+        ℓ,
+        ψ̃_name,
+        traj;
+        Q = Q,
+        knot_hvp = _ket_infidelity_knot_hvp(ComplexF64.(ψ_goal)),
     )
 end
 
@@ -543,8 +549,11 @@ using TestItems
     u = randn(1, N)
     Δt = fill(0.1, N)
 
-    traj =
-        NamedTrajectory((ψ̃1 = ψ̃1, ψ̃2 = ψ̃2, u = u, Δt = Δt); timestep = :Δt, controls = :u)
+    traj = NamedTrajectory(
+        (ψ̃1 = ψ̃1, ψ̃2 = ψ̃2, u = u, Δt = Δt);
+        timestep = :Δt,
+        controls = :u,
+    )
 
     # Goal states for X gate: |0⟩→|1⟩ and |1⟩→|0⟩
     ψ0 = ComplexF64[1.0, 0.0]

--- a/src/control/objectives.jl
+++ b/src/control/objectives.jl
@@ -147,9 +147,19 @@ function CoherentKetInfidelityObjective(
     ψ̃_names::Vector{Symbol},
     traj::NamedTrajectory;
     Q::Float64 = 100.0,
+    weights::Union{Nothing,Vector{Float64}} = nothing,
 )
     n_states = length(ψ_goals)
     @assert length(ψ̃_names) == n_states "Number of names must match number of goals"
+    # Weighted coherent fidelity: F = |Σᵢ wᵢ⟨gᵢ|ψᵢ⟩ / Σw|². The unweighted
+    # amplitude sum treats every ket equally, so an expensive minority (e.g.
+    # the 2 hard kets of 32 in a C⁴X curriculum) contributes only 2/32 of the
+    # amplitude and gets abandoned at the optimum (measured at i=4). Weights
+    # INSIDE the sum reshape the optimum itself; uniform weights reproduce the
+    # unweighted objective exactly.
+    w = weights === nothing ? ones(n_states) : copy(weights)
+    @assert length(w) == n_states "weights length must match number of states"
+    wsum = sum(w)
 
     # Convert goals to ComplexF64
     goals = [ComplexF64.(g) for g in ψ_goals]
@@ -168,14 +178,16 @@ function CoherentKetInfidelityObjective(
             offset += state_dims[i]
         end
 
-        # Coherent infidelity: 1 - F_coherent
-        return abs(1 - coherent_ket_fidelity(ψ̃s, goals))
+        # Weighted coherent infidelity: 1 − |Σ wᵢ⟨gᵢ|ψᵢ⟩ / Σw|²
+        overlap = sum(w[i] * (goals[i]' * iso_to_ket(ψ̃s[i])) for i = 1:n_states)
+        return abs(1 - abs2(overlap / wsum))
     end
 
     # Declarable matrix-free per-knot HVP. The coherent loss is exactly
     # `ℓ = |1 - F|` with `F = ‖A·z‖²`, so the per-knot Hessian factors as
     # `Aᵀ · G · A` with `G = -2·sign(1 - F)·I_2` (the `:neg2_sign` rule).
-    A = _coherent_ket_lowrank_factor(goals, state_dims)
+    # Per-ket blocks of A scale by wᵢ/Σw (uniform ⇒ the original 1/K).
+    A = _coherent_ket_lowrank_factor(goals, state_dims, w ./ wsum)
     cap = ConstantLowRankHVP(A, :neg2_sign)
 
     # Pass vector of component names for multi-component terminal objective
@@ -191,14 +203,15 @@ end
 function _coherent_ket_lowrank_factor(
     goals::AbstractVector{<:AbstractVector{<:Complex}},
     state_dims::AbstractVector{Int},
+    scales::Union{Nothing,AbstractVector{Float64}} = nothing,
 )
     K = length(goals)
     @assert length(state_dims) == K
     m = sum(state_dims)
     A = zeros(Float64, 2, m)
-    inv_K = 1.0 / K
     offset = 0
     for i = 1:K
+        inv_K = scales === nothing ? 1.0 / K : scales[i]
         d_iso = state_dims[i]
         @assert iseven(d_iso) "iso-state $i has odd dim $(d_iso); expected even"
         d_c = d_iso ÷ 2

--- a/src/control/templates/smooth_pulse_problem.jl
+++ b/src/control/templates/smooth_pulse_problem.jl
@@ -645,7 +645,23 @@ function _ensemble_ket_objective(
 )
     if coherent
         # Use coherent fidelity - phases must align for gate implementation
-        return CoherentKetInfidelityObjective(goals, snames, traj; Q = Q)
+        obj = CoherentKetInfidelityObjective(goals, snames, traj; Q = Q)
+        # Anchored coherent: the plain coherent overlap treats all kets equally
+        # and will abandon an expensive minority (measured at i=4 Stage-2: hard
+        # kets 0.9997 → 0.0018 while the 30 easy kets aligned — the same
+        # collapse behind the historical i=3 0.765 ceiling). Kets with weight
+        # above the minimum get DEDICATED per-ket anchor terms (phase-free,
+        # cannot be cancelled by the majority's gradient), scaled by the excess
+        # weight. Uniform weights ⇒ unchanged behavior.
+        wmin = minimum(weights)
+        anchors = [i for i in eachindex(weights) if weights[i] > wmin]
+        if !isempty(anchors)
+            obj += sum(
+                KetInfidelityObjective(goals[i], snames[i], traj;
+                    Q = (weights[i] - wmin) * Q) for i in anchors
+            )
+        end
+        return obj
     else
         # Use individual fidelity - each state optimized independently
         # Useful for cold-start on gates with negative phases (e.g. CZ)

--- a/src/control/templates/smooth_pulse_problem.jl
+++ b/src/control/templates/smooth_pulse_problem.jl
@@ -644,14 +644,8 @@ function _ensemble_ket_objective(
     coherent::Bool = true,
 )
     if coherent
-        # WEIGHTED coherent fidelity: weights go INSIDE the amplitude sum
-        # (F = |Σ wᵢ⟨gᵢ|ψᵢ⟩/Σw|²), reshaping the optimum itself. The unweighted
-        # sum abandons an expensive minority (measured at i=4 Stage-2: hard kets
-        # 0.9997 → 0.002 while 30 easy kets aligned — the same collapse behind
-        # the historical i=3 0.765 ceiling); external per-ket anchor terms wedge
-        # the solver when already satisfied. Uniform weights ⇒ the original
-        # objective exactly.
-        return CoherentKetInfidelityObjective(goals, snames, traj; Q = Q, weights = weights)
+        # Use coherent fidelity - phases must align for gate implementation
+        return CoherentKetInfidelityObjective(goals, snames, traj; Q = Q)
     else
         # Use individual fidelity - each state optimized independently
         # Useful for cold-start on gates with negative phases (e.g. CZ)

--- a/src/control/templates/smooth_pulse_problem.jl
+++ b/src/control/templates/smooth_pulse_problem.jl
@@ -651,8 +651,7 @@ function _ensemble_ket_objective(
         # the historical i=3 0.765 ceiling); external per-ket anchor terms wedge
         # the solver when already satisfied. Uniform weights ⇒ the original
         # objective exactly.
-        return CoherentKetInfidelityObjective(goals, snames, traj;
-            Q = Q, weights = weights)
+        return CoherentKetInfidelityObjective(goals, snames, traj; Q = Q, weights = weights)
     else
         # Use individual fidelity - each state optimized independently
         # Useful for cold-start on gates with negative phases (e.g. CZ)

--- a/src/control/templates/smooth_pulse_problem.jl
+++ b/src/control/templates/smooth_pulse_problem.jl
@@ -644,24 +644,15 @@ function _ensemble_ket_objective(
     coherent::Bool = true,
 )
     if coherent
-        # Use coherent fidelity - phases must align for gate implementation
-        obj = CoherentKetInfidelityObjective(goals, snames, traj; Q = Q)
-        # Anchored coherent: the plain coherent overlap treats all kets equally
-        # and will abandon an expensive minority (measured at i=4 Stage-2: hard
-        # kets 0.9997 → 0.0018 while the 30 easy kets aligned — the same
-        # collapse behind the historical i=3 0.765 ceiling). Kets with weight
-        # above the minimum get DEDICATED per-ket anchor terms (phase-free,
-        # cannot be cancelled by the majority's gradient), scaled by the excess
-        # weight. Uniform weights ⇒ unchanged behavior.
-        wmin = minimum(weights)
-        anchors = [i for i in eachindex(weights) if weights[i] > wmin]
-        if !isempty(anchors)
-            obj += sum(
-                KetInfidelityObjective(goals[i], snames[i], traj;
-                    Q = (weights[i] - wmin) * Q) for i in anchors
-            )
-        end
-        return obj
+        # WEIGHTED coherent fidelity: weights go INSIDE the amplitude sum
+        # (F = |Σ wᵢ⟨gᵢ|ψᵢ⟩/Σw|²), reshaping the optimum itself. The unweighted
+        # sum abandons an expensive minority (measured at i=4 Stage-2: hard kets
+        # 0.9997 → 0.002 while 30 easy kets aligned — the same collapse behind
+        # the historical i=3 0.765 ceiling); external per-ket anchor terms wedge
+        # the solver when already satisfied. Uniform weights ⇒ the original
+        # objective exactly.
+        return CoherentKetInfidelityObjective(goals, snames, traj;
+            Q = Q, weights = weights)
     else
         # Use individual fidelity - each state optimized independently
         # Useful for cold-start on gates with negative phases (e.g. CZ)


### PR DESCRIPTION
## Move matrix-free HVP carrier construction out of public Piccolo → Piccolissimo

Public Piccolo should carry only objective/loss definitions, not the solver-specific matrix-free per-knot HVP construction. That construction (and its consumer) belongs in Piccolissimo's `altissimo_backend.jl`. This PR **removes all matrix-free carrier code from Piccolo**; the construction moves to **harmoniqs/Piccolissimo.jl#214** (`FidelityCarriers` module), which this pairs with.

### Removed from `src/control/objectives.jl`
- `_ket_infidelity_knot_hvp` (added earlier in this PR's history) — ket-infidelity rank-2 factor.
- `_coherent_ket_lowrank_factor` and `_unitary_lowrank_factor` (pre-existing on `main`) — coherent-ket and unitary rank-2 factors.
- Every `knot_hvp = …` attachment on `KetInfidelityObjective`, `CoherentKetInfidelityObjective`, `UnitaryInfidelityObjective`.
- The `weights` kwarg on `CoherentKetInfidelityObjective` (weighted variant now lives in Piccolissimo).
- The 4 `knot_hvp` matrix-free testitems.

### Result
Piccolo objectives are **carrier-free** — `knot_hvp(obj, traj) === nothing` — carrying only the loss physics, exactly as before the carrier work. Correctness is unchanged: outside the Altissimo backend a carrier-free objective takes the dense/ForwardDiff HVP.

**No speed regression for default solver runs.** When a carrier-free ket / coherent-ket / full-op unitary objective goes through the Altissimo backend (harmoniqs/Piccolissimo.jl#214), the backend now **auto-attaches** the analytic rank-2 carrier: it rebuilds and self-validates the factor from the trajectory goals — bit-identical to the old declared carrier — so ALL THREE objective types that declared carriers on `main` (ket, coherent-ket, full-op unitary) keep the pre-refactor wall time at any problem size and skip the expensive nested-ForwardDiff rank probe. `EmbeddedOperator` unitaries stay on the fallback — exact parity with `main`, which also never gave them a carrier. Verified end-to-end: i=2 default run (carrier-free objective + auto-attach) reproduces the pre-refactor solve **bit-identically** — fid 0.99930377 to all printed digits, outer trajectory identical, wall 887.6 s vs banked 909.5 s. Campaign runs needing the weighted-coherent objective build it explicitly from Piccolissimo's `FidelityCarriers` constructors. The backend consumption seam (`knot_hvp(obj, template)`) is untouched.

Verified (rqpnn `validate_carrier_refactor.jl`): Piccolo coherent objective carrier-free; Piccolissimo constructors attach `ConstantLowRankHVP`; ket + weighted-coherent F-form and Hessian identities vs ForwardDiff at 4.4e-16 / 1.1e-16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


