### PR TITLE
T0: convenience trajectory ctors are random (not zero); add seedable rng

### DIFF
--- a/src/quantum/trajectories/_quantum_trajectories.jl
+++ b/src/quantum/trajectories/_quantum_trajectories.jl
@@ -1,6 +1,7 @@
 module QuantumTrajectories
 
 using Distributions: Uniform
+using Random: AbstractRNG, default_rng
 using LinearAlgebra
 using OrdinaryDiffEqLinear
 using OrdinaryDiffEqTsit5

--- a/src/quantum/trajectories/density_trajectory.jl
+++ b/src/quantum/trajectories/density_trajectory.jl
@@ -69,7 +69,8 @@ end
 """
     DensityTrajectory(system, initial, goal, T::Real; drive_name=:u, algorithm=Tsit5(), abstol=1e-8, reltol=1e-8)
 
-Convenience constructor that creates a zero pulse of duration T.
+Convenience constructor that creates a random pulse of duration T
+(each drive sampled uniformly within its `drive_bounds`; pass `rng` for reproducibility).
 """
 function DensityTrajectory(
     system::OpenQuantumSystem,
@@ -80,9 +81,11 @@ function DensityTrajectory(
     algorithm = Tsit5(),
     abstol::Real = 1e-8,
     reltol::Real = 1e-8,
+    rng::AbstractRNG = default_rng(),
 )
     times = [0.0, T]
-    controls = vcat([rand(Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
+    controls =
+        vcat([rand(rng, Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
     pulse = ZeroOrderPulse(controls, times; drive_name)
     return DensityTrajectory(system, pulse, initial, goal; algorithm, abstol, reltol)
 end

--- a/src/quantum/trajectories/ensemble_trajectory.jl
+++ b/src/quantum/trajectories/ensemble_trajectory.jl
@@ -179,7 +179,8 @@ end
 """
     MultiKetTrajectory(system, initials, goals, T::Real; weights=..., drive_name=:u, algorithm=MagnusAdapt4(), abstol=1e-8, reltol=1e-8)
 
-Convenience constructor that creates a zero pulse of duration T.
+Convenience constructor that creates a random pulse of duration T
+(each drive sampled uniformly within its `drive_bounds`; pass `rng` for reproducibility).
 
 # Arguments
 - `system::QuantumSystem`: The quantum system
@@ -205,9 +206,11 @@ function MultiKetTrajectory(
     abstol::Real = 1e-8,
     reltol::Real = 1e-8,
     rollout::Symbol = :cpu,
+    rng::AbstractRNG = default_rng(),
 )
     times = [0.0, T]
-    controls = vcat([rand(Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
+    controls =
+        vcat([rand(rng, Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
     pulse = ZeroOrderPulse(controls, times; drive_name)
     return MultiKetTrajectory(
         system,

--- a/src/quantum/trajectories/ket_trajectory.jl
+++ b/src/quantum/trajectories/ket_trajectory.jl
@@ -73,7 +73,8 @@ end
 """
     KetTrajectory(system, initial, goal, T::Real; drive_name=:u, algorithm=MagnusAdapt4(), abstol=1e-8, reltol=1e-8)
 
-Convenience constructor that creates a zero pulse of duration T.
+Convenience constructor that creates a random pulse of duration T
+(each drive sampled uniformly within its `drive_bounds`; pass `rng` for reproducibility).
 
 # Arguments
 - `system::QuantumSystem`: The quantum system
@@ -96,9 +97,11 @@ function KetTrajectory(
     algorithm = nothing,
     abstol::Real = 1e-8,
     reltol::Real = 1e-8,
+    rng::AbstractRNG = default_rng(),
 )
     times = [0.0, T]
-    controls = vcat([rand(Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
+    controls =
+        vcat([rand(rng, Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
     pulse = ZeroOrderPulse(controls, times; drive_name)
     return KetTrajectory(system, pulse, initial, goal; algorithm, abstol, reltol)
 end

--- a/src/quantum/trajectories/multi_density_trajectory.jl
+++ b/src/quantum/trajectories/multi_density_trajectory.jl
@@ -97,7 +97,8 @@ end
 """
     MultiDensityTrajectory(system, initials, goals, T::Real; weights=..., drive_name=:u, algorithm=Tsit5(), abstol=1e-8, reltol=1e-8)
 
-Convenience constructor that creates a zero pulse of duration T.
+Convenience constructor that creates a random pulse of duration T
+(each drive sampled uniformly within its `drive_bounds`; pass `rng` for reproducibility).
 
 # Arguments
 - `system::OpenQuantumSystem`: The open quantum system
@@ -122,9 +123,11 @@ function MultiDensityTrajectory(
     algorithm = Tsit5(),
     abstol::Real = 1e-8,
     reltol::Real = 1e-8,
+    rng::AbstractRNG = default_rng(),
 )
     times = [0.0, T]
-    controls = vcat([rand(Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
+    controls =
+        vcat([rand(rng, Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
     pulse = ZeroOrderPulse(controls, times; drive_name)
     return MultiDensityTrajectory(
         system,

--- a/src/quantum/trajectories/unitary_trajectory.jl
+++ b/src/quantum/trajectories/unitary_trajectory.jl
@@ -80,7 +80,8 @@ end
 """
     UnitaryTrajectory(system, goal, T::Real; drive_name=:u, algorithm=MagnusAdapt4(), abstol=1e-8, reltol=1e-8)
 
-Convenience constructor that creates a zero pulse of duration T.
+Convenience constructor that creates a random pulse of duration T
+(each drive sampled uniformly within its `drive_bounds`; pass `rng` for reproducibility).
 
 # Arguments
 - `system::QuantumSystem`: The quantum system
@@ -101,9 +102,11 @@ function UnitaryTrajectory(
     algorithm = nothing,
     abstol::Real = 1e-8,
     reltol::Real = 1e-8,
+    rng::AbstractRNG = default_rng(),
 )
     times = [0.0, T]
-    controls = vcat([rand(Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
+    controls =
+        vcat([rand(rng, Uniform(b...), 1, length(times)) for b in system.drive_bounds]...)
     pulse = ZeroOrderPulse(controls, times; drive_name)
     return UnitaryTrajectory(system, pulse, goal; algorithm, abstol, reltol)
 end
@@ -367,4 +370,19 @@ end
     )
 
     @test fid_adapt ≈ fid_gl4_fine atol = 1e-6
+end
+
+@testitem "convenience UnitaryTrajectory ctor is rng-reproducible" begin
+    using Piccolo
+    using Random: MersenneTwister
+
+    σx = ComplexF64[0 1; 1 0]
+    σz = ComplexF64[1 0; 0 -1]
+    sys = QuantumSystem(0.1σz, [σx], [1.0])
+    goal = ComplexF64[0 1; 1 0]   # X gate
+
+    # The convenience ctor draws a RANDOM pulse; a supplied rng makes it reproducible.
+    controls(rng) = sample(get_pulse(UnitaryTrajectory(sys, goal, 1.0; rng = rng)), 8)[1]
+    @test controls(MersenneTwister(0)) == controls(MersenneTwister(0))   # same seed → identical
+    @test controls(MersenneTwister(0)) != controls(MersenneTwister(1))   # different seed → differs
 end


### PR DESCRIPTION
T0 defect from the API-ergonomics program (spec [armonissima#33](https://github.com/harmoniqs/armonissima/pull/33), tier **T0**). Additive `[A]`.

## What

All five `XTrajectory(system, …, T::Real; …)` convenience constructors (Unitary/Ket/MultiKet/Density/MultiDensity) document **"creates a zero pulse of duration T"** but actually draw `rand(Uniform(drive_bounds…))` — and **unseeded**, so construction was non-reproducible while claiming to be a fixed zero pulse.

## Change

- **Docstrings corrected** to say a random pulse is drawn (uniform within each drive's bounds).
- Added **`rng::AbstractRNG = default_rng()`** kwarg to each convenience ctor, threaded into the draw. Default preserves current behavior; a supplied `rng` makes it reproducible.
- `using Random: AbstractRNG, default_rng` added to the `QuantumTrajectories` module.

## Testing

```
TEST_FILTER="convenience UnitaryTrajectory ctor is rng-reproducible" julia --startup-file=no --project=. <filtered>
→ Test Summary: Package | Pass 2  Total 2
```
(same seed → identical controls; different seed → differ; plus the file's existing testitem.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)