### PR TITLE
feat(frames): system-agnostic frame-transformation layer + TransmonSystem.lab_frame carrier fix

### DIFF
--- a/src/quantum/_quantum.jl
+++ b/src/quantum/_quantum.jl
@@ -58,6 +58,10 @@ include("operators/direct_sums.jl")
 include("system_utils.jl")
 @reexport using .QuantumSystemUtils
 
+# Frames (depends on systems, operators, object utils)
+include("frames/_frames.jl")
+@reexport using .Frames
+
 # Dynamics
 include("dynamics.jl")
 @reexport using .Rollouts

--- a/src/quantum/frames/_frames.jl
+++ b/src/quantum/frames/_frames.jl
@@ -1,3 +1,32 @@
+"""
+    Frames
+
+System-agnostic frame transformations for `QuantumSystem`s. A frame is defined by
+its generator ``H_f = \\sum_i \\omega_i n_i`` (per-subsystem frame frequencies).
+
+- [`RotatingFrame`](@ref) / [`LabFrame`](@ref) — frame descriptors.
+- [`FrameSpec`](@ref) — the subsystem/drive metadata (`number_ops`, `drive_map`,
+  `drive_ops`) the transforms read; auto-derivable from a `CompositeQuantumSystem`
+  or a matrix-drive `QuantumSystem`.
+- [`to_lab_frame`](@ref) — rotating → **lab**: adds the frame generator back into
+  the drift and reconstructs each quadrature pair `(u_x, u_y)` as a carrier-
+  modulated real field ``\\Omega\\cos(\\omega_d t + \\phi)(a+a^\\dagger)``. Returns a
+  `time_dependent=true` `QuantumSystem` rolled through the `Rollouts` **ODE** path
+  (not `SplineIntegrator`).
+- [`to_rotating_frame`](@ref) — the RWA inverse.
+
+# Example
+```julia
+levels = 3; a = annihilate(levels)
+Hx = 0.5 * Matrix(a + a'); Hy = 0.5 * Matrix(im * (a' - a))
+sys_rot = QuantumSystem(0.5 * (-0.2) * Matrix(a' * a' * a * a), [Hx, Hy], [0.05, 0.05])
+spec = FrameSpec(number_ops = [Matrix(a' * a)],
+                 drive_map = [(1, :x, +1.0), (1, :y, +1.0)], drive_ops = [Hx, Hy])
+sys_lab = to_lab_frame(sys_rot, RotatingFrame(4.0), spec)     # carrier-modulated device
+# roll the lab-frame (time-dependent) system via the ODE path:
+qtraj = UnitaryTrajectory(sys_lab, pulse, U_goal)             # default MagnusAdapt4()
+```
+"""
 module Frames
 
 using LinearAlgebra

--- a/src/quantum/frames/_frames.jl
+++ b/src/quantum/frames/_frames.jl
@@ -13,6 +13,7 @@ include("frame_transforms.jl")
 
 # exports added incrementally in A1–A3:
 export AbstractFrame, RotatingFrame, LabFrame, FrameSpec
-# export to_lab_frame, to_rotating_frame
+export to_lab_frame
+# export to_rotating_frame
 
 end

--- a/src/quantum/frames/_frames.jl
+++ b/src/quantum/frames/_frames.jl
@@ -1,0 +1,17 @@
+module Frames
+
+using LinearAlgebra
+using SparseArrays
+using ..QuantumSystems       # QuantumSystem, CompositeQuantumSystem, AbstractDrive, LinearDrive
+import ..QuantumSystems: drive_matrix   # materialize an AbstractDrive's operator matrix
+using ..QuantumObjectUtils   # annihilate
+using ..LiftedOperators      # lift_operator
+
+include("frame_types.jl")
+include("frame_transforms.jl")
+
+# exports added incrementally in A1–A3:
+# export AbstractFrame, RotatingFrame, LabFrame, FrameSpec
+# export to_lab_frame, to_rotating_frame
+
+end

--- a/src/quantum/frames/_frames.jl
+++ b/src/quantum/frames/_frames.jl
@@ -14,6 +14,6 @@ include("frame_transforms.jl")
 # exports added incrementally in A1–A3:
 export AbstractFrame, RotatingFrame, LabFrame, FrameSpec
 export to_lab_frame
-# export to_rotating_frame
+export to_rotating_frame
 
 end

--- a/src/quantum/frames/_frames.jl
+++ b/src/quantum/frames/_frames.jl
@@ -2,6 +2,7 @@ module Frames
 
 using LinearAlgebra
 using SparseArrays
+using TestItems             # @testitem (no-op during normal package load)
 using ..QuantumSystems       # QuantumSystem, CompositeQuantumSystem, AbstractDrive, LinearDrive
 import ..QuantumSystems: drive_matrix   # materialize an AbstractDrive's operator matrix
 using ..QuantumObjectUtils   # annihilate
@@ -11,7 +12,7 @@ include("frame_types.jl")
 include("frame_transforms.jl")
 
 # exports added incrementally in A1–A3:
-# export AbstractFrame, RotatingFrame, LabFrame, FrameSpec
+export AbstractFrame, RotatingFrame, LabFrame, FrameSpec
 # export to_lab_frame, to_rotating_frame
 
 end

--- a/src/quantum/frames/frame_transforms.jl
+++ b/src/quantum/frames/frame_transforms.jl
@@ -58,7 +58,9 @@ function to_lab_frame(sys_rot::QuantumSystem, frame::RotatingFrame, spec::FrameS
             ωd = ω_of_sub[sub]
             if kind === :pair
                 ux = sx * u[ix]; uy = sy * u[iy]
-                Ω = sqrt(ux^2 + uy^2); φ = atan(uy, ux)
+                # RWA of Ω cos(ωt+φ)(a+a†) = Ω cosφ·Hx − Ω sinφ·Hy, so matching
+                # u_x·Hx + u_y·Hy ⇒ u_x = Ω cosφ, u_y = −Ω sinφ ⇒ φ = atan2(−u_y, u_x).
+                Ω = sqrt(ux^2 + uy^2); φ = atan(-uy, ux)
                 H += Ω * cos(ωd * t + φ) * (2 * ops[ix])
             else  # :real — the op IS already the physical field; modulate directly (no 2×)
                 H += (sx * u[ix]) * cos(ωd * t) * ops[ix]
@@ -202,5 +204,55 @@ end
 
     for u in ([0.0, 0.0], [0.03, 0.0], [0.0, 0.02], [0.02, -0.03]), t in (0.0, 1.3, 7.1)
         @test norm(Matrix(back.H(u, t)) - Matrix(sys_rot.H(u, t))) < 1e-8
+    end
+end
+
+@testitem "frames: lab-frame reproduces rotating-frame evolution as Ω_max/ω_d → 0" begin
+    using Piccolo
+    using LinearAlgebra
+    using OrdinaryDiffEqLinear: MagnusAdapt4     # not re-exported by Piccolo
+    levels = 3
+    a = annihilate(levels)
+    nop = Matrix(a' * a)
+    Hx = 0.5 * Matrix(a + a'); Hy = 0.5 * Matrix(im * (a' - a))
+    α = -0.2
+    sys_rot = QuantumSystem(0.5 * α * Matrix(a' * a' * a * a), [Hx, Hy], [1.0, 1.0])
+    spec = FrameSpec(number_ops = [nop], drive_map = [(1, :x, +1.0), (1, :y, +1.0)],
+                     drive_ops = [Hx, Hy])
+
+    T = 40.0; N = 41
+    times = collect(range(0.0, T, length = N))
+    Ωmax = π / T
+    u = zeros(2, N); u[1, :] .= Ωmax; u[2, :] .= 0.4 * Ωmax   # both quadratures (pins φ sign)
+    pulse = ZeroOrderPulse(u, times)
+    Xgoal = EmbeddedOperator(GATES[:X], sys_rot)   # an X pulse in the rotating frame
+
+    # Reference: the rotating-frame propagator — the physics the lab must reproduce.
+    U_rwa = UnitaryTrajectory(sys_rot, pulse, Xgoal;
+                              algorithm = MagnusAdapt4()).solution.u[end]
+
+    # METRIC NOTE — the original plan compared `fidelity(...)`-to-X for lab vs rot, but
+    # that cannot test the carrier physics here:
+    #   (1) the lab drift ω_d·n makes U_lab(T) = e^{-iω_d T n} U_rot(T); with ω_d·T
+    #       incommensurate with 2π this frame precession scrambles fixed-phase fidelity
+    #       (it never converges, for ANY factor/sign);
+    #   (2) an X goal is conjugation-symmetric, so fidelity-to-X is BLIND to the carrier
+    #       phase sign (φ → −φ is a complex conjugation that preserves |tr(X'U)|).
+    # Instead we test the intent directly: de-rotate the lab propagator by the exactly
+    # known frame rotation e^{+iω_d T n} to recover the rotating-frame evolution, and
+    # require it to converge to U_rwa. This operator distance pins BOTH the ½-quadrature
+    # (2×) field factor and the atan phase sign — every wrong factor/sign leaves a
+    # residual ‖ΔU‖ ≈ O(1) that does not shrink with ω_d (verified: only the 2×,
+    # φ=atan(−u_y,u_x) combination converges; the other three plateau at 1.1–1.6).
+    prev = Ref(Inf)   # Ref so the loop-body assignment survives testitem soft scope
+    for ωd in (40.0, 400.0)                    # increasing carrier ⇒ Ωmax/ωd → 0
+        sys_lab = to_lab_frame(sys_rot, RotatingFrame(ωd), spec)
+        U_lab = UnitaryTrajectory(sys_lab, pulse, Xgoal;
+                    algorithm = MagnusAdapt4(), abstol = 1e-10, reltol = 1e-10).solution.u[end]
+        U_derot = exp(im * ωd * T * nop) * U_lab   # back to the rotating frame at t=T
+        gap = norm(U_derot - U_rwa)
+        @test gap < (ωd ≥ 400.0 ? 1e-3 : 5e-2)   # converges as ωd grows
+        @test gap < prev[]                        # monotone shrink ⇒ carrier physics correct
+        prev[] = gap
     end
 end

--- a/src/quantum/frames/frame_transforms.jl
+++ b/src/quantum/frames/frame_transforms.jl
@@ -1,0 +1,2 @@
+# frame_transforms.jl — to_lab_frame / to_rotating_frame + drive reconstruction.
+# (Populated in Tasks A2–A3.)

--- a/src/quantum/frames/frame_transforms.jl
+++ b/src/quantum/frames/frame_transforms.jl
@@ -6,8 +6,9 @@ export to_lab_frame
 # Group physical drive indices by subsystem into quadrature pairs / lone reals.
 # Returns Vector of (subsystem, kind, ix, iy, sx, sy) where kind ∈ (:pair, :real).
 function _grouped_drives(spec::FrameSpec, n_drives::Int)
-    length(spec.drive_map) == n_drives ||
-        error("FrameSpec drive_map has $(length(spec.drive_map)) entries; system has $n_drives drives")
+    length(spec.drive_map) == n_drives || error(
+        "FrameSpec drive_map has $(length(spec.drive_map)) entries; system has $n_drives drives",
+    )
     groups = Any[]
     pending = Dict{Int,Tuple{Int,Float64}}()   # subsystem => (x-index, x-sign) awaiting its :y
     for (k, (sub, q, sg)) in enumerate(spec.drive_map)
@@ -17,14 +18,19 @@ function _grouped_drives(spec::FrameSpec, n_drives::Int)
             haskey(pending, sub) && error("two :x drives on subsystem $sub without a :y")
             pending[sub] = (k, sg)
         elseif q === :y
-            haskey(pending, sub) || error("drive $k is :y on subsystem $sub but no preceding :x — a single quadrature cannot form (Ω, φ); mark it :real to carrier-modulate directly")
-            (ix, sx) = pending[sub]; delete!(pending, sub)
+            haskey(pending, sub) || error(
+                "drive $k is :y on subsystem $sub but no preceding :x — a single quadrature cannot form (Ω, φ); mark it :real to carrier-modulate directly",
+            )
+            (ix, sx) = pending[sub]
+            delete!(pending, sub)
             push!(groups, (sub, :pair, ix, k, sx, sg))
         else
             error("unknown quadrature $q (expected :x, :y, :real)")
         end
     end
-    isempty(pending) || error("unpaired :x drive(s) on subsystem(s) $(collect(keys(pending))) — a single quadrature cannot form (Ω, φ); mark :real to carrier-modulate directly")
+    isempty(pending) || error(
+        "unpaired :x drive(s) on subsystem(s) $(collect(keys(pending))) — a single quadrature cannot form (Ω, φ); mark :real to carrier-modulate directly",
+    )
     return groups
 end
 
@@ -47,23 +53,28 @@ function to_lab_frame(sys_rot::QuantumSystem, frame::AbstractFrame, spec::FrameS
     n_sub = length(spec.number_ops)
     ωs = frame_frequencies(frame, n_sub)
 
-    Hf = sum(ωs[i] * spec.number_ops[i] for i in 1:n_sub; init = zeros(ComplexF64, levels, levels))
+    Hf = sum(
+        ωs[i] * spec.number_ops[i] for i = 1:n_sub;
+        init = zeros(ComplexF64, levels, levels),
+    )
     H_rot_drift = Matrix{ComplexF64}(sys_rot.H(zeros(sys_rot.n_drives), 0.0))
     H_lab_drift = H_rot_drift + Hf
 
     ops = spec.drive_ops
     groups = _grouped_drives(spec, sys_rot.n_drives)
-    ω_of_sub = Dict(i => ωs[i] for i in 1:n_sub)
+    ω_of_sub = Dict(i => ωs[i] for i = 1:n_sub)
 
     function H_lab(u, t)
         H = copy(H_lab_drift)
         for (sub, kind, ix, iy, sx, sy) in groups
             ωd = ω_of_sub[sub]
             if kind === :pair
-                ux = sx * u[ix]; uy = sy * u[iy]
+                ux = sx * u[ix]
+                uy = sy * u[iy]
                 # RWA of Ω cos(ωt+φ)(a+a†) = Ω cosφ·Hx − Ω sinφ·Hy, so matching
                 # u_x·Hx + u_y·Hy ⇒ u_x = Ω cosφ, u_y = −Ω sinφ ⇒ φ = atan2(−u_y, u_x).
-                Ω = sqrt(ux^2 + uy^2); φ = atan(-uy, ux)
+                Ω = sqrt(ux^2 + uy^2)
+                φ = atan(-uy, ux)
                 H += Ω * cos(ωd * t + φ) * (2 * ops[ix])
             else  # :real — the op IS already the physical field; modulate directly (no 2×)
                 H += (sx * u[ix]) * cos(ωd * t) * ops[ix]
@@ -72,9 +83,13 @@ function to_lab_frame(sys_rot::QuantumSystem, frame::AbstractFrame, spec::FrameS
         return H
     end
 
-    return QuantumSystem(H_lab, sys_rot.drive_bounds; time_dependent = true,
-                         global_params = sys_rot.global_params,
-                         hermitian = sys_rot.hermitian)
+    return QuantumSystem(
+        H_lab,
+        sys_rot.drive_bounds;
+        time_dependent = true,
+        global_params = sys_rot.global_params,
+        hermitian = sys_rot.hermitian,
+    )
 end
 
 """
@@ -91,7 +106,10 @@ function to_lab_frame(comp::CompositeQuantumSystem, frame::RotatingFrame, spec::
     n_sub = length(spec.number_ops)
     ωs = frame_frequencies(frame, n_sub)
 
-    Hf = sum(ωs[i] * spec.number_ops[i] for i in 1:n_sub; init = zeros(ComplexF64, levels, levels))
+    Hf = sum(
+        ωs[i] * spec.number_ops[i] for i = 1:n_sub;
+        init = zeros(ComplexF64, levels, levels),
+    )
     H_rot_drift = Matrix{ComplexF64}(comp.H(zeros(comp.n_drives), 0.0))
     H_lab_drift = H_rot_drift + Hf
 
@@ -103,8 +121,10 @@ function to_lab_frame(comp::CompositeQuantumSystem, frame::RotatingFrame, spec::
         for (sub, kind, ix, iy, sx, sy) in groups
             ωd = ωs[sub]
             if kind === :pair
-                ux = sx * u[ix]; uy = sy * u[iy]
-                Ω = sqrt(ux^2 + uy^2); φ = atan(-uy, ux)
+                ux = sx * u[ix]
+                uy = sy * u[iy]
+                Ω = sqrt(ux^2 + uy^2)
+                φ = atan(-uy, ux)
                 H += Ω * cos(ωd * t + φ) * (2 * ops[ix])
             else
                 H += (sx * u[ix]) * cos(ωd * t) * ops[ix]
@@ -128,12 +148,19 @@ quadrature pair `(u_x, u_y)` (dropping the counter-rotating e^{±2iωt} terms) �
 time-independent rotating-frame `QuantumSystem`. `rwa=false` retains explicit
 time-dependence.
 """
-function to_rotating_frame(sys_lab::QuantumSystem, frame::RotatingFrame, spec::FrameSpec;
-                           rwa::Bool = true)
+function to_rotating_frame(
+    sys_lab::QuantumSystem,
+    frame::RotatingFrame,
+    spec::FrameSpec;
+    rwa::Bool = true,
+)
     levels = sys_lab.levels
     n_sub = length(spec.number_ops)
     ωs = frame_frequencies(frame, n_sub)
-    Hf = sum(ωs[i] * spec.number_ops[i] for i in 1:n_sub; init = zeros(ComplexF64, levels, levels))
+    Hf = sum(
+        ωs[i] * spec.number_ops[i] for i = 1:n_sub;
+        init = zeros(ComplexF64, levels, levels),
+    )
     H_lab_drift = Matrix{ComplexF64}(sys_lab.H(zeros(sys_lab.n_drives), 0.0))
     H_rot_drift = H_lab_drift - Hf
 
@@ -148,9 +175,11 @@ function to_rotating_frame(sys_lab::QuantumSystem, frame::RotatingFrame, spec::F
             for (sub, kind, ix, iy, sx, sy) in groups
                 ωd = ωs[sub]
                 if kind === :pair
-                    ux = sx * u[ix]; uy = sy * u[iy]
+                    ux = sx * u[ix]
+                    uy = sy * u[iy]
                     # φ sign matches the forward to_lab_frame convention: atan(−uy, ux).
-                    Ω = sqrt(ux^2 + uy^2); φ = atan(-uy, ux)
+                    Ω = sqrt(ux^2 + uy^2)
+                    φ = atan(-uy, ux)
                     H += Ω * cos(ωd * t + φ) * (2 * ops[ix])
                 else
                     H += (sx * u[ix]) * cos(ωd * t) * ops[ix]
@@ -158,8 +187,13 @@ function to_rotating_frame(sys_lab::QuantumSystem, frame::RotatingFrame, spec::F
             end
             return H
         end
-        return QuantumSystem(H_full, sys_lab.drive_bounds; time_dependent = true,
-                             global_params = sys_lab.global_params, hermitian = sys_lab.hermitian)
+        return QuantumSystem(
+            H_full,
+            sys_lab.drive_bounds;
+            time_dependent = true,
+            global_params = sys_lab.global_params,
+            hermitian = sys_lab.hermitian,
+        )
     end
 
     function H_slow(u, t)
@@ -174,8 +208,13 @@ function to_rotating_frame(sys_lab::QuantumSystem, frame::RotatingFrame, spec::F
         end
         return H
     end
-    return QuantumSystem(H_slow, sys_lab.drive_bounds; time_dependent = false,
-                         global_params = sys_lab.global_params, hermitian = sys_lab.hermitian)
+    return QuantumSystem(
+        H_slow,
+        sys_lab.drive_bounds;
+        time_dependent = false,
+        global_params = sys_lab.global_params,
+        hermitian = sys_lab.hermitian,
+    )
 end
 
 @testitem "to_lab_frame: single transmon builds a carrier-modulated time-dependent system" begin
@@ -186,13 +225,17 @@ end
     nop = Matrix(a' * a)
     Hx = 0.5 * Matrix(a + a')            # rotating-frame quadratures
     Hy = 0.5 * Matrix(im * (a' - a))     #   (see substrate_transmon convention)
-    α = -0.2; Δ = 0.0
+    α = -0.2
+    Δ = 0.0
     Hdrift_rot = Δ * nop + 0.5 * α * Matrix(a' * a' * a * a)
     sys_rot = QuantumSystem(Hdrift_rot, [Hx, Hy], [0.05, 0.05])
 
     ωd = 4.0
-    spec = FrameSpec(number_ops = [nop], drive_map = [(1, :x, +1.0), (1, :y, +1.0)],
-                     drive_ops = [Hx, Hy])
+    spec = FrameSpec(
+        number_ops = [nop],
+        drive_map = [(1, :x, +1.0), (1, :y, +1.0)],
+        drive_ops = [Hx, Hy],
+    )
     sys_lab = to_lab_frame(sys_rot, RotatingFrame(ωd), spec)
 
     @test sys_lab isa QuantumSystem
@@ -216,18 +259,29 @@ end
     nop = Matrix(a' * a)
     # (i) no drives ⇒ pure drift relabel (bare oscillator, no carrier)
     sys0 = QuantumSystem(0.0 * nop + 0.5 * (-0.2) * Matrix(a' * a' * a * a))
-    lab0 = to_lab_frame(sys0, RotatingFrame(4.0),
-        FrameSpec(number_ops = [nop], drive_map = [], drive_ops = []))
+    lab0 = to_lab_frame(
+        sys0,
+        RotatingFrame(4.0),
+        FrameSpec(number_ops = [nop], drive_map = [], drive_ops = []),
+    )
     @test lab0.n_drives == 0
-    @test norm(Matrix(lab0.H(Float64[], 0.0)) - Matrix(sys0.H(Float64[], 0.0) + 4.0 * nop)) < 1e-10
+    @test norm(
+        Matrix(lab0.H(Float64[], 0.0)) - Matrix(sys0.H(Float64[], 0.0) + 4.0 * nop),
+    ) < 1e-10
     # (ii) unpaired quadrature (single :x with no matching :y) ⇒ clear error
     Hx = 0.5 * Matrix(a + a')
     sys1 = QuantumSystem(0.0 * nop, [Hx], [0.05])
-    @test_throws ErrorException to_lab_frame(sys1, RotatingFrame(4.0),
-        FrameSpec(number_ops = [nop], drive_map = [(1, :x, +1.0)], drive_ops = [Hx]))
+    @test_throws ErrorException to_lab_frame(
+        sys1,
+        RotatingFrame(4.0),
+        FrameSpec(number_ops = [nop], drive_map = [(1, :x, +1.0)], drive_ops = [Hx]),
+    )
     # (iii) lone :real drive ⇒ allowed, carrier-modulated directly
-    lab1 = to_lab_frame(sys1, RotatingFrame(4.0),
-        FrameSpec(number_ops = [nop], drive_map = [(1, :real, +1.0)], drive_ops = [Hx]))
+    lab1 = to_lab_frame(
+        sys1,
+        RotatingFrame(4.0),
+        FrameSpec(number_ops = [nop], drive_map = [(1, :real, +1.0)], drive_ops = [Hx]),
+    )
     @test lab1.time_dependent && lab1.n_drives == 1
 end
 
@@ -237,12 +291,17 @@ end
     levels = 3
     a = annihilate(levels)
     nop = Matrix(a' * a)
-    Hx = 0.5 * Matrix(a + a'); Hy = 0.5 * Matrix(im * (a' - a))
-    α = -0.2; Δ = 0.01
+    Hx = 0.5 * Matrix(a + a')
+    Hy = 0.5 * Matrix(im * (a' - a))
+    α = -0.2
+    Δ = 0.01
     Hdrift = Δ * nop + 0.5 * α * Matrix(a' * a' * a * a)
     sys_rot = QuantumSystem(Hdrift, [Hx, Hy], [0.05, 0.05])
-    spec = FrameSpec(number_ops = [nop], drive_map = [(1, :x, +1.0), (1, :y, +1.0)],
-                     drive_ops = [Hx, Hy])
+    spec = FrameSpec(
+        number_ops = [nop],
+        drive_map = [(1, :x, +1.0), (1, :y, +1.0)],
+        drive_ops = [Hx, Hy],
+    )
     frame = RotatingFrame(4.0)
 
     back = to_rotating_frame(to_lab_frame(sys_rot, frame, spec), frame, spec; rwa = true)
@@ -259,22 +318,29 @@ end
     levels = 3
     a = annihilate(levels)
     nop = Matrix(a' * a)
-    Hx = 0.5 * Matrix(a + a'); Hy = 0.5 * Matrix(im * (a' - a))
+    Hx = 0.5 * Matrix(a + a')
+    Hy = 0.5 * Matrix(im * (a' - a))
     α = -0.2
     sys_rot = QuantumSystem(0.5 * α * Matrix(a' * a' * a * a), [Hx, Hy], [1.0, 1.0])
-    spec = FrameSpec(number_ops = [nop], drive_map = [(1, :x, +1.0), (1, :y, +1.0)],
-                     drive_ops = [Hx, Hy])
+    spec = FrameSpec(
+        number_ops = [nop],
+        drive_map = [(1, :x, +1.0), (1, :y, +1.0)],
+        drive_ops = [Hx, Hy],
+    )
 
-    T = 40.0; N = 41
+    T = 40.0
+    N = 41
     times = collect(range(0.0, T, length = N))
     Ωmax = π / T
-    u = zeros(2, N); u[1, :] .= Ωmax; u[2, :] .= 0.4 * Ωmax   # both quadratures (pins φ sign)
+    u = zeros(2, N)
+    u[1, :] .= Ωmax
+    u[2, :] .= 0.4 * Ωmax   # both quadratures (pins φ sign)
     pulse = ZeroOrderPulse(u, times)
     Xgoal = EmbeddedOperator(GATES[:X], sys_rot)   # an X pulse in the rotating frame
 
     # Reference: the rotating-frame propagator — the physics the lab must reproduce.
-    U_rwa = UnitaryTrajectory(sys_rot, pulse, Xgoal;
-                              algorithm = MagnusAdapt4()).solution.u[end]
+    U_rwa =
+        UnitaryTrajectory(sys_rot, pulse, Xgoal; algorithm = MagnusAdapt4()).solution.u[end]
 
     # METRIC NOTE — the original plan compared `fidelity(...)`-to-X for lab vs rot, but
     # that cannot test the carrier physics here:
@@ -292,8 +358,14 @@ end
     prev = Ref(Inf)   # Ref so the loop-body assignment survives testitem soft scope
     for ωd in (40.0, 400.0)                    # increasing carrier ⇒ Ωmax/ωd → 0
         sys_lab = to_lab_frame(sys_rot, RotatingFrame(ωd), spec)
-        U_lab = UnitaryTrajectory(sys_lab, pulse, Xgoal;
-                    algorithm = MagnusAdapt4(), abstol = 1e-10, reltol = 1e-10).solution.u[end]
+        U_lab = UnitaryTrajectory(
+            sys_lab,
+            pulse,
+            Xgoal;
+            algorithm = MagnusAdapt4(),
+            abstol = 1e-10,
+            reltol = 1e-10,
+        ).solution.u[end]
         U_derot = exp(im * ωd * T * nop) * U_lab   # back to the rotating frame at t=T
         gap = norm(U_derot - U_rwa)
         @test gap < (ωd ≥ 400.0 ? 1e-3 : 5e-2)   # converges as ωd grows
@@ -305,8 +377,13 @@ end
 @testitem "frames: composes on a multi-transmon (distinct carriers) — round trip + validity" begin
     using Piccolo
     using LinearAlgebra
-    comp = MultiTransmonSystem([4.0, 4.1], [0.2, 0.2], [0.0 0.005; 0.005 0.0];
-                               levels_per_transmon = 3, drive_bounds = 0.05)
+    comp = MultiTransmonSystem(
+        [4.0, 4.1],
+        [0.2, 0.2],
+        [0.0 0.005; 0.005 0.0];
+        levels_per_transmon = 3,
+        drive_bounds = 0.05,
+    )
     spec = FrameSpec(comp)                    # auto-derived (2 number ops, 4 quadrature drives)
     frame = RotatingFrame([4.0, 4.1])
     sys_lab = to_lab_frame(comp, frame, spec)      # composite input → flat QuantumSystem output
@@ -325,10 +402,12 @@ end
     using LinearAlgebra
     # LabFrame ⇒ ω = 0 ⇒ to_lab_frame is the identity: no generator added to the drift,
     # and a :real drive modulated by cos(0)=1 reproduces the original drive exactly.
-    a = annihilate(3); nop = Matrix(a' * a)
+    a = annihilate(3)
+    nop = Matrix(a' * a)
     fieldop = Matrix(a + a')                      # a genuine physical field (:real)
     sys = QuantumSystem(0.5 * (-0.2) * Matrix(a' * a' * a * a), [fieldop], [0.05])
-    spec = FrameSpec(number_ops = [nop], drive_map = [(1, :real, +1.0)], drive_ops = [fieldop])
+    spec =
+        FrameSpec(number_ops = [nop], drive_map = [(1, :real, +1.0)], drive_ops = [fieldop])
     lab = to_lab_frame(sys, LabFrame(), spec)
     @test norm(Matrix(lab.H([0.02], 0.0)) - Matrix(sys.H([0.02], 0.0))) < 1e-10
 end

--- a/src/quantum/frames/frame_transforms.jl
+++ b/src/quantum/frames/frame_transforms.jl
@@ -1,2 +1,126 @@
 # frame_transforms.jl — to_lab_frame / to_rotating_frame + drive reconstruction.
 # (Populated in Tasks A2–A3.)
+
+export to_lab_frame
+
+# Group physical drive indices by subsystem into quadrature pairs / lone reals.
+# Returns Vector of (subsystem, kind, ix, iy, sx, sy) where kind ∈ (:pair, :real).
+function _grouped_drives(spec::FrameSpec, n_drives::Int)
+    length(spec.drive_map) == n_drives ||
+        error("FrameSpec drive_map has $(length(spec.drive_map)) entries; system has $n_drives drives")
+    groups = Any[]
+    pending = Dict{Int,Tuple{Int,Float64}}()   # subsystem => (x-index, x-sign) awaiting its :y
+    for (k, (sub, q, sg)) in enumerate(spec.drive_map)
+        if q === :real
+            push!(groups, (sub, :real, k, 0, sg, 0.0))
+        elseif q === :x
+            haskey(pending, sub) && error("two :x drives on subsystem $sub without a :y")
+            pending[sub] = (k, sg)
+        elseif q === :y
+            haskey(pending, sub) || error("drive $k is :y on subsystem $sub but no preceding :x — a single quadrature cannot form (Ω, φ); mark it :real to carrier-modulate directly")
+            (ix, sx) = pending[sub]; delete!(pending, sub)
+            push!(groups, (sub, :pair, ix, k, sx, sg))
+        else
+            error("unknown quadrature $q (expected :x, :y, :real)")
+        end
+    end
+    isempty(pending) || error("unpaired :x drive(s) on subsystem(s) $(collect(keys(pending))) — a single quadrature cannot form (Ω, φ); mark :real to carrier-modulate directly")
+    return groups
+end
+
+"""
+    to_lab_frame(sys_rot::QuantumSystem, frame::RotatingFrame, spec::FrameSpec) -> QuantumSystem
+
+Transform a rotating-frame system into the physically correct **lab frame**:
+adds the frame generator `Σ_i ω_i n_i` back into the drift (bare oscillator) and
+replaces each rotating-frame quadrature pair `(u_x, u_y)` on subsystem `i` with a
+carrier-modulated real field `Ω_i cos(ω_{d,i} t + φ_i)(a_i + a_i^†)`,
+`Ω = √(u_x²+u_y²)`, `φ = atan2(u_y, u_x)`. Returns a `time_dependent=true`
+function-based `QuantumSystem` (rolled via the `Rollouts` ODE path, not
+`SplineIntegrator`).
+"""
+function to_lab_frame(sys_rot::QuantumSystem, frame::RotatingFrame, spec::FrameSpec)
+    levels = sys_rot.levels
+    n_sub = length(spec.number_ops)
+    ωs = frame_frequencies(frame, n_sub)
+
+    Hf = sum(ωs[i] * spec.number_ops[i] for i in 1:n_sub; init = zeros(ComplexF64, levels, levels))
+    H_rot_drift = Matrix{ComplexF64}(sys_rot.H(zeros(sys_rot.n_drives), 0.0))
+    H_lab_drift = H_rot_drift + Hf
+
+    ops = spec.drive_ops
+    groups = _grouped_drives(spec, sys_rot.n_drives)
+    ω_of_sub = Dict(i => ωs[i] for i in 1:n_sub)
+
+    function H_lab(u, t)
+        H = copy(H_lab_drift)
+        for (sub, kind, ix, iy, sx, sy) in groups
+            ωd = ω_of_sub[sub]
+            if kind === :pair
+                ux = sx * u[ix]; uy = sy * u[iy]
+                Ω = sqrt(ux^2 + uy^2); φ = atan(uy, ux)
+                H += Ω * cos(ωd * t + φ) * (2 * ops[ix])
+            else  # :real — the op IS already the physical field; modulate directly (no 2×)
+                H += (sx * u[ix]) * cos(ωd * t) * ops[ix]
+            end
+        end
+        return H
+    end
+
+    return QuantumSystem(H_lab, sys_rot.drive_bounds; time_dependent = true,
+                         global_params = sys_rot.global_params,
+                         hermitian = sys_rot.hermitian)
+end
+
+@testitem "to_lab_frame: single transmon builds a carrier-modulated time-dependent system" begin
+    using Piccolo
+    using LinearAlgebra
+    levels = 3
+    a = annihilate(levels)
+    nop = Matrix(a' * a)
+    Hx = 0.5 * Matrix(a + a')            # rotating-frame quadratures
+    Hy = 0.5 * Matrix(im * (a' - a))     #   (see substrate_transmon convention)
+    α = -0.2; Δ = 0.0
+    Hdrift_rot = Δ * nop + 0.5 * α * Matrix(a' * a' * a * a)
+    sys_rot = QuantumSystem(Hdrift_rot, [Hx, Hy], [0.05, 0.05])
+
+    ωd = 4.0
+    spec = FrameSpec(number_ops = [nop], drive_map = [(1, :x, +1.0), (1, :y, +1.0)],
+                     drive_ops = [Hx, Hy])
+    sys_lab = to_lab_frame(sys_rot, RotatingFrame(ωd), spec)
+
+    @test sys_lab isa QuantumSystem
+    @test sys_lab.time_dependent
+    @test sys_lab.n_drives == sys_rot.n_drives
+    # lab drift adds back the frame generator ω n
+    @test norm(Matrix(sys_lab.H([0.0, 0.0], 0.0)) - (Hdrift_rot + ωd * nop)) < 1e-10
+    # the drive oscillates in absolute time (carrier present)
+    u = [0.03, 0.01]
+    H0 = Matrix(sys_lab.H(u, 0.0))
+    Hq = Matrix(sys_lab.H(u, 2π / ωd / 4))     # quarter carrier period later
+    @test norm(H0 - Hq) > 1e-6
+    @test ishermitian(H0) && ishermitian(Hq)
+end
+
+@testitem "to_lab_frame: edge cases (no drives, unpaired quadrature)" begin
+    using Piccolo
+    using LinearAlgebra
+    levels = 3
+    a = annihilate(levels)
+    nop = Matrix(a' * a)
+    # (i) no drives ⇒ pure drift relabel (bare oscillator, no carrier)
+    sys0 = QuantumSystem(0.0 * nop + 0.5 * (-0.2) * Matrix(a' * a' * a * a))
+    lab0 = to_lab_frame(sys0, RotatingFrame(4.0),
+        FrameSpec(number_ops = [nop], drive_map = [], drive_ops = []))
+    @test lab0.n_drives == 0
+    @test norm(Matrix(lab0.H(Float64[], 0.0)) - Matrix(sys0.H(Float64[], 0.0) + 4.0 * nop)) < 1e-10
+    # (ii) unpaired quadrature (single :x with no matching :y) ⇒ clear error
+    Hx = 0.5 * Matrix(a + a')
+    sys1 = QuantumSystem(0.0 * nop, [Hx], [0.05])
+    @test_throws ErrorException to_lab_frame(sys1, RotatingFrame(4.0),
+        FrameSpec(number_ops = [nop], drive_map = [(1, :x, +1.0)], drive_ops = [Hx]))
+    # (iii) lone :real drive ⇒ allowed, carrier-modulated directly
+    lab1 = to_lab_frame(sys1, RotatingFrame(4.0),
+        FrameSpec(number_ops = [nop], drive_map = [(1, :real, +1.0)], drive_ops = [Hx]))
+    @test lab1.time_dependent && lab1.n_drives == 1
+end

--- a/src/quantum/frames/frame_transforms.jl
+++ b/src/quantum/frames/frame_transforms.jl
@@ -35,7 +35,7 @@ Transform a rotating-frame system into the physically correct **lab frame**:
 adds the frame generator `Σ_i ω_i n_i` back into the drift (bare oscillator) and
 replaces each rotating-frame quadrature pair `(u_x, u_y)` on subsystem `i` with a
 carrier-modulated real field `Ω_i cos(ω_{d,i} t + φ_i)(a_i + a_i^†)`,
-`Ω = √(u_x²+u_y²)`, `φ = atan2(u_y, u_x)`. Returns a `time_dependent=true`
+`Ω = √(u_x²+u_y²)`, `φ = atan2(-u_y, u_x)`. Returns a `time_dependent=true`
 function-based `QuantumSystem` (rolled via the `Rollouts` ODE path, not
 `SplineIntegrator`).
 
@@ -141,13 +141,16 @@ function to_rotating_frame(sys_lab::QuantumSystem, frame::RotatingFrame, spec::F
     groups = _grouped_drives(spec, sys_lab.n_drives)
 
     if !rwa
+        # NOTE: the rwa=false path is provided for completeness only — nothing calls it
+        # and it is NOT covered by the round-trip guard (which exercises rwa=true).
         function H_full(u, t)
             H = copy(H_rot_drift)
             for (sub, kind, ix, iy, sx, sy) in groups
                 ωd = ωs[sub]
                 if kind === :pair
                     ux = sx * u[ix]; uy = sy * u[iy]
-                    Ω = sqrt(ux^2 + uy^2); φ = atan(uy, ux)
+                    # φ sign matches the forward to_lab_frame convention: atan(−uy, ux).
+                    Ω = sqrt(ux^2 + uy^2); φ = atan(-uy, ux)
                     H += Ω * cos(ωd * t + φ) * (2 * ops[ix])
                 else
                     H += (sx * u[ix]) * cos(ωd * t) * ops[ix]

--- a/src/quantum/frames/frame_transforms.jl
+++ b/src/quantum/frames/frame_transforms.jl
@@ -72,6 +72,65 @@ function to_lab_frame(sys_rot::QuantumSystem, frame::RotatingFrame, spec::FrameS
                          hermitian = sys_rot.hermitian)
 end
 
+export to_rotating_frame
+
+"""
+    to_rotating_frame(sys_lab::QuantumSystem, frame::RotatingFrame, spec::FrameSpec;
+                      rwa::Bool=true) -> QuantumSystem
+
+Inverse of `to_lab_frame`. Subtracts the frame generator `Σ ω_i n_i` from the
+drift and, under `rwa=true`, reduces each carrier field back to its slow
+quadrature pair `(u_x, u_y)` (dropping the counter-rotating e^{±2iωt} terms) — a
+time-independent rotating-frame `QuantumSystem`. `rwa=false` retains explicit
+time-dependence.
+"""
+function to_rotating_frame(sys_lab::QuantumSystem, frame::RotatingFrame, spec::FrameSpec;
+                           rwa::Bool = true)
+    levels = sys_lab.levels
+    n_sub = length(spec.number_ops)
+    ωs = frame_frequencies(frame, n_sub)
+    Hf = sum(ωs[i] * spec.number_ops[i] for i in 1:n_sub; init = zeros(ComplexF64, levels, levels))
+    H_lab_drift = Matrix{ComplexF64}(sys_lab.H(zeros(sys_lab.n_drives), 0.0))
+    H_rot_drift = H_lab_drift - Hf
+
+    ops = spec.drive_ops
+    groups = _grouped_drives(spec, sys_lab.n_drives)
+
+    if !rwa
+        function H_full(u, t)
+            H = copy(H_rot_drift)
+            for (sub, kind, ix, iy, sx, sy) in groups
+                ωd = ωs[sub]
+                if kind === :pair
+                    ux = sx * u[ix]; uy = sy * u[iy]
+                    Ω = sqrt(ux^2 + uy^2); φ = atan(uy, ux)
+                    H += Ω * cos(ωd * t + φ) * (2 * ops[ix])
+                else
+                    H += (sx * u[ix]) * cos(ωd * t) * ops[ix]
+                end
+            end
+            return H
+        end
+        return QuantumSystem(H_full, sys_lab.drive_bounds; time_dependent = true,
+                             global_params = sys_lab.global_params, hermitian = sys_lab.hermitian)
+    end
+
+    function H_slow(u, t)
+        H = copy(H_rot_drift)
+        for (sub, kind, ix, iy, sx, sy) in groups
+            if kind === :pair
+                H += (sx * u[ix]) * ops[ix]
+                H += (sy * u[iy]) * ops[iy]
+            else
+                H += (sx * u[ix]) * ops[ix]
+            end
+        end
+        return H
+    end
+    return QuantumSystem(H_slow, sys_lab.drive_bounds; time_dependent = false,
+                         global_params = sys_lab.global_params, hermitian = sys_lab.hermitian)
+end
+
 @testitem "to_lab_frame: single transmon builds a carrier-modulated time-dependent system" begin
     using Piccolo
     using LinearAlgebra
@@ -123,4 +182,25 @@ end
     lab1 = to_lab_frame(sys1, RotatingFrame(4.0),
         FrameSpec(number_ops = [nop], drive_map = [(1, :real, +1.0)], drive_ops = [Hx]))
     @test lab1.time_dependent && lab1.n_drives == 1
+end
+
+@testitem "frames: round-trip to_rotating_frame(to_lab_frame(s)) ≈ s (RWA)" begin
+    using Piccolo
+    using LinearAlgebra
+    levels = 3
+    a = annihilate(levels)
+    nop = Matrix(a' * a)
+    Hx = 0.5 * Matrix(a + a'); Hy = 0.5 * Matrix(im * (a' - a))
+    α = -0.2; Δ = 0.01
+    Hdrift = Δ * nop + 0.5 * α * Matrix(a' * a' * a * a)
+    sys_rot = QuantumSystem(Hdrift, [Hx, Hy], [0.05, 0.05])
+    spec = FrameSpec(number_ops = [nop], drive_map = [(1, :x, +1.0), (1, :y, +1.0)],
+                     drive_ops = [Hx, Hy])
+    frame = RotatingFrame(4.0)
+
+    back = to_rotating_frame(to_lab_frame(sys_rot, frame, spec), frame, spec; rwa = true)
+
+    for u in ([0.0, 0.0], [0.03, 0.0], [0.0, 0.02], [0.02, -0.03]), t in (0.0, 1.3, 7.1)
+        @test norm(Matrix(back.H(u, t)) - Matrix(sys_rot.H(u, t))) < 1e-8
+    end
 end

--- a/src/quantum/frames/frame_transforms.jl
+++ b/src/quantum/frames/frame_transforms.jl
@@ -29,7 +29,7 @@ function _grouped_drives(spec::FrameSpec, n_drives::Int)
 end
 
 """
-    to_lab_frame(sys_rot::QuantumSystem, frame::RotatingFrame, spec::FrameSpec) -> QuantumSystem
+    to_lab_frame(sys_rot::QuantumSystem, frame::AbstractFrame, spec::FrameSpec) -> QuantumSystem
 
 Transform a rotating-frame system into the physically correct **lab frame**:
 adds the frame generator `Σ_i ω_i n_i` back into the drift (bare oscillator) and
@@ -38,8 +38,11 @@ carrier-modulated real field `Ω_i cos(ω_{d,i} t + φ_i)(a_i + a_i^†)`,
 `Ω = √(u_x²+u_y²)`, `φ = atan2(u_y, u_x)`. Returns a `time_dependent=true`
 function-based `QuantumSystem` (rolled via the `Rollouts` ODE path, not
 `SplineIntegrator`).
+
+A `LabFrame()` (all `ω_i = 0`) is a no-op on the drift and reduces every carrier
+to `cos(0)=1`, so the system is reproduced unchanged (identity transform).
 """
-function to_lab_frame(sys_rot::QuantumSystem, frame::RotatingFrame, spec::FrameSpec)
+function to_lab_frame(sys_rot::QuantumSystem, frame::AbstractFrame, spec::FrameSpec)
     levels = sys_rot.levels
     n_sub = length(spec.number_ops)
     ωs = frame_frequencies(frame, n_sub)
@@ -72,6 +75,45 @@ function to_lab_frame(sys_rot::QuantumSystem, frame::RotatingFrame, spec::FrameS
     return QuantumSystem(H_lab, sys_rot.drive_bounds; time_dependent = true,
                          global_params = sys_rot.global_params,
                          hermitian = sys_rot.hermitian)
+end
+
+"""
+    to_lab_frame(comp::CompositeQuantumSystem, frame::RotatingFrame, spec::FrameSpec) -> QuantumSystem
+
+Composite overload: materializes the composite's rotating drift (`comp.H(0,0)`,
+which already contains the lifted subsystem anharmonicities and the fixed coupling),
+adds the per-subsystem frame generators `Σ_i ω_i n_i`, and reconstructs each
+subsystem's carrier-modulated drive from `spec`. Returns a flat, `time_dependent=true`
+function-based `QuantumSystem` (never a composite). `spec` should be `FrameSpec(comp)`.
+"""
+function to_lab_frame(comp::CompositeQuantumSystem, frame::RotatingFrame, spec::FrameSpec)
+    levels = comp.levels
+    n_sub = length(spec.number_ops)
+    ωs = frame_frequencies(frame, n_sub)
+
+    Hf = sum(ωs[i] * spec.number_ops[i] for i in 1:n_sub; init = zeros(ComplexF64, levels, levels))
+    H_rot_drift = Matrix{ComplexF64}(comp.H(zeros(comp.n_drives), 0.0))
+    H_lab_drift = H_rot_drift + Hf
+
+    ops = spec.drive_ops
+    groups = _grouped_drives(spec, comp.n_drives)
+
+    function H_lab(u, t)
+        H = copy(H_lab_drift)
+        for (sub, kind, ix, iy, sx, sy) in groups
+            ωd = ωs[sub]
+            if kind === :pair
+                ux = sx * u[ix]; uy = sy * u[iy]
+                Ω = sqrt(ux^2 + uy^2); φ = atan(-uy, ux)
+                H += Ω * cos(ωd * t + φ) * (2 * ops[ix])
+            else
+                H += (sx * u[ix]) * cos(ωd * t) * ops[ix]
+            end
+        end
+        return H
+    end
+
+    return QuantumSystem(H_lab, comp.drive_bounds; time_dependent = true, hermitian = true)
 end
 
 export to_rotating_frame
@@ -255,4 +297,35 @@ end
         @test gap < prev[]                        # monotone shrink ⇒ carrier physics correct
         prev[] = gap
     end
+end
+
+@testitem "frames: composes on a multi-transmon (distinct carriers) — round trip + validity" begin
+    using Piccolo
+    using LinearAlgebra
+    comp = MultiTransmonSystem([4.0, 4.1], [0.2, 0.2], [0.0 0.005; 0.005 0.0];
+                               levels_per_transmon = 3, drive_bounds = 0.05)
+    spec = FrameSpec(comp)                    # auto-derived (2 number ops, 4 quadrature drives)
+    frame = RotatingFrame([4.0, 4.1])
+    sys_lab = to_lab_frame(comp, frame, spec)      # composite input → flat QuantumSystem output
+    @test sys_lab isa QuantumSystem
+    @test sys_lab.time_dependent
+    @test sys_lab.levels == comp.levels
+    back = to_rotating_frame(sys_lab, frame, spec; rwa = true)
+    u = 0.01 .* [1.0, -1.0, 0.5, 0.2]
+    for t in (0.0, 2.0, 5.0)
+        @test norm(Matrix(back.H(u, t)) - Matrix(comp.H(u, t))) < 1e-7
+    end
+end
+
+@testitem "frames: to_lab_frame on a system with no number-operator frame is a no-op / clear error" begin
+    using Piccolo
+    using LinearAlgebra
+    # LabFrame ⇒ ω = 0 ⇒ to_lab_frame is the identity: no generator added to the drift,
+    # and a :real drive modulated by cos(0)=1 reproduces the original drive exactly.
+    a = annihilate(3); nop = Matrix(a' * a)
+    fieldop = Matrix(a + a')                      # a genuine physical field (:real)
+    sys = QuantumSystem(0.5 * (-0.2) * Matrix(a' * a' * a * a), [fieldop], [0.05])
+    spec = FrameSpec(number_ops = [nop], drive_map = [(1, :real, +1.0)], drive_ops = [fieldop])
+    lab = to_lab_frame(sys, LabFrame(), spec)
+    @test norm(Matrix(lab.H([0.02], 0.0)) - Matrix(sys.H([0.02], 0.0))) < 1e-10
 end

--- a/src/quantum/frames/frame_types.jl
+++ b/src/quantum/frames/frame_types.jl
@@ -1,0 +1,2 @@
+# frame_types.jl — frame descriptors and drive/subsystem metadata.
+# (Populated in Task A1.)

--- a/src/quantum/frames/frame_types.jl
+++ b/src/quantum/frames/frame_types.jl
@@ -1,2 +1,158 @@
 # frame_types.jl — frame descriptors and drive/subsystem metadata.
 # (Populated in Task A1.)
+
+export AbstractFrame, RotatingFrame, LabFrame, FrameSpec, frame_frequencies
+
+"""
+    AbstractFrame
+
+A reference frame for `to_lab_frame`/`to_rotating_frame`. A frame is defined by
+its generator `H_f = Σ_i ω_i n_i` (per-subsystem frame frequencies).
+"""
+abstract type AbstractFrame end
+
+"""
+    RotatingFrame(ωs::Vector{Float64})
+    RotatingFrame(ω::Real)
+
+Rotating frame carrying one frame/carrier frequency per subsystem (single-carrier
+= length 1). Angular units (rad/time) to match the systems it transforms.
+"""
+struct RotatingFrame <: AbstractFrame
+    ωs::Vector{Float64}
+end
+RotatingFrame(ω::Real) = RotatingFrame(Float64[ω])
+
+"""
+    LabFrame()
+
+The bare/lab frame — the ω = 0 frame (all frame frequencies zero).
+"""
+struct LabFrame <: AbstractFrame end
+
+"""
+    frame_frequencies(frame, n_subsystems) -> Vector{Float64}
+
+Per-subsystem frame frequencies. `LabFrame` ⇒ zeros; `RotatingFrame` ⇒ its `ωs`
+(broadcast to `n_subsystems` if length 1).
+"""
+frame_frequencies(::LabFrame, n::Int) = zeros(Float64, n)
+function frame_frequencies(f::RotatingFrame, n::Int)
+    length(f.ωs) == n && return f.ωs
+    length(f.ωs) == 1 && return fill(f.ωs[1], n)
+    error("RotatingFrame has $(length(f.ωs)) frequencies but system has $n subsystems")
+end
+
+"""
+    FrameSpec(; number_ops, drive_map, drive_ops)
+
+Subsystem + drive metadata the frame layer needs but a bare `QuantumSystem` does
+not carry. **All three fields are the "input data" the layer reads and never
+guesses** — both `to_lab_frame` and `to_rotating_frame` read operators from a
+`FrameSpec`, never from a system's `H_drives` (a function-based lab system stores
+none). Fields:
+- `number_ops[i]` — number operator n_i of subsystem i, **lifted to the full
+  Hilbert space** (the frame generator pieces `H_f = Σ ω_i n_i`).
+- `drive_map[k] = (subsystem::Int, quadrature::Symbol, sign::Float64)` — physical
+  drive index `k`, `quadrature ∈ (:x, :y, :real)`. `:x`/`:y` are the two members
+  of an (u_x, u_y) pair combined into (Ω, φ); `:real` is a lone real drive to
+  carrier-modulate directly.
+- `drive_ops[k]` — the operator matrix physical control `k` multiplies in the
+  rotating frame (e.g. `½(a+a†)` for `:x`, `½·i(a†−a)` for `:y`). The lab **field**
+  operator for that drive is `2·drive_ops[k]` (undoes the ½), and the RWA inverse
+  reuses `drive_ops[k]` directly — so the ½/sign convention lives entirely in this
+  operator, pinned by the round-trip test.
+"""
+struct FrameSpec
+    number_ops::Vector{Matrix{ComplexF64}}
+    drive_map::Vector{Tuple{Int,Symbol,Float64}}
+    drive_ops::Vector{Matrix{ComplexF64}}
+end
+function FrameSpec(; number_ops, drive_map, drive_ops)
+    dmap = [(Int(s), Symbol(q), Float64(sg)) for (s, q, sg) in drive_map]
+    length(drive_ops) == length(dmap) ||
+        error("FrameSpec: drive_ops ($(length(drive_ops))) must match drive_map ($(length(dmap)))")
+    return FrameSpec(Matrix{ComplexF64}.(number_ops), dmap, Matrix{ComplexF64}.(drive_ops))
+end
+
+"""
+    FrameSpec(sys::QuantumSystem, drive_map; number_ops) -> FrameSpec
+
+Build a spec for a matrix-drive-built `QuantumSystem`, reading `drive_ops` from its
+`H_drives` (`drive_matrix.(sys.H_drives)`, which exist on matrix/typed-drive
+systems). `number_ops` must be supplied (a bare system has no subsystem structure).
+"""
+function FrameSpec(sys::QuantumSystem, drive_map; number_ops)
+    ops = [Matrix{ComplexF64}(drive_matrix(d)) for d in sys.H_drives]
+    return FrameSpec(number_ops = number_ops, drive_map = drive_map, drive_ops = ops)
+end
+
+"""
+    FrameSpec(sys::CompositeQuantumSystem) -> FrameSpec
+
+Fully auto-derive from a Piccolo-built multi-transmon composite: `n_i = a_i^† a_i`
+lifted per subsystem; drive map = each subsystem's (x, y) quadrature pair in
+drive-index order (coupling drives, if any, are skipped — no single-subsystem
+carrier); `drive_ops` read from `sys.H_drives` at the matching indices. Uses
+`subsystem_levels`/`subsystems`.
+"""
+function FrameSpec(sys::CompositeQuantumSystem)
+    levels = sys.subsystem_levels
+    nops = Matrix{ComplexF64}[]
+    for i in eachindex(sys.subsystems)
+        a = annihilate(levels[i])
+        push!(nops, Matrix{ComplexF64}(lift_operator(a' * a, i, levels)))
+    end
+    all_ops = [Matrix{ComplexF64}(drive_matrix(d)) for d in sys.H_drives]
+    dmap = Tuple{Int,Symbol,Float64}[]
+    ops = Matrix{ComplexF64}[]
+    n_sub_drives = sum(s.n_drives for s in sys.subsystems)
+    n_coupling = sys.n_drives - n_sub_drives
+    k = n_coupling
+    for (i, s) in enumerate(sys.subsystems)
+        s.n_drives == 0 && continue
+        s.n_drives == 2 || error("FrameSpec auto-derivation expects 2 quadrature drives per driven subsystem (got $(s.n_drives) on subsystem $i)")
+        push!(dmap, (i, :x, +1.0)); push!(ops, all_ops[k + 1])
+        push!(dmap, (i, :y, +1.0)); push!(ops, all_ops[k + 2])
+        k += 2
+    end
+    return FrameSpec(nops, dmap, ops)
+end
+
+@testitem "frame descriptors: RotatingFrame / LabFrame" begin
+    using Piccolo
+    rf = RotatingFrame([4.0, 4.1])
+    @test rf.ωs == [4.0, 4.1]
+    @test LabFrame() isa AbstractFrame            # exported by Frames
+    @test RotatingFrame(4.0).ωs == [4.0]          # scalar convenience
+    # LabFrame is the ω=0 rotating frame
+    @test frame_frequencies(LabFrame(), 2) == [0.0, 0.0]
+end
+
+@testitem "FrameSpec: explicit, from-system, and from-composite" begin
+    using Piccolo
+    using LinearAlgebra
+    levels = 3
+    a = annihilate(levels)
+    nop = Matrix(a' * a)
+    Hx = 0.5 * Matrix(a + a'); Hy = 0.5 * Matrix(im * (a' - a))
+    spec = FrameSpec(number_ops = [nop],
+                     drive_map = [(1, :x, +1.0), (1, :y, +1.0)],
+                     drive_ops = [Hx, Hy])
+    @test length(spec.number_ops) == 1
+    @test spec.drive_map[2] == (1, :y, +1.0)
+    @test length(spec.drive_ops) == 2
+    @test spec.drive_ops[1] ≈ Hx
+
+    sys = QuantumSystem(nop, [Hx, Hy], [0.05, 0.05])
+    sspec = FrameSpec(sys, [(1, :x, +1.0), (1, :y, +1.0)]; number_ops = [nop])
+    @test length(sspec.drive_ops) == sys.n_drives
+    @test sspec.drive_ops[2] ≈ Hy
+
+    comp = MultiTransmonSystem([4.0, 4.1], [0.2, 0.2], [0.0 0.01; 0.01 0.0])
+    dspec = FrameSpec(comp)
+    @test length(dspec.number_ops) == 2
+    @test all(op -> size(op, 1) == comp.levels, dspec.number_ops)
+    @test length(dspec.drive_map) == comp.n_drives
+    @test length(dspec.drive_ops) == comp.n_drives
+end

--- a/src/quantum/frames/frame_types.jl
+++ b/src/quantum/frames/frame_types.jl
@@ -70,8 +70,9 @@ struct FrameSpec
 end
 function FrameSpec(; number_ops, drive_map, drive_ops)
     dmap = [(Int(s), Symbol(q), Float64(sg)) for (s, q, sg) in drive_map]
-    length(drive_ops) == length(dmap) ||
-        error("FrameSpec: drive_ops ($(length(drive_ops))) must match drive_map ($(length(dmap)))")
+    length(drive_ops) == length(dmap) || error(
+        "FrameSpec: drive_ops ($(length(drive_ops))) must match drive_map ($(length(dmap)))",
+    )
     return FrameSpec(Matrix{ComplexF64}.(number_ops), dmap, Matrix{ComplexF64}.(drive_ops))
 end
 
@@ -111,9 +112,13 @@ function FrameSpec(sys::CompositeQuantumSystem)
     k = n_coupling
     for (i, s) in enumerate(sys.subsystems)
         s.n_drives == 0 && continue
-        s.n_drives == 2 || error("FrameSpec auto-derivation expects 2 quadrature drives per driven subsystem (got $(s.n_drives) on subsystem $i)")
-        push!(dmap, (i, :x, +1.0)); push!(ops, all_ops[k + 1])
-        push!(dmap, (i, :y, +1.0)); push!(ops, all_ops[k + 2])
+        s.n_drives == 2 || error(
+            "FrameSpec auto-derivation expects 2 quadrature drives per driven subsystem (got $(s.n_drives) on subsystem $i)",
+        )
+        push!(dmap, (i, :x, +1.0))
+        push!(ops, all_ops[k+1])
+        push!(dmap, (i, :y, +1.0))
+        push!(ops, all_ops[k+2])
         k += 2
     end
     return FrameSpec(nops, dmap, ops)
@@ -135,10 +140,13 @@ end
     levels = 3
     a = annihilate(levels)
     nop = Matrix(a' * a)
-    Hx = 0.5 * Matrix(a + a'); Hy = 0.5 * Matrix(im * (a' - a))
-    spec = FrameSpec(number_ops = [nop],
-                     drive_map = [(1, :x, +1.0), (1, :y, +1.0)],
-                     drive_ops = [Hx, Hy])
+    Hx = 0.5 * Matrix(a + a')
+    Hy = 0.5 * Matrix(im * (a' - a))
+    spec = FrameSpec(
+        number_ops = [nop],
+        drive_map = [(1, :x, +1.0), (1, :y, +1.0)],
+        drive_ops = [Hx, Hy],
+    )
     @test length(spec.number_ops) == 1
     @test spec.drive_map[2] == (1, :y, +1.0)
     @test length(spec.drive_ops) == 2

--- a/src/quantum/templates/transmons/transmon_system.jl
+++ b/src/quantum/templates/transmons/transmon_system.jl
@@ -324,10 +324,17 @@ end
 @testitem "TransmonSystem: lab_frame applies a carrier-modulated drive (not static quadratures)" begin
     using Piccolo
     using LinearAlgebra
-    sys = TransmonSystem(ω = 4.0, δ = 0.2, levels = 3, lab_frame = true, drive_bounds = fill(0.05, 2))
+    sys = TransmonSystem(
+        ω = 4.0,
+        δ = 0.2,
+        levels = 3,
+        lab_frame = true,
+        drive_bounds = fill(0.05, 2),
+    )
     @test sys.time_dependent                       # was false (static) before the fix
     u = [0.03, 0.0]
-    H0 = Matrix(sys.H(u, 0.0)); Hq = Matrix(sys.H(u, 2π / (2π * 4.0) / 4))
+    H0 = Matrix(sys.H(u, 0.0))
+    Hq = Matrix(sys.H(u, 2π / (2π * 4.0) / 4))
     @test norm(H0 - Hq) > 1e-6
     @test ishermitian(H0)
 end
@@ -336,20 +343,45 @@ end
     using Piccolo
     using LinearAlgebra
     using OrdinaryDiffEqLinear: MagnusAdapt4
-    levels = 3; δ = 0.2
-    sys_rot = TransmonSystem(ω = 4.0, δ = δ, levels = levels, lab_frame = false, drive_bounds = fill(1.0, 2))
-    a = annihilate(levels); nop = Matrix(a' * a)
-    T = 40.0; N = 41; times = collect(range(0.0, T, length = N))
+    levels = 3
+    δ = 0.2
+    sys_rot = TransmonSystem(
+        ω = 4.0,
+        δ = δ,
+        levels = levels,
+        lab_frame = false,
+        drive_bounds = fill(1.0, 2),
+    )
+    a = annihilate(levels)
+    nop = Matrix(a' * a)
+    T = 40.0
+    N = 41
+    times = collect(range(0.0, T, length = N))
     Ωmax = π / T
-    u = zeros(2, N); u[1, :] .= Ωmax; u[2, :] .= 0.4 * Ωmax    # BOTH quadratures (pins the y-sign)
+    u = zeros(2, N)
+    u[1, :] .= Ωmax
+    u[2, :] .= 0.4 * Ωmax    # BOTH quadratures (pins the y-sign)
     pulse = ZeroOrderPulse(u, times)
     Xgoal = EmbeddedOperator(GATES[:X], sys_rot)
-    U_rot = UnitaryTrajectory(sys_rot, pulse, Xgoal; algorithm = MagnusAdapt4()).solution.u[end]
+    U_rot =
+        UnitaryTrajectory(sys_rot, pulse, Xgoal; algorithm = MagnusAdapt4()).solution.u[end]
     prev = Ref(Inf)
     for ωc in (40.0, 120.0)          # sweep the CARRIER frequency; larger ⇒ RWA better
-        sys_lab = TransmonSystem(ω = ωc, δ = δ, levels = levels, lab_frame = true, drive_bounds = fill(1.0, 2))
-        U_lab = UnitaryTrajectory(sys_lab, pulse, Xgoal; algorithm = MagnusAdapt4(),
-                                  abstol = 1e-10, reltol = 1e-10).solution.u[end]
+        sys_lab = TransmonSystem(
+            ω = ωc,
+            δ = δ,
+            levels = levels,
+            lab_frame = true,
+            drive_bounds = fill(1.0, 2),
+        )
+        U_lab = UnitaryTrajectory(
+            sys_lab,
+            pulse,
+            Xgoal;
+            algorithm = MagnusAdapt4(),
+            abstol = 1e-10,
+            reltol = 1e-10,
+        ).solution.u[end]
         U_derot = exp(im * (2π * ωc) * T * nop) * U_lab   # de-rotate by the 2π-scaled carrier
         gap = norm(U_derot - U_rot)
         @test gap < (ωc ≥ 120.0 ? 3e-2 : 1e-1)            # correct sign converges; wrong sign stays O(1)

--- a/src/quantum/templates/transmons/transmon_system.jl
+++ b/src/quantum/templates/transmons/transmon_system.jl
@@ -4,6 +4,10 @@ export MultiTransmonSystem
 export QuantumSystemCoupling
 export TransmonCavitySystem
 
+# Frame layer (sibling submodule under Quantum) — used by the lab-frame :duffing path
+# of TransmonSystem to build a carrier-modulated drive instead of static quadratures.
+using ..Frames: FrameSpec, RotatingFrame, to_lab_frame
+
 @doc raw"""
     TransmonSystem(;
         ω::Float64=4.4153,  # GHz
@@ -56,6 +60,27 @@ function TransmonSystem(;
     end
 
     a = annihilate(levels)
+
+    # Lab-frame :duffing with drives: route through the frame layer so the drive is a
+    # physically correct carrier-modulated field, not a static quadrature pair. Only the
+    # :duffing flavor decomposes cleanly as (frame generator ω·n) + (rotating drift); the
+    # driveless and :quartic/:cosine driven paths keep their static construction below.
+    if lab_frame && drives && lab_frame_type == :duffing
+        # rotating drift = anharmonicity only (the ω·n term is the frame generator,
+        # re-added by to_lab_frame)
+        H_drift_rot = -δ / 2 * a' * a' * a * a
+        H_drives_rot = [a + a', 1.0im * (a - a')]
+        if multiply_by_2π
+            H_drift_rot *= 2π
+            H_drives_rot .*= 2π          # keep drive scaling identical to the old path
+        end
+        sys_rot = QuantumSystem(H_drift_rot, H_drives_rot, drive_bounds)
+        nop = Matrix{ComplexF64}(a' * a)
+        # carrier/frame frequency must be in the SAME (angular) units as the 2π-scaled drift:
+        ω_carrier = multiply_by_2π ? 2π * ω : ω
+        spec = FrameSpec(sys_rot, [(1, :x, +1.0), (1, :y, -1.0)]; number_ops = [nop])
+        return to_lab_frame(sys_rot, RotatingFrame(ω_carrier), spec)
+    end
 
     if lab_frame
         if lab_frame_type == :duffing
@@ -294,6 +319,43 @@ end
 
 @testitem "TransmonSystem: error on invalid lab_frame_type" begin
     @test_throws AssertionError TransmonSystem(lab_frame = true, lab_frame_type = :invalid)
+end
+
+@testitem "TransmonSystem: lab_frame applies a carrier-modulated drive (not static quadratures)" begin
+    using Piccolo
+    using LinearAlgebra
+    sys = TransmonSystem(ω = 4.0, δ = 0.2, levels = 3, lab_frame = true, drive_bounds = fill(0.05, 2))
+    @test sys.time_dependent                       # was false (static) before the fix
+    u = [0.03, 0.0]
+    H0 = Matrix(sys.H(u, 0.0)); Hq = Matrix(sys.H(u, 2π / (2π * 4.0) / 4))
+    @test norm(H0 - Hq) > 1e-6
+    @test ishermitian(H0)
+end
+
+@testitem "TransmonSystem: lab_frame carrier reproduces rotating-frame evolution (RWA limit)" begin
+    using Piccolo
+    using LinearAlgebra
+    using OrdinaryDiffEqLinear: MagnusAdapt4
+    levels = 3; δ = 0.2
+    sys_rot = TransmonSystem(ω = 4.0, δ = δ, levels = levels, lab_frame = false, drive_bounds = fill(1.0, 2))
+    a = annihilate(levels); nop = Matrix(a' * a)
+    T = 40.0; N = 41; times = collect(range(0.0, T, length = N))
+    Ωmax = π / T
+    u = zeros(2, N); u[1, :] .= Ωmax; u[2, :] .= 0.4 * Ωmax    # BOTH quadratures (pins the y-sign)
+    pulse = ZeroOrderPulse(u, times)
+    Xgoal = EmbeddedOperator(GATES[:X], sys_rot)
+    U_rot = UnitaryTrajectory(sys_rot, pulse, Xgoal; algorithm = MagnusAdapt4()).solution.u[end]
+    prev = Ref(Inf)
+    for ωc in (40.0, 120.0)          # sweep the CARRIER frequency; larger ⇒ RWA better
+        sys_lab = TransmonSystem(ω = ωc, δ = δ, levels = levels, lab_frame = true, drive_bounds = fill(1.0, 2))
+        U_lab = UnitaryTrajectory(sys_lab, pulse, Xgoal; algorithm = MagnusAdapt4(),
+                                  abstol = 1e-10, reltol = 1e-10).solution.u[end]
+        U_derot = exp(im * (2π * ωc) * T * nop) * U_lab   # de-rotate by the 2π-scaled carrier
+        gap = norm(U_derot - U_rot)
+        @test gap < (ωc ≥ 120.0 ? 3e-2 : 1e-1)            # correct sign converges; wrong sign stays O(1)
+        @test gap < prev[]                                 # monotone shrink ⇒ carrier physics correct
+        prev[] = gap
+    end
 end
 
 @testitem "TransmonDipoleCoupling: both constructors and frames" begin


### PR DESCRIPTION
## Summary

Adds a public `Frames` submodule (`src/quantum/frames/`): a system-agnostic
frame-transformation layer that converts a rotating-frame `QuantumSystem` into the
physically correct **lab frame** (carrier-modulated, time-dependent) and back under
the RWA. Also fixes the incomplete `TransmonSystem.lab_frame`, whose drives were
static rotating-frame quadratures with **no carrier**.

Motivation: the calibration ablative study v2 (transmon arm) needs a real device
that evolves in the lab frame under a fast carrier with counter-rotating terms and
|2⟩ leakage — the transmon analogue of the atoms finite-blockade out-of-model error.

## What's here

- `RotatingFrame(ωs)` / `LabFrame()` — frame descriptors (`H_f = Σ ωᵢ nᵢ`).
- `FrameSpec(number_ops, drive_map, drive_ops)` — the subsystem/drive metadata the
  transforms read (operators are **input data**, never guessed); auto-derivable from
  a `CompositeQuantumSystem` or a matrix-drive `QuantumSystem`.
- `to_lab_frame(sys_rot, frame, spec)` — adds the frame generator back into the drift
  and reconstructs each quadrature pair `(u_x, u_y)` as `Ω cos(ω_d t + φ)(a+a†)`,
  `Ω=√(u_x²+u_y²)`, `φ=atan2(−u_y, u_x)`. Returns a `time_dependent=true` function
  system rolled via the `Rollouts` **ODE** path (`KetTrajectory`/`UnitaryTrajectory`
  + SciML `MagnusAdapt4()`) — **not** `SplineIntegrator` (which rejects function-based
  `H` and has interval-local `t`).
- `to_rotating_frame(sys_lab, frame, spec; rwa=true)` — the RWA inverse.
- `TransmonSystem(lab_frame=true)` now routes through the layer → a correct
  carrier-modulated, time-dependent system.

## Guarantees (tests) — verified locally: **frames 64/64 green**

1. **Round-trip:** `to_rotating_frame(to_lab_frame(s)) ≈ s` (RWA) to < 1e-8.
2. **Validity limit:** lab-frame gate fidelity → RWA fidelity as Ω_max/ω_d → 0
   (monotone, < 1e-3 at large ω_d), driving **both** quadratures so the carrier
   physics (φ, y-sign, field factor) is actually pinned.
3. **Drive-carrier regression:** `TransmonSystem(lab_frame=true)` applies a
   carrier-modulated drive (guards against reverting to static quadratures).
4. **Cross-template:** composes on a multi-transmon (`CompositeQuantumSystem`,
   distinct per-subsystem ω_d) with the same invariants.

Verification (main env, `--startup-file=no`):
- `run_tests(filter="frame")` → **64 pass / 0 fail**.
- broad sweep (frame/transmon/kettrajectory/unitarytrajectory/composite) → all green
  except 3 `pulse_plots.jl` tests that error on `CairoMakie not found` (a **test-env-
  only** dep; they error identically on `main` and are unrelated to this change).

## Reviewer-critical deviations / decisions

- **Operator provenance (design decision):** a function-based lab `QuantumSystem`
  stores no `H_drives`, so `FrameSpec` carries `drive_ops` and **both** transforms
  read operators from the spec — never from a system's drive list. This is what makes
  the round-trip a clean structural inverse.
- **φ-sign convention:** the ½-factor/sign were **pinned by the round-trip + validity
  tests**, not derived in prose. The converged convention is `φ = atan2(−u_y, u_x)`
  with `field = 2·(½-quadrature op)`; a lone `:real` drive is modulated directly (no
  2×). The `rwa=false` inverse branch is completeness-only (not round-trip-guarded).
- **A4 metric:** the validity-limit test asserts a *monotone shrinking* gap vs ω_d
  (not just a threshold), and drives both quadratures — otherwise the round-trip
  (a structural inverse) would not exercise the carrier math.
- **`FrameSpec(comp)` auto-derivation** skips coupling drives (no single-subsystem
  carrier) and reads per-subsystem quadrature operators from `comp.H_drives`.

## Notes
- Public core; no IP concern — frame transforms are generically useful.
- **Review only — please do not merge yet** (part of a staged v2 rollout; the demo
  consumer follows after this API is reviewed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)