### PR TITLE
fix: thread per-state weights through remaining coherent ket surfaces

### DIFF
--- a/src/control/constraints.jl
+++ b/src/control/constraints.jl
@@ -1,7 +1,11 @@
 module QuantumConstraints
 
 using ..QuantumObjectives
-using ..QuantumObjectives: ket_fidelity_loss, unitary_fidelity_loss, coherent_ket_fidelity
+using ..QuantumObjectives:
+    ket_fidelity_loss,
+    unitary_fidelity_loss,
+    coherent_ket_fidelity,
+    coherent_fidelity_weights
 
 using DirectTrajOpt
 using LinearAlgebra
@@ -85,9 +89,9 @@ end
 
 Create a final fidelity constraint using coherent ket fidelity across multiple states.
 
-Coherent fidelity: F = |1/n ∑ᵢ ⟨ψᵢ_goal|ψᵢ⟩|²
+Coherent fidelity: F = |∑ᵢ wᵢ ⟨ψᵢ_goal|ψᵢ⟩ / ∑ᵢ wᵢ|²
 
-This constraint enforces that all state overlaps have aligned phases, which is 
+This constraint enforces that all state overlaps have aligned phases, which is
 essential when implementing a gate via multiple state transfers (e.g., MultiKetTrajectory).
 
 # Arguments
@@ -95,6 +99,12 @@ essential when implementing a gate via multiple state transfers (e.g., MultiKetT
 - `ψ̃_names::Vector{Symbol}`: Names of isomorphic state variables in trajectory
 - `final_fidelity::Float64`: Minimum fidelity threshold (constraint: F ≥ final_fidelity)
 - `traj::NamedTrajectory`: The trajectory
+
+# Keyword Arguments
+- `weights::Union{Nothing, AbstractVector{<:Real}}=nothing`: Per-state weights on the
+  coherent mean of overlaps. Pass the same weights as the objective so the constrained
+  quantity is the one being minimized. `nothing` or uniform weights give the unweighted
+  fidelity |1/n ∑ᵢ ⟨ψᵢ_goal|ψᵢ⟩|².
 
 # Example
 ```julia
@@ -108,13 +118,18 @@ function FinalCoherentKetFidelityConstraint(
     ψ_goals::Vector{<:AbstractVector{<:Complex}},
     ψ̃_names::Vector{Symbol},
     final_fidelity::Float64,
-    traj::NamedTrajectory,
+    traj::NamedTrajectory;
+    weights::Union{Nothing,AbstractVector{<:Real}} = nothing,
 )
     n_states = length(ψ_goals)
     @assert length(ψ̃_names) == n_states "Number of names must match number of goals"
 
     # Convert goals to ComplexF64
     goals = [ComplexF64.(g) for g in ψ_goals]
+
+    # Normalize once at construction, so the constraint captures self-describing
+    # weights and matches the fidelity a weighted objective drives to one
+    ws = coherent_fidelity_weights(weights, n_states)
 
     # Get component info for extracting states from concatenated vector
     state_dims = [traj.dims[name] for name in ψ̃_names]
@@ -129,7 +144,7 @@ function FinalCoherentKetFidelityConstraint(
         end
 
         # Constraint: final_fidelity - F_coherent ≤ 0
-        return [final_fidelity - coherent_ket_fidelity(ψ̃s, goals)]
+        return [final_fidelity - coherent_ket_fidelity(ψ̃s, goals; weights = ws)]
     end
 
     return NonlinearKnotPointConstraint(
@@ -146,17 +161,24 @@ end
 
 Free-phase version: `goals_fn(θ)` returns phase-adjusted goal kets.
 Uses `NonlinearGlobalKnotPointConstraint` to include global phase variables.
+
+Accepts the same `weights` keyword as the fixed-phase method; weights apply to the
+phased overlaps, so weighting composes with the phase rotation.
 """
 function FinalCoherentKetFidelityConstraint(
     goals_fn::Function,
     ψ̃_names::Vector{Symbol},
     θ_names::AbstractVector{Symbol},
     final_fidelity::Float64,
-    traj::NamedTrajectory,
+    traj::NamedTrajectory;
+    weights::Union{Nothing,AbstractVector{<:Real}} = nothing,
 )
     n_states = length(ψ̃_names)
     state_dims = [traj.dims[name] for name in ψ̃_names]
     total_state_dim = sum(state_dims)
+
+    # Normalize once at construction (see the fixed-phase method above)
+    ws = coherent_fidelity_weights(weights, n_states)
 
     function terminal_constraint(z)
         x = z[1:total_state_dim]
@@ -171,7 +193,7 @@ function FinalCoherentKetFidelityConstraint(
         end
 
         phased_goals = goals_fn(θ)
-        return [final_fidelity - coherent_ket_fidelity(ψ̃s, phased_goals)]
+        return [final_fidelity - coherent_ket_fidelity(ψ̃s, phased_goals; weights = ws)]
     end
 
     return NonlinearGlobalKnotPointConstraint(
@@ -530,6 +552,103 @@ end
     @test constraint.equality == false
     @test constraint.times == [traj.N]
     @test constraint.g_dim == 1
+end
+
+@testitem "FinalCoherentKetFidelityConstraint honors per-state weights" begin
+    using NamedTrajectories
+    using DirectTrajOpt
+    using LinearAlgebra
+
+    N = 10
+    ket_dim = 4  # iso dim for 2-level system
+
+    ψ0 = ComplexF64[1.0, 0.0]
+    ψ1 = ComplexF64[0.0, 1.0]
+    goals = [ψ1, ψ0]
+
+    # Asymmetric states: ⟨ψ1|ψ̃1⟩ = 1, ⟨ψ0|ψ̃2⟩ = ½
+    ψ̃1 = zeros(ket_dim, N)
+    ψ̃2 = zeros(ket_dim, N)
+    for k = 1:N
+        ψ̃1[:, k] = ket_to_iso(ψ1)
+        ψ̃2[:, k] = ket_to_iso(0.5 * ψ0)
+    end
+
+    final_fidelity = 0.9
+
+    residual(c, traj) = (v = zeros(c.dim); DirectTrajOpt.evaluate!(v, c, traj); v)
+
+    # ---- fixed-phase method ----
+    traj = NamedTrajectory(
+        (ψ̃1 = ψ̃1, ψ̃2 = ψ̃2, u = randn(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+    )
+
+    fixed(ws) = residual(
+        FinalCoherentKetFidelityConstraint(
+            goals,
+            [:ψ̃1, :ψ̃2],
+            final_fidelity,
+            traj;
+            weights = ws,
+        ),
+        traj,
+    )
+
+    # Constraint is final_fidelity - F_coherent, with
+    # F = |0.9·1 + 0.1·½|² = 0.9025  and  |0.1·1 + 0.9·½|² = 0.3025
+    @test fixed([0.9, 0.1]) ≈ [final_fidelity - 0.9025]
+    @test fixed([0.1, 0.9]) ≈ [final_fidelity - 0.3025]
+    @test fixed([0.9, 0.1]) != fixed([0.1, 0.9])
+    @test fixed(nothing) == fixed([0.5, 0.5])
+    @test fixed(nothing) == fixed([1.0, 1.0])
+
+    # ---- free-phase method ----
+    function goals_fn(θ)
+        phase_diag = [one(eltype(θ)), exp(im * θ[1])]
+        return [phase_diag .* g for g in goals]
+    end
+
+    traj_θ = NamedTrajectory(
+        (ψ̃1 = ψ̃1, ψ̃2 = ψ̃2, u = randn(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+        global_data = [0.0],
+        global_components = (φ_1 = 1:1,),
+    )
+
+    free(ws) = residual(
+        FinalCoherentKetFidelityConstraint(
+            goals_fn,
+            [:ψ̃1, :ψ̃2],
+            [:φ_1],
+            final_fidelity,
+            traj_θ;
+            weights = ws,
+        ),
+        traj_θ,
+    )
+
+    # At θ = 0 the phased goals equal the goals, so the same analytic values hold
+    @test free([0.9, 0.1]) ≈ [final_fidelity - 0.9025]
+    @test free([0.1, 0.9]) ≈ [final_fidelity - 0.3025]
+    @test free([0.9, 0.1]) != free([0.1, 0.9])
+    @test free(nothing) == free([0.5, 0.5])
+    @test free(nothing) == free([1.0, 1.0])
+
+    # Objective and constraint must agree on what "coherent fidelity" means:
+    # the constraint residual is final_fidelity minus the fidelity the
+    # weighted objective is driving to one
+    obj = CoherentKetInfidelityObjective(
+        goals,
+        [:ψ̃1, :ψ̃2],
+        traj;
+        Q = 1.0,
+        weights = [0.9, 0.1],
+    )
+    F_from_objective = 1 - objective_value(obj, traj)
+    @test only(fixed([0.9, 0.1])) ≈ final_fidelity - F_from_objective
 end
 
 @testitem "BoundStateL2Constraint block layout" begin

--- a/src/control/objectives.jl
+++ b/src/control/objectives.jl
@@ -230,9 +230,10 @@ Coherent ket infidelity with optimizable single-qubit Z-phase rotations.
 in the trajectory's `global_data` and optimized alongside the pulse.
 
 The objective minimizes:
-    1 - |1/n Σᵢ ⟨goal_i(θ)|ψ_i⟩|²
+    1 - |Σᵢ wᵢ ⟨goal_i(θ)|ψ_i⟩ / Σᵢ wᵢ|²
 
-where `goal_i(θ) = Φ(θ) · goal_i` with `Φ(θ) = Z₁(θ₁) ⊗ Z₂(θ₂) ⊗ ⋯`.
+where `goal_i(θ) = Φ(θ) · goal_i` with `Φ(θ) = Z₁(θ₁) ⊗ Z₂(θ₂) ⊗ ⋯`. Weights
+apply to the *phased* overlaps, so weighting composes with the phase rotation.
 
 # Arguments
 - `goals_fn::Function`: Maps phase vector `θ` to phased goal kets
@@ -242,6 +243,9 @@ where `goal_i(θ) = Φ(θ) · goal_i` with `Φ(θ) = Z₁(θ₁) ⊗ Z₂(θ₂)
 
 # Keyword Arguments
 - `Q::Float64=100.0`: Weight on the infidelity objective
+- `weights::Union{Nothing, AbstractVector{<:Real}}=nothing`: Per-state weights on the
+  coherent mean of overlaps. Normalized at construction; only their ratios matter.
+  `nothing` or uniform weights give the unweighted fidelity |1/n Σᵢ ⟨goal_i(θ)|ψ_i⟩|².
 """
 function CoherentKetFreePhaseInfidelityObjective(
     goals_fn::Function,
@@ -249,10 +253,14 @@ function CoherentKetFreePhaseInfidelityObjective(
     θ_names::AbstractVector{Symbol},
     traj::NamedTrajectory;
     Q::Float64 = 100.0,
+    weights::Union{Nothing,AbstractVector{<:Real}} = nothing,
 )
     n_states = length(ψ̃_names)
     state_dims = [length(traj.components[name]) for name in ψ̃_names]
     total_state_dim = sum(state_dims)
+
+    # Normalize once at construction, so the loss captures self-describing weights
+    ws = coherent_fidelity_weights(weights, n_states)
 
     function ℓ(z)
         x = z[1:total_state_dim]
@@ -267,7 +275,7 @@ function CoherentKetFreePhaseInfidelityObjective(
         end
 
         phased_goals = goals_fn(θ)
-        return abs(1 - coherent_ket_fidelity(ψ̃s, phased_goals))
+        return abs(1 - coherent_ket_fidelity(ψ̃s, phased_goals; weights = ws))
     end
 
     return GlobalKnotPointObjective(
@@ -740,6 +748,79 @@ end
     J_rand = objective_value(obj_rand, traj_rand)
     @test isfinite(J_rand)
     @test 0.0 <= J_rand <= 100.0
+
+    # Per-state weights must reach the free-phase objective too (issue #263).
+    # Asymmetric states at θ=0: ⟨ψ1|ψ̃1⟩ = 1, ⟨ψ0|ψ̃2⟩ = ½
+    ψ̃1_asym = zeros(ket_dim, N)
+    ψ̃2_asym = zeros(ket_dim, N)
+    for k = 1:N
+        ψ̃1_asym[:, k] = ket_to_iso(ψ1)
+        ψ̃2_asym[:, k] = ket_to_iso(0.5 * ψ0)
+    end
+    traj_asym = NamedTrajectory(
+        (ψ̃1 = ψ̃1_asym, ψ̃2 = ψ̃2_asym, u = randn(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+        global_data = [0.0],
+        global_components = (φ_1 = 1:1,),
+    )
+
+    free_phase_value(ws) = objective_value(
+        CoherentKetFreePhaseInfidelityObjective(
+            goals_fn,
+            [:ψ̃1, :ψ̃2],
+            θ_names,
+            traj_asym;
+            Q = 100.0,
+            weights = ws,
+        ),
+        traj_asym,
+    )
+
+    # Goals are phase-rotated by θ=0 here, so the weighted mean is analytic:
+    # F = |0.9·1 + 0.1·½|² = 0.9025  and  |0.1·1 + 0.9·½|² = 0.3025
+    @test free_phase_value([0.9, 0.1]) ≈ 100.0 * (1 - 0.9025)
+    @test free_phase_value([0.1, 0.9]) ≈ 100.0 * (1 - 0.3025)
+    @test free_phase_value([0.9, 0.1]) != free_phase_value([0.1, 0.9])
+
+    # Omitted and uniform weights leave today's value exactly where it is
+    @test free_phase_value(nothing) === free_phase_value([0.5, 0.5])
+    @test free_phase_value(nothing) === free_phase_value([1.0, 1.0])
+
+    # Weighting composes with the phase rotation rather than replacing it:
+    # a nonzero phase still moves a weighted objective
+    traj_phase = NamedTrajectory(
+        (ψ̃1 = ψ̃1_asym, ψ̃2 = ψ̃2_asym, u = randn(1, N), Δt = fill(0.1, N));
+        timestep = :Δt,
+        controls = :u,
+        global_data = [0.7],
+        global_components = (φ_1 = 1:1,),
+    )
+    obj_phase_w = CoherentKetFreePhaseInfidelityObjective(
+        goals_fn,
+        [:ψ̃1, :ψ̃2],
+        θ_names,
+        traj_phase;
+        Q = 100.0,
+        weights = [0.9, 0.1],
+    )
+    @test objective_value(obj_phase_w, traj_phase) != free_phase_value([0.9, 0.1])
+
+    # Weighted free-phase objectives stay differentiable
+    ∇_w = zeros(traj_asym.dim * traj_asym.N + traj_asym.global_dim)
+    gradient!(
+        ∇_w,
+        CoherentKetFreePhaseInfidelityObjective(
+            goals_fn,
+            [:ψ̃1, :ψ̃2],
+            θ_names,
+            traj_asym;
+            Q = 100.0,
+            weights = [0.9, 0.1],
+        ),
+        traj_asym,
+    )
+    @test !all(∇_w .== 0)
 end
 
 @testitem "KetFreePhaseInfidelityObjective" begin

--- a/src/control/templates/bang_bang_pulse_problem.jl
+++ b/src/control/templates/bang_bang_pulse_problem.jl
@@ -343,7 +343,14 @@ function BangBangPulseProblem(
 
     # Build objective: weighted sum of infidelities for each state
     J = if free_phase && !isnothing(goals_fn)
-        CoherentKetFreePhaseInfidelityObjective(goals_fn, snames, θ_names, traj_bb; Q = Q)
+        CoherentKetFreePhaseInfidelityObjective(
+            goals_fn,
+            snames,
+            θ_names,
+            traj_bb;
+            Q = Q,
+            weights = weights,
+        )
     else
         _ensemble_ket_objective(qtraj, traj_bb, snames, weights, goals, Q; coherent = coherent)
     end

--- a/src/control/templates/smooth_pulse_problem.jl
+++ b/src/control/templates/smooth_pulse_problem.jl
@@ -433,7 +433,14 @@ function SmoothPulseProblem(
 
     # Build objective: coherent fidelity for ensemble (with optional free phase)
     J = if free_phase && !isnothing(goals_fn)
-        CoherentKetFreePhaseInfidelityObjective(goals_fn, snames, θ_names, traj_smooth; Q = Q)
+        CoherentKetFreePhaseInfidelityObjective(
+            goals_fn,
+            snames,
+            θ_names,
+            traj_smooth;
+            Q = Q,
+            weights = weights,
+        )
     else
         _ensemble_ket_objective(
             qtraj,
@@ -1516,6 +1523,36 @@ end
 
     # Check bounds were set
     @test length(qcp.prob.constraints) > 0
+
+    # The free-phase branch must honor trajectory weights, matching the
+    # fixed-phase branch of the same template (issue #263)
+    ψp = ComplexF64[1.0, 1.0] / √2
+    ψm = ComplexF64[1.0, -1.0] / √2
+    times_arr = (0:(N-1)) ./ (N - 1)
+    u_det =
+        0.1 *
+        vcat(reshape(cos.(2π .* times_arr), 1, N), reshape(sin.(2π .* times_arr), 1, N))
+    pulse_det = ZeroOrderPulse(u_det, collect(range(0.0, T, length = N)))
+
+    function free_phase_objective_value(ws)
+        qtraj = MultiKetTrajectory(sys, pulse_det, [ψ0, ψ1, ψp], [ψ1, ψ0, ψm]; weights = ws)
+        p = SmoothPulseProblem(
+            qtraj,
+            N;
+            Q = 100.0,
+            R = 1e-2,
+            free_phase = true,
+            subsystem_levels = [2],
+        )
+        objective_value(p.prob.objective, p.prob.trajectory)
+    end
+
+    @test free_phase_objective_value([0.8, 0.1, 0.1]) !=
+          free_phase_objective_value([0.1, 0.1, 0.8])
+
+    # Uniform weights leave today's value exactly where it was
+    @test free_phase_objective_value(fill(1 / 3, 3)) ===
+          free_phase_objective_value(fill(1.0, 3))
 end
 
 @testitem "SmoothPulseProblem free_phase requires subsystem_levels" begin

--- a/src/control/templates/spline_pulse_problem.jl
+++ b/src/control/templates/spline_pulse_problem.jl
@@ -533,7 +533,14 @@ function SplinePulseProblem(
 
     # Build objective: coherent fidelity for ensemble (with optional free phase)
     J = if free_phase && !isnothing(goals_fn)
-        CoherentKetFreePhaseInfidelityObjective(goals_fn, snames, θ_names, traj; Q = Q)
+        CoherentKetFreePhaseInfidelityObjective(
+            goals_fn,
+            snames,
+            θ_names,
+            traj;
+            Q = Q,
+            weights = weights,
+        )
     else
         _ensemble_ket_objective(qtraj, traj, snames, weights, goals, Q; coherent = coherent)
     end
@@ -1102,6 +1109,30 @@ end
     @test qcp isa QuantumControlProblem
     traj = get_trajectory(qcp)
     @test haskey(traj.global_components, :φ_1)
+
+    # The free-phase branch must honor trajectory weights (issue #263)
+    ψp = ComplexF64[1.0, 1.0] / √2
+    ψm = ComplexF64[1.0, -1.0] / √2
+    pulse_det =
+        LinearSplinePulse(0.1 * reshape(cos.(2π .* (0:(N-1)) ./ (N - 1)), 1, N), times)
+
+    function free_phase_objective_value(ws)
+        qt = MultiKetTrajectory(sys, pulse_det, [ψ0, ψ1, ψp], [ψ1, ψ0, ψm]; weights = ws)
+        p = SplinePulseProblem(
+            qt,
+            N;
+            Q = 100.0,
+            R = 1e-2,
+            free_phase = true,
+            subsystem_levels = [2],
+        )
+        objective_value(p.prob.objective, p.prob.trajectory)
+    end
+
+    @test free_phase_objective_value([0.8, 0.1, 0.1]) !=
+          free_phase_objective_value([0.1, 0.1, 0.8])
+    @test free_phase_objective_value(fill(1 / 3, 3)) ===
+          free_phase_objective_value(fill(1.0, 3))
 end
 
 @testitem "SplinePulseProblem free_phase requires EmbeddedOperator for unitary" begin


### PR DESCRIPTION
Closes #263 · **Depends on #262** — this PR is stacked on `#262`'s branch and targets it as base, because it builds on the `weights` keyword and canonicalization helper that #262 introduces. **Retarget to `main` once #262 merges.**

## Problem

#261/#262 made the *fixed-phase* coherent ket objective weight-aware. Three sibling surfaces still computed an unweighted coherent fidelity and accepted no weights:

- the free-phase coherent ket objective
- `FinalCoherentKetFidelityConstraint`, fixed-phase method
- `FinalCoherentKetFidelityConstraint`, free-phase method

The templates were the visible symptom. They bind `weights = qtraj.weights` *before* branching on `free_phase`, then passed them on one branch only — so after #262, the same template silently meant two different things depending on an unrelated flag. Reproduced end-to-end before the fix: `SmoothPulseProblem` with `free_phase=true` returned `93.40922440120845` for both `[0.8, 0.1, 0.1]` and `[0.1, 0.1, 0.8]`; `SplinePulseProblem` likewise returned `99.89899382966321` for both.

## Change

- `CoherentKetFreePhaseInfidelityObjective(...; weights)` — weights apply to the **phased** overlaps, so weighting composes with the phase rotation rather than reordering it.
- `FinalCoherentKetFidelityConstraint(...; weights)` on both methods.
- Smooth, spline, and bang-bang templates pass the trajectory's weights on their free-phase branch, matching their fixed-phase branch.

All four surfaces reuse `coherent_fidelity_weights` from #262 rather than re-deriving normalization, so they agree on the definition by construction. Omitted and uniform weights route to the unweighted path — bit-for-bit unchanged, asserted with `===`.

## Tests

| Acceptance criterion | Covered by |
|---|---|
| 1. Free-phase objective value depends on trajectory weights | `CoherentKetFreePhaseInfidelityObjective` (extended) + `SmoothPulseProblem …free_phase=true` end-to-end |
| 2. Both constraint methods accept weights; residual depends on them | `FinalCoherentKetFidelityConstraint honors per-state weights` (new) |
| 3. Every template threads weights on the free-phase branch | smooth + spline end-to-end; see bang-bang note below |
| 4. Omitted/uniform weights reproduce today's values exactly | `===` assertions on all four surfaces |
| 5. Two weight vectors → two values, per surface | asserted at objective, constraint (both methods), and template level |

Each new assertion was verified RED against the unfixed code before being made green — including reverting the one-line template thread to confirm the smooth and spline end-to-end tests actually catch the drop.

`FinalCoherentKetFidelityConstraint` had **no test coverage at all** before this. Its new test also asserts the constraint residual equals `final_fidelity` minus the fidelity a weighted objective drives to one, so the objective and constraint forms cannot drift apart.

## Notes

**Bang-bang is changed but not tested end-to-end.** Its MultiKet free-phase path throws (`requires a custom integrator that supports global variables`) before the objective is built, so it is unreachable with the default integrator. The one-line change is identical to the other two templates and the shared objective constructor is directly tested; building a custom integrator purely to exercise it was disproportionate. Flagging rather than silently claiming coverage.

**Local verification:** the full suite is 2274 pass / 0 genuine failures under `--project=.`; the 56 errors there are all missing test-only deps (CairoMakie, QuantumToolbox, JET, Aqua) that live in `test/Project.toml` and are present in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)