### PR TITLE
Chore: bump shipped Julia env compat to admit Piccolo v1.21 (Specs Phase 1)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,6 +2,16 @@
 
 ## Todo
 
+### Bump shipped Julia env compat bound to admit Piccolo v1.21 (Specs Phase 1)
+<!-- id: #271 -->
+- **Labels:** chore, hitl
+
+The provisioned Julia environment (`~/.amico/julia`) pins `Piccolo ~1.19`,
+which predates `Piccolo.Specs`.  Raise the compat bound to admit v1.21 after
+re-vetting the bundled templates against the 1.20-breaking changes
+(`integrator_type = :spline` rejection, free-phase-aware `fidelity`, and
+`sync_trajectory!` divergence warnings).
+
 ### Improved testing for re-solving problems with global variables
 <!-- id: PVTI_lADOC9ysqc4BETyazgmXCJk -->
 - **Labels:** testing


### PR DESCRIPTION
Closes #271.

## What

Raise the `~/.amico/julia` Project.toml `Piccolo` compat bound from `~1.19` to `~1.21` so `amico-run` can dispatch scriptless `problem_spec` solves via `Piccolo.Specs.solve_spec`.

## Checklist

- [ ] Re-vet bundled templates (`scores/pulse-designer/templates/solve.jl`, `scores/pasqal-mis/templates/solve.jl`, exemplars) against Piccolo 1.21.0 for:
  - `integrator_type = :spline` rejection (1.20 breaking change)
  - `fidelity(qcp)` return-type changes (free-phase-aware)
  - `sync_trajectory!` optimizer-vs-rollout divergence warning
  - any Specs materialize-dispatch differences
- [ ] Re-run re-rollout verification on each template with 1.21.0
- [ ] Bump `Project.toml` compat: `Piccolo = "~1.21"`
- [ ] Regenerate `Manifest.toml` (exact tree-sha pin for new minor)
- [ ] Ship the updated env files to the amicode extension provisioning path